### PR TITLE
90%: Queue bulk composite generation

### DIFF
--- a/scripts/mongo/createSearchDocuments.php
+++ b/scripts/mongo/createSearchDocuments.php
@@ -1,7 +1,7 @@
 <?php
 
 $options = getopt(
-    "c:s:q:ht:i:a",
+    "c:s:q:hd:i:a",
     array(
         "config:",
         "storename:",
@@ -16,21 +16,19 @@ $options = getopt(
     )
 );
 
-function showUsage()
+function showUsage($scriptName)
 {
     $help = <<<END
-createTables.php
-
 Usage:
 
-php createTables.php -c/--config path/to/tripod-config.json -s/--storename store-name [options]
+php $scriptName -c/--config path/to/tripod-config.json -s/--storename store-name [options]
 
 Options:
     -h --help               This help
     -c --config             path to MongoTripodConfig configuration (required)
-    -s --storename          Store to create tables for (required)
-    -t --spec               Only create for specified table specs
-    -i --id                 Resource ID to regenerate table rows for
+    -s --storename          Store to create views for (required)
+    -d --spec               Only create for specified search document specs
+    -i --id                 Resource ID to regenerate search documents for
     -a --async              Generate table rows via queue
     -q --queue              Queue name to place jobs on (defaults to configured TRIPOD_APPLY_QUEUE value)
 
@@ -47,7 +45,7 @@ if(empty($options) || isset($options['h']) || isset($options['help']) ||
     (!isset($options['s']) && !isset($options['storename']))
 )
 {
-    showUsage();
+    showUsage($argv[0]);
     exit();
 }
 $configLocation = isset($options['c']) ? $options['c'] : $options['config'];
@@ -60,7 +58,7 @@ if(isset($options['tripod-dir']))
     }
     else
     {
-        showUsage();
+        showUsage($argv[0]);
         exit();
     }
 }
@@ -80,34 +78,34 @@ require_once 'mongo/MongoTripod.class.php';
 
 /**
  * @param string|null $id
- * @param string|null $tableId
+ * @param string|null $specId
  * @param string|null $storeName
  * @param iTripodStat|null $stat
  * @param string|null $queue
  */
-function generateTables($id, $tableId, $storeName, $stat = null, $queue = null)
+function generateSearchDocuments($id, $specId, $storeName, $stat = null, $queue = null)
 {
-    $tableSpec = MongoTripodConfig::getInstance()->getTableSpecification($storeName, $tableId);
-    if(empty($tableSpec)) // Older version of Tripod being used?
+    $spec = MongoTripodConfig::getInstance()->getSearchDocumentSpecification($storeName, $specId);
+    if(empty($spec)) // Older version of Tripod being used?
     {
-        $tableSpec = MongoTripodConfig::getInstance()->getTableSpecification($tableId);
+        $spec = MongoTripodConfig::getInstance()->getSearchDocumentSpecification($specId);
     }
-    if (array_key_exists("from",$tableSpec))
+    if (array_key_exists("from",$spec))
     {
         MongoCursor::$timeout = -1;
 
-        print "Generating $tableId";
-        $tripod = new MongoTripod($tableSpec['from'], $storeName, array('stat'=>$stat));
-        $tTables = $tripod->getTripodTables();//new MongoTripodTables($tripod->storeName,$tripod->collection,$tripod->defaultContext);
+        print "Generating $specId";
+        $tripod = new MongoTripod($spec['from'], $storeName, array('stat'=>$stat));
+        $search = $tripod->getSearchIndexer();
         if ($id)
         {
             print " for $id....\n";
-            $tTables->generateTableRows($tableId, $id);
+            $search->generateSearchDocuments($specId, $id, null, $queue);
         }
         else
         {
             print " for all tables....\n";
-            $tTables->generateTableRows($tableId, null, null, $queue);
+            $search->generateSearchDocuments($specId, null, null, $queue);
         }
     }
 }
@@ -126,13 +124,13 @@ else
     $storeName = null;
 }
 
-if(isset($options['t']) || isset($options['spec']))
+if(isset($options['d']) || isset($options['spec']))
 {
-    $tableId = isset($options['t']) ? $options['t'] : $options['spec'];
+    $specId = isset($options['d']) ? $options['t'] : $options['spec'];
 }
 else
 {
-    $tableId = null;
+    $specId = null;
 }
 
 if(isset($options['i']) || isset($options['id']))
@@ -164,17 +162,17 @@ if(isset($options['stat-loader']))
     $stat = include_once $options['stat-loader'];
 }
 
-if ($tableId)
+if ($specId)
 {
-    generateTables($id, $tableId, $storeName, $stat, $queue);
+    generateSearchDocuments($id, $specId, $storeName, $stat, $queue);
 }
 else
 {
-    foreach(MongoTripodConfig::getInstance()->getTableSpecifications($storeName) as $tableSpec)
+    foreach(MongoTripodConfig::getInstance()->getSearchDocumentSpecifications($storeName) as $searchSpec)
     {
-        generateTables($id, $tableSpec['_id'], $storeName, $stat, $queue);
+        generateSearchDocuments($id, $searchSpec['_id'], $storeName, $stat, $queue);
     }
 }
 
 $t->stop();
