### PR TITLE
90%: Scripts redesign

### DIFF
--- a/scripts/mongo/createTables.php
+++ b/scripts/mongo/createTables.php
@@ -27,7 +27,7 @@ function generateTables($id, $tableId,$storeName)
         }
         else
         {
-            print " for all views....\n";
+            print " for all tables....\n";
             $tTables->generateTableRows($tableId);
         }
     }

--- a/scripts/mongo/createTables2.php
+++ b/scripts/mongo/createTables2.php
@@ -1,0 +1,140 @@
+<?php
+
+$options = getopt(
+    "c:s:ht:i:",
+    array(
+        "config:",
+        "storename:",
+        "tripod-dir:",
+        "spec:",
+        "id:",
+        "help",
+        "stat-loader:",
+    )
+);
+
+function showUsage()
+{
+    $help = <<<END
+createTables2.php
+
+Usage:
+
+php createTables2.php -c/--config path/to/tripod-config.json [options]
+
+Options:
+    -h --help               This help
+    -c --config             path to MongoTripodConfig configuration (required)
+    -s --storename          Store to create tables for
+    -t --spec               Only create for specified table specs
+    -i --id                 Resource ID to regenerate table rows for
+
+    --stat-loader           Path to script to initialize a Stat object.  Note, it *must* return an iTripodStat object!
+    --tripod-dir            Path to tripod directory base
+
+END;
+    echo $help;
+}
+
+if(empty($options) || isset($options['h']) || isset($options['help']) ||
+    (!isset($options['c']) && !isset($options['config'])) ||
+    (!isset($options['s']) && !isset($options['storename']))
+)
+{
+    showUsage();
+    exit();
+}
+$configLocation = isset($options['c']) ? $options['c'] : $options['config'];
+$tripodBasePath = isset($options['tripod-dir']) ? $options['tripod-dir'] : dirname(dirname(dirname(__FILE__)));
+set_include_path(
+    get_include_path()
+    . PATH_SEPARATOR . $tripodBasePath.'/src'
+    . PATH_SEPARATOR . $tripodBasePath.'/src/classes');
+
+require_once 'tripod.inc.php';
+require_once 'classes/Timer.class.php';
+require_once 'mongo/MongoTripodConfig.class.php';
+require_once 'mongo/MongoTripod.class.php';
+
+/**
+ * @param string|null $id
+ * @param string|null $tableId
+ * @param string|null $storeName
+ * @param iTripodStat|null $stat
+ */
+function generateTables($id, $tableId, $storeName, $stat = null)
+{
+    $tableSpec = MongoTripodConfig::getInstance()->getTableSpecification($storeName, $tableId);
+    if (array_key_exists("from",$tableSpec))
+    {
+        MongoCursor::$timeout = -1;
+
+        print "Generating $tableId";
+        $tripod = new MongoTripod($tableSpec['from'], $storeName, array('stat'=>$stat));
+        $tTables = $tripod->getTripodTables();//new MongoTripodTables($tripod->storeName,$tripod->collection,$tripod->defaultContext);
+        if ($id)
+        {
+            print " for $id....\n";
+            $tTables->generateTableRows($tableId, $id);
+        }
+        else
+        {
+            print " for all tables....\n";
+            $tTables->generateTableRows($tableId);
+        }
+    }
+}
+
+$t = new Timer();
+$t->start();
+
+MongoTripodConfig::setConfig(json_decode(file_get_contents($configLocation),true));
+
+$stat = null;
+
+if(isset($options['stat-loader']))
+{
+    $stat = include_once $options['stat-loader'];
+}
+
+if(isset($options['s']) || isset($options['storename']))
+{
+    $storeName = isset($options['s']) ? $options['s'] : $options['storeName'];
+}
+else
+{
+    $storeName = null;
+}
+
+if(isset($options['t']) || isset($options['spec']))
+{
+    $tableId = isset($options['t']) ? $options['t'] : $options['spec'];
+}
+else
+{
+    $tableId = null;
+}
+
+if(isset($options['i']) || isset($options['id']))
+{
+    $id = isset($options['i']) ? $options['i'] : $options['id'];
+}
+else
+{
+    $id = null;
+}
+
+if ($tableId)
+{
+    generateTables($id, $tableId, $storeName, $stat);
+}
+else
+{
+    foreach(MongoTripodConfig::getInstance()->getTableSpecifications($storeName) as $tableSpec)
+    {
+        generateTables($id, $tableSpec['_id'], $storeName, $stat);
+    }
+}
+
+$t->stop();
+print "Tables created in ".$t->result()." secs\n";

