### PR TITLE
30% Allow tablespecs to have filters

### DIFF
--- a/src/mongo/delegates/MongoTripodTables.class.php
+++ b/src/mongo/delegates/MongoTripodTables.class.php
@@ -271,7 +271,6 @@ class MongoTripodTables extends MongoTripodBase implements SplObserver
         // default collection
         $from = (isset($tableSpec["from"])) ? $tableSpec["from"] : $this->collectionName;
 
-        $filter = array(); // this is used to filter the CBD table to speed up the view creation
         $types = array();
         if (is_array($tableSpec["type"]))
         {
@@ -297,6 +296,17 @@ class MongoTripodTables extends MongoTripodBase implements SplObserver
 //            $i=0;
 //            $this->doBulkMR($from, $tableSpec, $filter, $map, $reduce, $i); // todo: We are not detecting failure of individual m-r's here... fix
 //        }
+
+        // Allow a filter to be specified in the tablespec
+        if(isset($tableSpec['filter']) && is_array($tableSpec['filter']))
+        {
+            $filter['$and'] = array();
+            foreach($tableSpec['filter'] as $tableFilter)
+            {
+                $filter['$and'][] = array(key($tableFilter) => $tableFilter[key($tableFilter)]);
+            }
+        }
+
         $docs = $this->db->selectCollection($from)->find($filter);
         foreach ($docs as $doc)
         {


### PR DESCRIPTION
30% PR to test out the approach.

Tablespecs don't have filters. And on the user profile report, there are users that have signed in, but haven't created a profile - so on a tenancy with lots of users, there are loads of seemingly empty rows.

The tablespec for filters could look similar to the way they happen in search - but seeing as you're already working on a collection, you don't need to know where it's from - so something like this:

```
"filter":[
  {
    "spec:email":{
      "$exists":true
    }
  }
]
```