-print "Tables created in ".$t->result()." secs\n";
+print "Search documents created in ".$t->result()." secs\n";

--- a/scripts/mongo/createViews.php
+++ b/scripts/mongo/createViews.php
@@ -102,12 +102,12 @@ function generateViews($id, $viewId, $storeName, $stat, $queue)
         if ($id)
         {
             print " for $id....\n";
-            $views->generateView($viewId, $id);
+            $views->generateView($viewId, $id, null, $queue);
         }
         else
         {
             print " for all views....\n";
-            $views->generateView($viewId, null);
+            $views->generateView($viewId, null, null, $queue);
         }
     }
 }
@@ -172,7 +172,7 @@ else
 {
     foreach(MongoTripodConfig::getInstance()->getViewSpecifications($storeName) as $viewSpec)
     {
-        generateViews($id, $viewSpec['_id'], $storeName, $stat), $queue;
+        generateViews($id, $viewSpec['_id'], $storeName, $stat, $queue);
     }
 }
 

--- a/src/mongo/base/CompositeBase.class.php
+++ b/src/mongo/base/CompositeBase.class.php
@@ -190,4 +190,14 @@ abstract class CompositeBase extends MongoTripodBase implements IComposite
         return false;
     }
 
+    /**
+     * todo: Copied and pasted from JobBase -- how to fix this duplication?
+     * @param string $queueName
+     * @param string $class
+     * @param array $data
+     */
+    protected function submitJob($queueName, $class, Array $data)
+    {
+        Resque::enqueue($queueName, $class, $data);
+    }
 }

--- a/src/mongo/delegates/MongoTransactionLog.class.php
+++ b/src/mongo/delegates/MongoTransactionLog.class.php
@@ -12,15 +12,6 @@ class MongoTransactionLog
     {
         $config = MongoTripodConfig::getInstance();
         $this->config = $config->getTransactionLogConfig();
-        // connect to transaction db
-        $connStr = $config->getTransactionLogConnStr();
-        $m = null;
-        if(isset($this->config['replicaSet']) && !empty($this->config['replicaSet'])) {
-            $m = new MongoClient($connStr, array("replicaSet"=>$this->config['replicaSet']));
-        } else {
-            $m = new MongoClient($connStr);
-        }
-
         $this->transaction_db = $config->getTransactionLogDatabase();
         $this->transaction_collection = $this->transaction_db->selectCollection($this->config['collection']);
     }

--- a/src/mongo/delegates/MongoTripodSearchIndexer.class.php
+++ b/src/mongo/delegates/MongoTripodSearchIndexer.class.php
@@ -135,6 +135,83 @@ class MongoTripodSearchIndexer extends CompositeBase
             if(!empty($document)) $searchProvider->indexDocument($document);
         }
     }
+    
+    public function generateSearchDocuments($searchDocumentType, $resourceUri=null, $context=null, $queueName=null)
+    {
+        $t = new Timer();
+        $t->start();
+        // default the context
+        $contextAlias = $this->getContextAlias($context);
+        $spec = MongoTripodConfig::getInstance()->getSearchDocumentSpecification($this->getStoreName(), $searchDocumentType);
+        
+        if($resourceUri)
+        {            
+            $this->generateAndIndexSearchDocuments($resourceUri, $contextAlias, $spec['from'], $searchDocumentType);
+            return;
+        }
+
+
+        // default collection
+        $from = (isset($spec["from"])) ? $spec["from"] : $this->podName;
+
+        $types = array();
+        if (is_array($spec["type"]))
+        {
+            foreach ($spec["type"] as $type)
+            {
+                $types[] = array("rdf:type.u"=>$this->labeller->qname_to_alias($type));
+                $types[] = array("rdf:type.u"=>$this->labeller->uri_to_alias($type));
+            }
+        }
+        else
+        {
+            $types[] = array("rdf:type.u"=>$this->labeller->qname_to_alias($spec["type"]));
+            $types[] = array("rdf:type.u"=>$this->labeller->uri_to_alias($spec["type"]));
+        }
+        $filter = array('$or'=> $types);
+        if (isset($resource))
+        {
+            $filter["_id"] = array(_ID_RESOURCE=>$this->labeller->uri_to_alias($resource),_ID_CONTEXT=>$contextAlias);
+        }
+
+        $docs = $this->config->getCollectionForCBD($this->getStoreName(), $from)->find($filter);
+        foreach ($docs as $doc)
+        {
+            if($queueName && !$resourceUri)
+            {
+                $subject = new ImpactedSubject(
+                    $doc['_id'],
+                    OP_SEARCH,
+                    $this->storeName,
+                    $from,
+                    array($searchDocumentType)
+                );
+
+                $this->submitJob($queueName, 'ApplyOperation', array(
+                    "subject"=>$subject->toArray(),
+                    "tripodConfig"=>MongoTripodConfig::getConfig()
+                ));
+            }
+            else
+            {
+                $this->generateAndIndexSearchDocuments(
+                    $doc[_ID_KEY][_ID_RESOURCE],
+                    $doc[_ID_KEY][_ID_CONTEXT],
+                    $spec['from'],
+                    $searchDocumentType
+                );
+            }
+        }
+
+        $t->stop();
+        $this->timingLog(MONGO_CREATE_TABLE, array(
+            'type'=>$spec['type'],
+            'duration'=>$t->result(),
+            'filter'=>$filter,
+            'from'=>$from));
+        $this->getStat()->timer(MONGO_CREATE_SEARCH_DOC.".$searchDocumentType",$t->result());
+        
+    }
 
     /**
      * @param array $resourcesAndPredicates

--- a/src/mongo/delegates/MongoTripodTables.class.php
+++ b/src/mongo/delegates/MongoTripodTables.class.php
@@ -443,6 +443,7 @@ class MongoTripodTables extends CompositeBase
      * @param string $tableType
      * @param string|null $resource
      * @param string|null $context
+     * @param string|null $queueName Queue for background bulk generation
      * @return null //@todo: this should be a bool
      */
     public function generateTableRows($tableType,$resource=null,$context=null,$queueName=null)