--- a/scripts/mongo/createTables2.php
+++ b/scripts/mongo/createTables2.php
@@ -37,8 +37,7 @@ END;
 }
 
 if(empty($options) || isset($options['h']) || isset($options['help']) ||
-    (!isset($options['c']) && !isset($options['config'])) ||
-    (!isset($options['s']) && !isset($options['storename']))
+    (!isset($options['c']) && !isset($options['config']))
 )
 {
     showUsage();

--- a/scripts/mongo/createTables2.php
+++ b/scripts/mongo/createTables2.php
@@ -112,16 +112,9 @@ $t->start();
 
 MongoTripodConfig::setConfig(json_decode(file_get_contents($configLocation),true));
 
-$stat = null;
-
-if(isset($options['stat-loader']))
-{
-    $stat = include_once $options['stat-loader'];
-}
-
 if(isset($options['s']) || isset($options['storename']))
 {
-    $storeName = isset($options['s']) ? $options['s'] : $options['storeName'];
+    $storeName = isset($options['s']) ? $options['s'] : $options['storename'];
 }
 else
 {
@@ -144,6 +137,14 @@ if(isset($options['i']) || isset($options['id']))
 else
 {
     $id = null;
+}
+
+
+$stat = null;
+
+if(isset($options['stat-loader']))
+{
+    $stat = include_once $options['stat-loader'];
 }
 
 if ($tableId)

--- a/scripts/mongo/createTables2.php
+++ b/scripts/mongo/createTables2.php
@@ -83,6 +83,10 @@ require_once 'mongo/MongoTripod.class.php';
 function generateTables($id, $tableId, $storeName, $stat = null)
 {
     $tableSpec = MongoTripodConfig::getInstance()->getTableSpecification($storeName, $tableId);
+    if(empty($tableSpec)) // Older version of Tripod being used?
+    {
+        $tableSpec = MongoTripodConfig::getInstance()->getTableSpecification($tableId);
+    }
     if (array_key_exists("from",$tableSpec))
     {
         MongoCursor::$timeout = -1;

--- a/scripts/mongo/createTables2.php
+++ b/scripts/mongo/createTables2.php
@@ -31,6 +31,7 @@ Options:
 
     --stat-loader           Path to script to initialize a Stat object.  Note, it *must* return an iTripodStat object!
     --tripod-dir            Path to tripod directory base
+    --arc-dir               Path to ARC2 (required with --tripod-dir)
 
 END;
     echo $help;
@@ -45,7 +46,23 @@ if(empty($options) || isset($options['h']) || isset($options['help']) ||
     exit();
 }
 $configLocation = isset($options['c']) ? $options['c'] : $options['config'];
-$tripodBasePath = isset($options['tripod-dir']) ? $options['tripod-dir'] : dirname(dirname(dirname(__FILE__)));
+if(isset($options['tripod-dir']))
+{
+    if(isset($options['arc-dir']))
+    {
+        $tripodBasePath = $options['tripod-dir'];
+        define('ARC_DIR', $options['arc-dir']);
+    }
+    else
+    {
+        showUsage();
+        exit();
+    }
+}
+else
+{
+    $tripodBasePath = dirname(dirname(dirname(__FILE__)));
+}
 set_include_path(
     get_include_path()
     . PATH_SEPARATOR . $tripodBasePath.'/src'

--- a/scripts/mongo/createTables2.php
+++ b/scripts/mongo/createTables2.php
@@ -6,6 +6,7 @@ $options = getopt(
         "config:",
         "storename:",
         "tripod-dir:",
+        "arc-dir:",
         "spec:",
         "id:",
         "help",

--- a/scripts/mongo/createViews2.php
+++ b/scripts/mongo/createViews2.php
@@ -113,16 +113,9 @@ $t->start();
 
 MongoTripodConfig::setConfig(json_decode(file_get_contents($configLocation),true));
 
-$stat = null;
-
-if(isset($options['stat-loader']))
-{
-    $stat = include_once $options['stat-loader'];
-}
-
 if(isset($options['s']) || isset($options['storename']))
 {
-    $storeName = isset($options['s']) ? $options['s'] : $options['storeName'];
+    $storeName = isset($options['s']) ? $options['s'] : $options['storename'];
 }
 else
 {
@@ -146,6 +139,17 @@ else
 {
     $id = null;
 }
+
+$stat = null;
+
+if(isset($options['stat-loader']))
+{
+    $stat = include_once $options['stat-loader'];
+}
+
+var_dump($stat);
+
+die();
 
 if ($viewId)
 {

--- a/scripts/mongo/createViews2.php
+++ b/scripts/mongo/createViews2.php
@@ -31,6 +31,7 @@ Options:
 
     --stat-loader           Path to script to initialize a Stat object.  Note, it *must* return an iTripodStat object!
     --tripod-dir            Path to tripod directory base
+    --arc-dir               Path to ARC2 (required with --tripod-dir)
 
 END;
     echo $help;
@@ -45,7 +46,23 @@ if(empty($options) || isset($options['h']) || isset($options['help']) ||
     exit();
 }
 $configLocation = isset($options['c']) ? $options['c'] : $options['config'];
-$tripodBasePath = isset($options['tripod-dir']) ? $options['tripod-dir'] : dirname(dirname(dirname(__FILE__)));
+if(isset($options['tripod-dir']))
+{
+    if(isset($options['arc-dir']))
+    {
+        $tripodBasePath = $options['tripod-dir'];
+        define('ARC_DIR', $options['arc-dir']);
+    }
+    else
+    {
+        showUsage();
+        exit();
+    }
+}
+else
+{
+    $tripodBasePath = dirname(dirname(dirname(__FILE__)));
+}
 set_include_path(
     get_include_path()
     . PATH_SEPARATOR . $tripodBasePath.'/src'

--- a/scripts/mongo/createViews2.php
+++ b/scripts/mongo/createViews2.php
@@ -6,6 +6,7 @@ $options = getopt(
         "config:",
         "storename:",
         "tripod-dir:",
+        "arc-dir:",
         "spec:",
         "id:",
         "help",

--- a/scripts/mongo/createViews2.php
+++ b/scripts/mongo/createViews2.php
@@ -83,6 +83,10 @@ require_once 'mongo/MongoTripod.class.php';
 function generateViews($id, $viewId, $storeName, $stat)
 {
     $viewSpec = MongoTripodConfig::getInstance()->getViewSpecification($storeName, $viewId);
+    if(empty($viewSpec)) // Older version of Tripod being used?
+    {
+        $viewSpec = MongoTripodConfig::getInstance()->getViewSpecification($viewId);
+    }
     echo $viewId;
     if (array_key_exists("from",$viewSpec))
     {

--- a/scripts/mongo/processQueue2.php
+++ b/scripts/mongo/processQueue2.php
@@ -1,0 +1,102 @@
+<?php
+
+$options = getopt(
+  "c:h",
+    array(
+        "config:",
+        "tripod-dir:",
+        "help",
+        "stat-loader:",
+    )
+);
+
+function showUsage()
+{
+    $help = <<<END
+processQueue2.php
+
+Usage:
+
+php processQueue2.php -c/--config path/to/tripod-config.json [options]
+
+Options:
+    -h --help               This help
+    -c --config             path to MongoTripodConfig configuration (required)
+
+    --stat-loader           Path to script to initialize an iStat object.  Note, it *must* return an iStat object!
+    --tripod-dir            Path to tripod directory base
+
+END;
+    echo $help;
+}
+
+if(empty($options) || isset($options['h']) || isset($options['help']) || (!isset($options['c']) && !isset($options['config'])))
+{
+    showUsage();
+    exit();
+}
+$configLocation = isset($options['c']) ? $options['c'] : $options['config'];
+$tripodBasePath = isset($options['tripod-dir']) ? $options['tripod-dir'] : dirname(dirname(dirname(__FILE__)));
+set_include_path(
+    get_include_path()
+    . PATH_SEPARATOR . $tripodBasePath.'/src'
+    . PATH_SEPARATOR . $tripodBasePath.'/src/classes');
+
+require_once 'tripod.inc.php';
+require_once 'mongo/MongoTripod.class.php';
+require_once 'mongo/MongoTripodConfig.class.php';
+require_once 'mongo/queue/MongoTripodQueue.class.php';
+
+ini_set("memory_limit","320M");
+
+MongoTripodConfig::setConfig(json_decode(file_get_contents($configLocation),true));
+
+$stat = null;
+
+if(isset($options['stat-loader']))
+{
+    $stat = include_once $options['stat-loader'];
+}
+gc_enable();
+echo "Memory limit: " . ini_get('memory_limit')."\n";
+echo "Garbage Collection is enabled: " . var_export(gc_enabled(), true) . "\n";
+
+echo("About to start indexing....\n");
+$i=0;
+$startTime = microtime(true);
+
+$queue = new MongoTripodQueue($stat);
+
+while(true)
+{
+    if ((++$i)%1000 == 0)
+    {
+        echo '.';
+    }
+
+    if ($i%10000 == 0)
+    {
+        echo "\nGarbage Collecting: " . gc_collect_cycles() ."\n";
+    }
+
+    if (!$queue->processNext())
+    {
+        if ($startTime !== null)
+        {
+            $duration = round(microtime(true) - $startTime, 0);
+            $sec = $duration % 60;
+            $min = ($duration - $sec) / 60;
+            echo "\nDuration: {$duration} seconds\n";
+            echo "\nDuration: {$min}m {$sec}s\n";
+
+            $peak_memory_usage_bytes = memory_get_peak_usage(true);
+            echo 'Peak Memory Usage (bytes): [' . $peak_memory_usage_bytes . ']' . "\n";
+
+            $startTime = null; // Don't keep logging out duration is the indexer is looping
+
+        }
+        echo "\nNothing to process - waiting...\n";
+        sleep(10);
+    }
+}
+?>

--- a/scripts/mongo/processQueue2.php
+++ b/scripts/mongo/processQueue2.php
@@ -25,7 +25,7 @@ Options:
 
     --stat-loader           Path to script to initialize a Stat object.  Note, it *must* return an iTripodStat object!
     --tripod-dir            Path to tripod directory base
-
+    --arc-dir               Path to ARC2 (required with --tripod-dir)
 END;
     echo $help;
 }
@@ -36,7 +36,23 @@ if(empty($options) || isset($options['h']) || isset($options['help']) || (!isset
     exit();
 }
 $configLocation = isset($options['c']) ? $options['c'] : $options['config'];
-$tripodBasePath = isset($options['tripod-dir']) ? $options['tripod-dir'] : dirname(dirname(dirname(__FILE__)));
+if(isset($options['tripod-dir']))
+{
+    if(isset($options['arc-dir']))
+    {
+        $tripodBasePath = $options['tripod-dir'];
+        define('ARC_DIR', $options['arc-dir']);
+    }
+    else
+    {
+        showUsage();
+        exit();
+    }
+}
+else
+{
+    $tripodBasePath = dirname(dirname(dirname(__FILE__)));
+}
 set_include_path(
     get_include_path()
     . PATH_SEPARATOR . $tripodBasePath.'/src'

--- a/scripts/mongo/processQueue2.php
+++ b/scripts/mongo/processQueue2.php
@@ -5,6 +5,7 @@ $options = getopt(
     array(
         "config:",
         "tripod-dir:",
+        "arc-dir:",
         "help",
         "stat-loader:",
     )

--- a/scripts/mongo/processQueue2.php
+++ b/scripts/mongo/processQueue2.php
@@ -23,7 +23,7 @@ Options:
     -h --help               This help
     -c --config             path to MongoTripodConfig configuration (required)
 
-    --stat-loader           Path to script to initialize an iStat object.  Note, it *must* return an iStat object!
+    --stat-loader           Path to script to initialize a Stat object.  Note, it *must* return an iTripodStat object!
     --tripod-dir            Path to tripod directory base
 
 END;

--- a/test/performance/rest-interface/bulkGenerateTablesViewsSearchDocs.php
+++ b/test/performance/rest-interface/bulkGenerateTablesViewsSearchDocs.php
@@ -1,0 +1,42 @@
+<?php
+
+require 'vendor/autoload.php';
+define('ARC_DIR', dirname(__FILE__) . '/vendor/semsol/arc2/');
+require_once dirname(__FILE__) . '/vendor/talis/tripod-php/src/tripod.inc.php';
+define('TASK_TABLES', 'tables');
+define('TASK_VIEWS', 'views');
+define('TASK_SEARCH_DOCS', 'search');
+
+$options = getopt("c:s:p:t:");
+
+if(!isset($options['c']))
+{
+    $options['c'] = dirname(__FILE__) . '/config/config.json';
+}
+
+if(isset($options['t']))
+{
+    if(!is_array($options['t']))
+    {
+        $options['t'] = array($options['t']);
+    }
+    $validTasks = array(TASK_TABLES, TASK_VIEWS, TASK_SEARCH_DOCS);
+    $tasks = array();
+    foreach($options['t'] as $task)
+    {
+        if(!in_array($task, $validTasks))
+        {
+            throw new InvalidArgumentException("Option '-t' must be one of: " . implode(", ", $validTasks));
+        }
+        if(!in_array($task, $tasks))
+        {
+            $tasks[] = $task;
+        }
+    }
+}
+else
+{
+    $tasks = array(TASK_TABLES, TASK_VIEWS, TASK_SEARCH_DOCS);
+}
+
+$appConfig = json_decode(file_get_contents($options['c']), true);


### PR DESCRIPTION
This PR is the start of deprecating the old tripod scripts for generating views, tables, etc. so we can use getopts (rather than argument order) and include stats monitoring, etc.

Currently, they run alongside the old scripts until we can identify and remove all references to the old ones.