### PR TITLE
90%: Sidestep cursor problems

### DIFF
--- a/src/mongo/base/MongoTripodBase.class.php
+++ b/src/mongo/base/MongoTripodBase.class.php
@@ -94,8 +94,8 @@ abstract class MongoTripodBase
 
         $ttlExpiredResources = false;
         $cursor->batchSize($cursorSize);
-        while($cursor->hasNext()) {
-            $result = $cursor->getNext();
+		foreach($cursor as $result)
+		{
             // handle MONGO_VIEWS that have expired due to ttl. These are expired
             // on read (lazily) rather than on write
             if ($type==MONGO_VIEW && array_key_exists(_EXPIRES,$result['value']))

--- a/src/mongo/base/MongoTripodBase.class.php
+++ b/src/mongo/base/MongoTripodBase.class.php
@@ -94,8 +94,8 @@ abstract class MongoTripodBase
 
         $ttlExpiredResources = false;
         $cursor->batchSize($cursorSize);
-		foreach($cursor as $result)
-		{
+        foreach($cursor as $result)
+        {
             // handle MONGO_VIEWS that have expired due to ttl. These are expired
             // on read (lazily) rather than on write
             if ($type==MONGO_VIEW && array_key_exists(_EXPIRES,$result['value']))

--- a/src/mongo/delegates/MongoTripodSearchDocuments.class.php
+++ b/src/mongo/delegates/MongoTripodSearchDocuments.class.php
@@ -171,9 +171,8 @@ class MongoTripodSearchDocuments extends MongoTripodBase
                 $cursor = $collection->find(array('_id'=>array('$in'=>$joinUris)));
                 // add to impact index
                 $this->addIdToImpactIndex($joinUris, $target);
-                while($cursor->hasNext()){
-                    $linkMatch = $cursor->getNext();
-
+				foreach($cursor as $linkMatch)
+				{               
                     if(isset($rules['fields'])){
                         $this->addFields($linkMatch, $rules['fields'], $target);
                     }

--- a/src/mongo/delegates/MongoTripodSearchDocuments.class.php
+++ b/src/mongo/delegates/MongoTripodSearchDocuments.class.php
@@ -171,8 +171,8 @@ class MongoTripodSearchDocuments extends MongoTripodBase
                 $cursor = $collection->find(array('_id'=>array('$in'=>$joinUris)));
                 // add to impact index
                 $this->addIdToImpactIndex($joinUris, $target);
-				foreach($cursor as $linkMatch)
-				{               
+                foreach($cursor as $linkMatch)
+                {               
                     if(isset($rules['fields'])){
                         $this->addFields($linkMatch, $rules['fields'], $target);
                     }

--- a/src/mongo/delegates/MongoTripodUpdates.class.php
+++ b/src/mongo/delegates/MongoTripodUpdates.class.php
@@ -1450,8 +1450,8 @@ class MongoTripodUpdates extends MongoTripodBase {
     {
 
         $cursor = $this->getTransactionLog()->getCompletedTransactions($this->dbName, $this->collectionName, $fromDate, $toDate);
-        while($cursor->hasNext()) {
-            $result = $cursor->getNext();
+		foreach($cursor as $result)
+		{
             $this->applyTransaction($result);
         }
 

--- a/src/mongo/delegates/MongoTripodUpdates.class.php
+++ b/src/mongo/delegates/MongoTripodUpdates.class.php
@@ -1450,8 +1450,8 @@ class MongoTripodUpdates extends MongoTripodBase {
     {
 
         $cursor = $this->getTransactionLog()->getCompletedTransactions($this->dbName, $this->collectionName, $fromDate, $toDate);
-		foreach($cursor as $result)
-		{
+        foreach($cursor as $result)
+        {
             $this->applyTransaction($result);
         }
 

--- a/src/mongo/providers/MongoSearchProvider.class.php
+++ b/src/mongo/providers/MongoSearchProvider.class.php
@@ -221,7 +221,7 @@ class MongoSearchProvider implements ITripodSearchProvider
             $searchResults['head']['count']     = $cursor->count();
 
             foreach($cursor as $result)
-			{
+            {
                 // if more than one field has been asked for we need to
                 // enumerate them in the results returned. However if only one has been
                 // asked for then results is just set to that single fields value.

--- a/src/mongo/providers/MongoSearchProvider.class.php
+++ b/src/mongo/providers/MongoSearchProvider.class.php
@@ -220,9 +220,8 @@ class MongoSearchProvider implements ITripodSearchProvider
         if($cursor->count() > 0) {
             $searchResults['head']['count']     = $cursor->count();
 
-            while($cursor->hasNext()){
-                $result = $cursor->getNext();
-
+            foreach($cursor as $result)
+			{
                 // if more than one field has been asked for we need to
                 // enumerate them in the results returned. However if only one has been
                 // asked for then results is just set to that single fields value.

--- a/test/unit/mongo/MongoSearchProviderTest.php
+++ b/test/unit/mongo/MongoSearchProviderTest.php
@@ -31,8 +31,8 @@ class MongoSearchProviderTest extends MongoTripodTestBase
 
         // index all the documents
         $cursor = $this->tripod->collection->find(array("rdf:type.u"=>array('$in'=>array("bibo:Book"))),array('_id'=>1,'rdf:type'=>1));//->limit(20);
-        while($cursor->hasNext()){
-            $result = $cursor->getNext();
+		foreach($cursor as $result)
+		{
             $t = array();
             if(isset($result['rdf:type']['u'])){
                 $t[] = $result['rdf:type']['u'];

--- a/test/unit/mongo/MongoSearchProviderTest.php
+++ b/test/unit/mongo/MongoSearchProviderTest.php
@@ -31,8 +31,8 @@ class MongoSearchProviderTest extends MongoTripodTestBase
 
         // index all the documents
         $cursor = $this->tripod->collection->find(array("rdf:type.u"=>array('$in'=>array("bibo:Book"))),array('_id'=>1,'rdf:type'=>1));//->limit(20);
-		foreach($cursor as $result)
-		{
+        foreach($cursor as $result)
+        {
             $t = array();
             if(isset($result['rdf:type']['u'])){
                 $t[] = $result['rdf:type']['u'];

--- a/test/unit/mongo/MongoTripodQueueOperationsTest.php
+++ b/test/unit/mongo/MongoTripodQueueOperationsTest.php
@@ -66,7 +66,7 @@ class MongoTripodQueueOperationsTest extends MongoTripodTestBase
         $cursor = $this->tripod->collection->find(array("rdf:type.u"=>array('$in'=>array("bibo:Book","foaf:Person"))),array('_id'=>1));//->limit(20);
         foreach($cursor as $result)
         { 
-			$this->tripod->getSearchIndexer()->generateAndIndexSearchDocuments($result['_id']['r'], $result['_id']['c'], $this->tripod->getCollectionName());
+            $this->tripod->getSearchIndexer()->generateAndIndexSearchDocuments($result['_id']['r'], $result['_id']['c'], $this->tripod->getCollectionName());
         }
     }
 

--- a/test/unit/mongo/MongoTripodQueueOperationsTest.php
+++ b/test/unit/mongo/MongoTripodQueueOperationsTest.php
@@ -64,9 +64,9 @@ class MongoTripodQueueOperationsTest extends MongoTripodTestBase
         $this->tripod->getTripodTables()->generateTableRowsForType("bibo:Book");
         // index all the documents
         $cursor = $this->tripod->collection->find(array("rdf:type.u"=>array('$in'=>array("bibo:Book","foaf:Person"))),array('_id'=>1));//->limit(20);
-        while($cursor->hasNext()){
-            $result = $cursor->getNext();
-            $this->tripod->getSearchIndexer()->generateAndIndexSearchDocuments($result['_id']['r'], $result['_id']['c'], $this->tripod->getCollectionName());
+        foreach($cursor as $result)
+        { 
+			$this->tripod->getSearchIndexer()->generateAndIndexSearchDocuments($result['_id']['r'], $result['_id']['c'], $this->tripod->getCollectionName());
         }
     }
 


### PR DESCRIPTION
This fixes a problem with Mongos vs. 2.6.+ where using 
```php 
while($cursor->hasNext()) {
    $result = $cursor->getNext();
```
causes ``` $result ``` to be empty.  It's not clear if this is a bug in php-mongo or mongo, but we've seen it consistently in 2.6+.  This should be backwards compatible with any versions of Mongo 2.0+