--- a/src/mongo/delegates/MongoTripodTables.class.php
+++ b/src/mongo/delegates/MongoTripodTables.class.php
@@ -460,8 +460,9 @@ class MongoTripodTables extends CompositeBase
             return null;
         }
 
-        // ensure both the ID field and the impactIndex indexes are correctly set up
+        // ensure that the ID field, view type, and the impactIndex indexes are correctly set up
         $collection->ensureIndex(array('_id.r'=>1, '_id.c'=>1,'_id.type'=>1),array('background'=>1));
+        $collection->ensureIndex(array('_id.type'=>1),array('background'=>1));
         $collection->ensureIndex(array('value.'._IMPACT_INDEX=>1),array('background'=>1));
 
         // ensure any custom view indexes

--- a/src/mongo/delegates/MongoTripodViews.class.php
+++ b/src/mongo/delegates/MongoTripodViews.class.php
@@ -373,8 +373,9 @@ class MongoTripodViews extends CompositeBase
                 throw new TripodViewException('Could not find any joins in view specification - usecase better served with select()');
             }
 
-            // ensure both the ID field and the impactIndex indexes are correctly set up
+            // ensure that the ID field, view type, and the impactIndex indexes are correctly set up
             $collection->ensureIndex(array('_id.r'=>1, '_id.c'=>1,'_id.type'=>1),array('background'=>1));
+            $collection->ensureIndex(array('_id.type'=>1),array('background'=>1));
             $collection->ensureIndex(array('value.'._IMPACT_INDEX=>1),array('background'=>1));
 
             // ensure any custom view indexes

--- a/test/unit/mongo/MongoTripodTablesTest.php
+++ b/test/unit/mongo/MongoTripodTablesTest.php
@@ -888,13 +888,18 @@ class MongoTripodTablesTest extends MongoTripodTestBase
             OP_TABLES,
             $this->defaultStoreName,
             $this->defaultPodName,
-            // Order of these doesn't matter - if the test fails, reverse the order and try again
             array("t_distinct","t_join_source_count_regex")
         );
 
         $impactedSubjects = $table->getImpactedSubjects($subjectsAndPredicatesOfChange, $this->defaultContext);
 
-        $this->assertEquals($expectedImpactedSubject, $impactedSubjects[0]);
+        $impactedSubject = $impactedSubjects[0];
+
+        $this->assertEquals($expectedImpactedSubject->getResourceId(), $impactedSubject->getResourceId());
+        $this->assertEquals($expectedImpactedSubject->getOperation(), $impactedSubject->getOperation());
+        $this->assertEquals($expectedImpactedSubject->getStoreName(), $impactedSubject->getStoreName());
+        $this->assertEquals($expectedImpactedSubject->getPodName(), $impactedSubject->getPodName());
+        $this->assertEquals($expectedImpactedSubject->getSpecTypes(), $impactedSubject->getSpecTypes());
 
         foreach($impactedSubjects as $subject)
         {


### PR DESCRIPTION
This refactors the createTables and createViews scripts to allow them to push the actual regeneration to the resque queue.  You may also specify which queue you want these to go on, so as not to clog the regular process queue.

It also introduces a createSearchDocuments script which never existed in Tripod.

The major difference between these and how they work currently is that the current version loops over the CBDs and generates the composites serially.  This version gives the option to loop over the CBDs and submits a job to generate the composite, so the actual generation can be scaled/stopped as needed without starting from the beginning to resume.

If you don't pass the -a/--async flag it works exactly as it does now.