### PR TITLE
Xip3152 add missing test to tripod

### DIFF
--- a/test/unit/mongo/MongoTripodTest.php
+++ b/test/unit/mongo/MongoTripodTest.php
@@ -545,7 +545,7 @@ class MongoTripodTest extends MongoTripodTestBase
 
         $tripodMock ->expects($this->exactly(3))
             ->method('validateGraphCardinality')
-            ->will($this->onConsecutiveCalls(null, $this->throwException(new Exception('Test')), null)
+            ->will($this->onConsecutiveCalls(null, $this->throwException(new Exception('readPreferenceOverMultipleSavesTestException')), null)
             );
 
         $expectedReadPreference = $tripodMock->getReadPreference();
@@ -564,6 +564,7 @@ class MongoTripodTest extends MongoTripodTestBase
         }
         catch(Exception $e){
             $exceptionThrown = true;
+            $this->assertEquals("readPreferenceOverMultipleSavesTestException", $e->getMessage());
         }
         $this->assertTrue($exceptionThrown);
         $this->assertEquals($expectedReadPreference, $tripodMock->getReadPreference());


### PR DESCRIPTION
Missing test from the previous merge.  Deferred in order to get the read preference changes merged.

This test ensures that the user read preferences are maintained in a tripod obejct over three calls to saveChanges, where the second call throws an exception.
