### PR TITLE
90% Updated is_int to is_numeric

### DIFF
--- a/src/mongo/util/IndexUtils.class.php
+++ b/src/mongo/util/IndexUtils.class.php
@@ -38,7 +38,7 @@ class IndexUtils
                 foreach ($indexes as $indexName=>$fields)
                 {
                     $indexName = substr($indexName,0,127); // ensure max 128 chars
-                    if (is_int($indexName))
+                    if (is_numeric($indexName))
                     {
                         // no name
                         $db->selectCollection($collectionName)->ensureIndex($fields,array("background"=>$background));


### PR DESCRIPTION
When using the ensureIndexes script in TARL, the name of the index always comes out as an integer. This is because is_int never evaluates the json key correctly as an integer, whereas is_numeric does.

This fixes this so that you get nice names for mongo indexes.
