### PR TITLE
Changed timeout opt to connectTimeoutMS per modern php-mongos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 composer.phar
 output
 vendor
+
+atlassian-ide-plugin.xml

--- a/src/mongo/MongoTripod.class.php
+++ b/src/mongo/MongoTripod.class.php
@@ -108,7 +108,7 @@ class MongoTripod extends MongoTripodBase implements ITripod
 
         // connect
         /* @var $m MongoClient */
-        $connectionOptions = array('timeout'=>20000); // set a 20 second timeout on establishing a connection
+        $connectionOptions = array('connectTimeoutMS'=>20000); // set a 20 second timeout on establishing a connection
         if($this->config->isReplicaSet($dbName)) {
             $connectionOptions['replicaSet'] = $this->config->getReplicaSetName($dbName);
         }


### PR DESCRIPTION
php-mongo no longer uses the 'timeout' option for MongoClient and, in fact, throw errors rather than just deprecation warnings.

This has been changed to connectTimeoutMS, so this PR is for that.
