### PR TITLE
90% - Use correct config array when getting the transaction log db

### DIFF
--- a/src/mongo/MongoTripodConfig.class.php
+++ b/src/mongo/MongoTripodConfig.class.php
@@ -2047,7 +2047,7 @@ class MongoTripodConfig
             $connectionOptions['replicaSet'] = $dataSource['replicaSet'];
         }
         $client = new MongoClient($dataSource['connection'], $connectionOptions);
-        $db = $client->selectDB($this->queueConfig['database']);
+        $db = $client->selectDB($this->tConfig['database']);
         $db->setReadPreference($readPreference);
         return $db;
     }

--- a/test/unit/mongo/MongoTripodConfigTest.php
+++ b/test/unit/mongo/MongoTripodConfigTest.php
@@ -1399,12 +1399,16 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $queueDB->drop();
 
         // Make sure the dbs do not exist
-        $transactionMongo = new MongoClient($newConfig['data_sources'][$newConfig['transaction_log']['data_source']]['connection']);
+        $transactionConnInfo = $newConfig['data_sources'][$newConfig['transaction_log']['data_source']];
+        $options = isset($transactionConnInfo['replicaSet']) && !empty($transactionConnInfo['replicaSet']) ? array('replicaSet' => $transactionConnInfo['replicaSet']): array();
+        $transactionMongo = new MongoClient($transactionConnInfo['connection'], $options);
         $transactionDbInfo = $transactionMongo->listDBs();
         foreach($transactionDbInfo['databases'] as $db){
             $this->assertNotEquals($db['name'], $newConfig['transaction_log']['database'], $newConfig['queue']['database']);
         }
-        $queuesMongo = new MongoClient($newConfig['data_sources'][$newConfig['queue']['data_source']]['connection']);
+        $tqueuesConnInfo = $newConfig['data_sources'][$newConfig['transaction_log']['data_source']];
+        $options = isset($tqueuesConnInfo['replicaSet']) && !empty($tqueuesConnInfo['replicaSet']) ? array('replicaSet' => $tqueuesConnInfo['replicaSet']): array();
+        $queuesMongo = new MongoClient($tqueuesConnInfo['connection'], $options);
         $queuesDbInfo = $queuesMongo->listDBs();
         foreach($queuesDbInfo['databases'] as $db){
             $this->assertNotEquals($db['name'], $newConfig['transaction_log']['database'], $newConfig['queue']['database']);


### PR DESCRIPTION
Tripod is currently using the queue db to store transaction logs.  Fixed this, and added a test to ensure queues and transaction logs stick to their own dbs.