### PR TITLE
70%: Introduce namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ require_once("tripod.inc.php");
 
 Config::setConfig($conf); // set the config, usually read in as JSON from a file
 
-$tripod = new Tripod(
+$tripod = new Driver(
   "CBD_users", // pod (read: MongoDB collection) we're working with
   "myapp" // store (read: MongoDB database)  we're working with
 );
@@ -65,7 +65,7 @@ $tripod->saveChanges(
 );
 
 // save, but background all the expensive view/table/search generation
-$tripod = new Tripod("CBD_users",  "usersdb", array(
+$tripod = new Driver("CBD_users",  "usersdb", array(
     'async' = array(OP_VIEWS,OP_TABLES,OP_SEARCH) // async opt says what to do later via a queue rather than as part of the save
   )
 );

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ Quickstart
 ```php
 require_once("tripod.inc.php");
 
-MongoTripodConfig::setConfig($conf); // set the config, usually read in as JSON from a file
+Config::setConfig($conf); // set the config, usually read in as JSON from a file
 
-$tripod = new MongoTripod(
+$tripod = new Tripod(
   "CBD_users", // pod (read: MongoDB collection) we're working with
   "myapp" // store (read: MongoDB database)  we're working with
 );
@@ -65,7 +65,7 @@ $tripod->saveChanges(
 );
 
 // save, but background all the expensive view/table/search generation
-$tripod = new MongoTripod("CBD_users",  "usersdb", array(
+$tripod = new Tripod("CBD_users",  "usersdb", array(
     'async' = array(OP_VIEWS,OP_TABLES,OP_SEARCH) // async opt says what to do later via a queue rather than as part of the save
   )
 );
@@ -91,7 +91,7 @@ What does the config look like?
 
 [Read the full docs](/docs/config.md)
 
-Before you can do anything with tripod you need to initialise the config via the ```MongoTripodConfig::setConfig()``` method. This takes an associative array which can generally be decoded from a JSON string. Here's an example:
+Before you can do anything with tripod you need to initialise the config via the ```Config::setConfig()``` method. This takes an associative array which can generally be decoded from a JSON string. Here's an example:
 
 ```javascript
 {

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,11 +1,11 @@
 Tripod config documentation
 ===========================
 
-Tripod config is typically defined as a JSON file or stream which is added to the MongoTripodConfig class somewhere early in your application, typically in your includes file or front controller:
+Tripod config is typically defined as a JSON file or stream which is added to the Config class somewhere early in your application, typically in your includes file or front controller:
 
 ```php
 $conf = json_decode(file_get_contents('tripod_config.json');
-MongoTripodConfig::setConfig($conf); // set the config, usually read in as JSON from a file
+Config::setConfig($conf); // set the config, usually read in as JSON from a file
 ```
 
 Namespaces

--- a/docs/primers/tables.md
+++ b/docs/primers/tables.md
@@ -275,7 +275,7 @@ Usage
 
 ```php
 
-$tripod = MongoTripod("CBD_resources", "resources", array("async"=>array(OP_VIEWS=>false, OP_TABLES=>false, OP_SEARCH=>false)));
+$tripod = Tripod("CBD_resources", "resources", array("async"=>array(OP_VIEWS=>false, OP_TABLES=>false, OP_SEARCH=>false)));
 
 // Here is the id the tableSpec
 $tableSpec = 't_resources';

--- a/docs/primers/tables.md
+++ b/docs/primers/tables.md
@@ -275,7 +275,7 @@ Usage
 
 ```php
 
-$tripod = Tripod("CBD_resources", "resources", array("async"=>array(OP_VIEWS=>false, OP_TABLES=>false, OP_SEARCH=>false)));
+$tripod = new Driver("CBD_resources", "resources", array("async"=>array(OP_VIEWS=>false, OP_TABLES=>false, OP_SEARCH=>false)));
 
 // Here is the id the tableSpec
 $tableSpec = 't_resources';

--- a/scripts/mongo/BSONToQuads.php
+++ b/scripts/mongo/BSONToQuads.php
@@ -17,16 +17,16 @@ if ($argc!=2)
 
 array_shift($argv);
 $config = json_decode(file_get_contents($argv[0]), true);
-MongoTripodConfig::setConfig($config);
+\Tripod\Mongo\Config::setConfig($config);
 
-$tu = new TriplesUtil();
+$tu = new \Tripod\Mongo\TriplesUtil();
 
 while (($line = fgets(STDIN)) !== false) {
     $line = rtrim($line);
     $doc = json_decode($line, true);
     $context = $doc['_id']['c'];
 
-    $graph = new MongoGraph();
+    $graph = new \Tripod\Mongo\MongoGraph();
     $graph->add_tripod_array($doc);
 
     echo $graph->to_nquads($context);

--- a/scripts/mongo/BSONToTriples.php
+++ b/scripts/mongo/BSONToTriples.php
@@ -16,14 +16,14 @@ if ($argc!=2)
 }
 array_shift($argv);
 $config = json_decode(file_get_contents($argv[0]), true);
-MongoTripodConfig::setConfig($config);
+\Tripod\Mongo\Config::setConfig($config);
 
-$tu = new TriplesUtil();
+$tu = new \Tripod\Mongo\TriplesUtil();
 
 while (($line = fgets(STDIN)) !== false) {
     $line = rtrim($line);
 
-    $graph = new MongoGraph();
+    $graph = new \Tripod\Mongo\MongoGraph();
     $doc = json_decode($line, true);
 
     if(array_key_exists("_id", $doc)) {

--- a/scripts/mongo/createTables.php
+++ b/scripts/mongo/createTables.php
@@ -25,7 +25,7 @@ php createTables.php -c/--config path/to/tripod-config.json -s/--storename store
 
 Options:
     -h --help               This help
-    -c --config             path to MongoTripodConfig configuration (required)
+    -c --config             path to Config configuration (required)
     -s --storename          Store to create tables for (required)
     -t --spec               Only create for specified table specs
     -i --id                 Resource ID to regenerate table rows for
@@ -71,8 +71,8 @@ set_include_path(
 
 require_once 'tripod.inc.php';
 require_once 'classes/Timer.class.php';
-require_once 'mongo/MongoTripodConfig.class.php';
-require_once 'mongo/MongoTripod.class.php';
+require_once 'mongo/Config.class.php';
+require_once 'mongo/Tripod.class.php';
 
 /**
  * @param string|null $id
@@ -82,10 +82,10 @@ require_once 'mongo/MongoTripod.class.php';
  */
 function generateTables($id, $tableId, $storeName, $stat = null)
 {
-    $tableSpec = MongoTripodConfig::getInstance()->getTableSpecification($storeName, $tableId);
+    $tableSpec = TripodConfig::getInstance()->getTableSpecification($storeName, $tableId);
     if(empty($tableSpec)) // Older version of Tripod being used?
     {
-        $tableSpec = MongoTripodConfig::getInstance()->getTableSpecification($tableId);
+        $tableSpec = TripodConfig::getInstance()->getTableSpecification($tableId);
     }
     if (array_key_exists("from",$tableSpec))
     {
@@ -93,7 +93,7 @@ function generateTables($id, $tableId, $storeName, $stat = null)
 
         print "Generating $tableId";
         $tripod = new MongoTripod($tableSpec['from'], $storeName, array('stat'=>$stat));
-        $tTables = $tripod->getTripodTables();//new MongoTripodTables($tripod->storeName,$tripod->collection,$tripod->defaultContext);
+        $tTables = $tripod->getTripodTables();//new Tables($tripod->storeName,$tripod->collection,$tripod->defaultContext);
         if ($id)
         {
             print " for $id....\n";
@@ -110,7 +110,7 @@ function generateTables($id, $tableId, $storeName, $stat = null)
 $t = new Timer();
 $t->start();
 
-MongoTripodConfig::setConfig(json_decode(file_get_contents($configLocation),true));
+TripodConfig::setConfig(json_decode(file_get_contents($configLocation),true));
 
 if(isset($options['s']) || isset($options['storename']))
 {
@@ -153,7 +153,7 @@ if ($tableId)
 }
 else
 {
-    foreach(MongoTripodConfig::getInstance()->getTableSpecifications($storeName) as $tableSpec)
+    foreach(TripodConfig::getInstance()->getTableSpecifications($storeName) as $tableSpec)
     {
         generateTables($id, $tableSpec['_id'], $storeName, $stat);
     }

--- a/scripts/mongo/createTables.php
+++ b/scripts/mongo/createTables.php
@@ -78,21 +78,21 @@ require_once 'mongo/Tripod.class.php';
  * @param string|null $id
  * @param string|null $tableId
  * @param string|null $storeName
- * @param iTripodStat|null $stat
+ * @param \Tripod\ITripodStat|null $stat
  */
 function generateTables($id, $tableId, $storeName, $stat = null)
 {
-    $tableSpec = TripodConfig::getInstance()->getTableSpecification($storeName, $tableId);
+    $tableSpec = \Tripod\Mongo\Config::getInstance()->getTableSpecification($storeName, $tableId);
     if(empty($tableSpec)) // Older version of Tripod being used?
     {
-        $tableSpec = TripodConfig::getInstance()->getTableSpecification($tableId);
+        $tableSpec = \Tripod\Mongo\Config::getInstance()->getTableSpecification($tableId);
     }
     if (array_key_exists("from",$tableSpec))
     {
         MongoCursor::$timeout = -1;
 
         print "Generating $tableId";
-        $tripod = new MongoTripod($tableSpec['from'], $storeName, array('stat'=>$stat));
+        $tripod = new \Tripod\Mongo\Tripod($tableSpec['from'], $storeName, array('stat'=>$stat));
         $tTables = $tripod->getTripodTables();//new Tables($tripod->storeName,$tripod->collection,$tripod->defaultContext);
         if ($id)
         {
@@ -107,10 +107,10 @@ function generateTables($id, $tableId, $storeName, $stat = null)
     }
 }
 
-$t = new Timer();
+$t = new \Tripod\Timer();
 $t->start();
 
-TripodConfig::setConfig(json_decode(file_get_contents($configLocation),true));
+\Tripod\Mongo\Config::setConfig(json_decode(file_get_contents($configLocation),true));
 
 if(isset($options['s']) || isset($options['storename']))
 {
@@ -153,7 +153,7 @@ if ($tableId)
 }
 else
 {
-    foreach(TripodConfig::getInstance()->getTableSpecifications($storeName) as $tableSpec)
+    foreach(\Tripod\Mongo\Config::getInstance()->getTableSpecifications($storeName) as $tableSpec)
     {
         generateTables($id, $tableSpec['_id'], $storeName, $stat);
     }

--- a/scripts/mongo/createTables.php
+++ b/scripts/mongo/createTables.php
@@ -72,7 +72,7 @@ set_include_path(
 require_once 'tripod.inc.php';
 require_once 'classes/Timer.class.php';
 require_once 'mongo/Config.class.php';
-require_once 'mongo/Tripod.class.php';
+require_once 'mongo/Driver.class.php';
 
 /**
  * @param string|null $id
@@ -92,7 +92,7 @@ function generateTables($id, $tableId, $storeName, $stat = null)
         MongoCursor::$timeout = -1;
 
         print "Generating $tableId";
-        $tripod = new \Tripod\Mongo\Tripod($tableSpec['from'], $storeName, array('stat'=>$stat));
+        $tripod = new \Tripod\Mongo\Driver($tableSpec['from'], $storeName, array('stat'=>$stat));
         $tTables = $tripod->getTripodTables();//new Tables($tripod->storeName,$tripod->collection,$tripod->defaultContext);
         if ($id)
         {

--- a/scripts/mongo/createViews.php
+++ b/scripts/mongo/createViews.php
@@ -25,7 +25,7 @@ php createViews.php -c/--config path/to/tripod-config.json -s/--storename store-
 
 Options:
     -h --help               This help
-    -c --config             path to MongoTripodConfig configuration (required)
+    -c --config             path to Config configuration (required)
     -s --storename          Store to create views for (required)
     -v --spec               Only create for specified view specs
     -i --id                 Resource ID to regenerate views for
@@ -71,8 +71,8 @@ set_include_path(
 
 require_once 'tripod.inc.php';
 require_once 'classes/Timer.class.php';
-require_once 'mongo/MongoTripodConfig.class.php';
-require_once 'mongo/MongoTripod.class.php';
+require_once 'mongo/TripodConfigs.php';
+require_once 'mongo/Tripods.php';
 
 /**
  * @param string|null $id
@@ -94,7 +94,7 @@ function generateViews($id, $viewId, $storeName, $stat)
 
         print "Generating $viewId";
         $tripod = new MongoTripod($viewSpec['from'], $storeName, array('stat'=>$stat));
-        $views = $tripod->getTripodViews();//new MongoTripodViews($tripod->storeName,$tripod->collection,$tripod->defaultContext);
+        $views = $tripod->getTripodViews();//new Views($tripod->storeName,$tripod->collection,$tripod->defaultContext);
         if ($id)
         {
             print " for $id....\n";

--- a/scripts/mongo/createViews.php
+++ b/scripts/mongo/createViews.php
@@ -93,7 +93,7 @@ function generateViews($id, $viewId, $storeName, $stat)
         MongoCursor::$timeout = -1;
 
         print "Generating $viewId";
-        $tripod = new \Tripod\Mongo\Tripod($viewSpec['from'], $storeName, array('stat'=>$stat));
+        $tripod = new \Tripod\Mongo\Driver($viewSpec['from'], $storeName, array('stat'=>$stat));
         $views = $tripod->getTripodViews();//new Views($tripod->storeName,$tripod->collection,$tripod->defaultContext);
         if ($id)
         {

--- a/scripts/mongo/createViews.php
+++ b/scripts/mongo/createViews.php
@@ -78,14 +78,14 @@ require_once 'mongo/Tripods.php';
  * @param string|null $id
  * @param string|null $viewId
  * @param string $storeName
- * @param iTripodStat|null $stat
+ * @param \Tripod\ITripodStat|null $stat
  */
 function generateViews($id, $viewId, $storeName, $stat)
 {
-    $viewSpec = MongoTripodConfig::getInstance()->getViewSpecification($storeName, $viewId);
+    $viewSpec = \Tripod\Mongo\Config::getInstance()->getViewSpecification($storeName, $viewId);
     if(empty($viewSpec)) // Older version of Tripod being used?
     {
-        $viewSpec = MongoTripodConfig::getInstance()->getViewSpecification($viewId);
+        $viewSpec = \Tripod\Mongo\Config::getInstance()->getViewSpecification($viewId);
     }
     echo $viewId;
     if (array_key_exists("from",$viewSpec))
@@ -93,7 +93,7 @@ function generateViews($id, $viewId, $storeName, $stat)
         MongoCursor::$timeout = -1;
 
         print "Generating $viewId";
-        $tripod = new MongoTripod($viewSpec['from'], $storeName, array('stat'=>$stat));
+        $tripod = new \Tripod\Mongo\Tripod($viewSpec['from'], $storeName, array('stat'=>$stat));
         $views = $tripod->getTripodViews();//new Views($tripod->storeName,$tripod->collection,$tripod->defaultContext);
         if ($id)
         {
@@ -108,10 +108,10 @@ function generateViews($id, $viewId, $storeName, $stat)
     }
 }
 
-$t = new Timer();
+$t = new \Tripod\Timer();
 $t->start();
 
-MongoTripodConfig::setConfig(json_decode(file_get_contents($configLocation),true));
+\Tripod\Mongo\Config::setConfig(json_decode(file_get_contents($configLocation),true));
 
 if(isset($options['s']) || isset($options['storename']))
 {
@@ -153,7 +153,7 @@ if ($viewId)
 }
 else
 {
-    foreach(MongoTripodConfig::getInstance()->getViewSpecifications($storeName) as $viewSpec)
+    foreach(\Tripod\Mongo\Config::getInstance()->getViewSpecifications($storeName) as $viewSpec)
     {
         generateViews($id, $viewSpec['_id'], $storeName, $stat);
     }

--- a/scripts/mongo/detectNamespaces.php
+++ b/scripts/mongo/detectNamespaces.php
@@ -5,7 +5,8 @@ set_include_path(
         . PATH_SEPARATOR . dirname(dirname(dirname(__FILE__))).'/src/classes');
 
 require_once 'tripod.inc.php';
-require_once 'mongo/Config.class.phpquire_once 'mongo/MongoGraph.class.php';
+require_once 'mongo/Config.class.php';
+require_once 'mongo/MongoGraph.class.php';
 require_once 'mongo/util/TriplesUtil.class.php';
 
 ini_set('memory_limit','32M');
@@ -40,10 +41,10 @@ $config = array(
     ),
 );
 
-MongoTripodConfig::setConfig($config);
+\Tripod\Mongo\Config::setConfig($config);
 
 
-$util = new TriplesUtil();
+$util = new \Tripod\Mongo\TriplesUtil();
 $objectNs = array();
 $i=0;
 while (($line = fgets(STDIN)) !== false) {
@@ -91,7 +92,7 @@ while (($line = fgets(STDIN)) !== false) {
                 $newNsConfig[$prefix] = $n;
                 echo "\nFound ns $n suggest prefix $prefix";
                 $config["namespaces"] = array_merge($config["namespaces"],$newNsConfig);
-                MongoTripodConfig::setConfig($config);
+                \Tripod\Mongo\Config::setConfig($config);
             }
         }
         $ns = $util->extractMissingObjectNs($triples);
@@ -117,7 +118,7 @@ while (($line = fgets(STDIN)) !== false) {
                     $newNsConfig[$prefix] = $n;
                     echo "\nFound object ns $n occurs > 500 times, suggest prefix $prefix";
                     $config["namespaces"] = array_merge($config["namespaces"],$newNsConfig);
-                    MongoTripodConfig::setConfig($config);
+                    \Tripod\Mongo\Config::setConfig($config);
                 }
             }
         }
@@ -130,6 +131,10 @@ while (($line = fgets(STDIN)) !== false) {
 
 print "Suggested namespace configuration:\n\n";
 
+/**
+ * @param string $json
+ * @return string
+ */
 function indent($json) {
 
     $result      = '';

--- a/scripts/mongo/detectNamespaces.php
+++ b/scripts/mongo/detectNamespaces.php
@@ -5,8 +5,7 @@ set_include_path(
         . PATH_SEPARATOR . dirname(dirname(dirname(__FILE__))).'/src/classes');
 
 require_once 'tripod.inc.php';
-require_once 'mongo/MongoTripodConfig.class.php';
-require_once 'mongo/MongoGraph.class.php';
+require_once 'mongo/Config.class.phpquire_once 'mongo/MongoGraph.class.php';
 require_once 'mongo/util/TriplesUtil.class.php';
 
 ini_set('memory_limit','32M');

--- a/scripts/mongo/discoverUnnamespacedUris.php
+++ b/scripts/mongo/discoverUnnamespacedUris.php
@@ -9,11 +9,16 @@ if ($argc!=4 && $argc!=3)
 }
 
 array_shift($argv);
-$client = new MongoClient($argv[0]);
+$client = new \MongoClient($argv[0]);
 
 /* @var $db MongoDB */
 $db = $client->selectDb($argv[1]);
 
+/**
+ * @param string $uri
+ * @param string|null $baseUri
+ * @return bool
+ */
 function isUnNamespaced($uri,$baseUri=null)
 {
     if ($baseUri==null)

--- a/scripts/mongo/ensureIndexes.php
+++ b/scripts/mongo/ensureIndexes.php
@@ -8,7 +8,7 @@ set_include_path(
 require_once 'tripod.inc.php';
 require_once 'classes/Timer.class.php';
 require_once 'mongo/util/IndexUtils.class.php';
-require_once 'mongo/TripodConfigs.php';
+require_once 'mongo/Config.class.php';
 
 if ($argc!=2&&$argc!=3&&$argc!=4)
 {
@@ -17,16 +17,16 @@ if ($argc!=2&&$argc!=3&&$argc!=4)
 }
 array_shift($argv);
 
-MongoTripodConfig::setConfig(json_decode(file_get_contents($argv[0]),true));
+\Tripod\Mongo\Config::setConfig(json_decode(file_get_contents($argv[0]),true));
 
 $storeName = (isset($argv[1])) ? $argv[1] : null;
 $forceReindex = (isset($argv[2])&&($argv[2]=="true")) ? true : false;
 
-$ei = new IndexUtils();
+$ei = new \Tripod\Mongo\IndexUtils();
 
-$t = new Timer();
+$t = new \Tripod\Timer();
 $t->start();
-print("About to start indexing on $dbName...\n");
+print("About to start indexing on $storeName...\n");
 $ei->ensureIndexes($forceReindex,$storeName);
 $t->stop();
 print "Indexing complete, took {$t->result()} seconds\n";

--- a/scripts/mongo/ensureIndexes.php
+++ b/scripts/mongo/ensureIndexes.php
@@ -8,7 +8,7 @@ set_include_path(
 require_once 'tripod.inc.php';
 require_once 'classes/Timer.class.php';
 require_once 'mongo/util/IndexUtils.class.php';
-require_once 'mongo/MongoTripodConfig.class.php';
+require_once 'mongo/TripodConfigs.php';
 
 if ($argc!=2&&$argc!=3&&$argc!=4)
 {

--- a/scripts/mongo/loadTriples.php
+++ b/scripts/mongo/loadTriples.php
@@ -9,7 +9,15 @@ require_once 'tripod.inc.php';
 require_once 'mongo/util/TriplesUtil.class.php';
 require_once 'classes/Timer.class.php';
 
-function load(TriplesUtil $loader,$subject,Array $triples,Array &$errors,$podName,$storeName)
+/**
+ * @param \Tripod\Mongo\TriplesUtil $loader
+ * @param string $subject
+ * @param array $triples
+ * @param array $errors
+ * @param string $podName
+ * @param string $storeName
+ */
+function load(\Tripod\Mongo\TriplesUtil $loader,$subject,Array $triples,Array &$errors,$podName,$storeName)
 {
     try
     {
@@ -22,7 +30,7 @@ function load(TriplesUtil $loader,$subject,Array $triples,Array &$errors,$podNam
     }
 }
 
-$timer = new Timer();
+$timer = new \Tripod\Timer();
 $timer->start();
 
 if ($argc!=4)
@@ -34,13 +42,13 @@ array_shift($argv);
 
 $storeName = $argv[0];
 $podName = $argv[1];
-MongoTripodConfig::setConfig(json_decode(file_get_contents($argv[2]),true));
+\Tripod\Mongo\Config::setConfig(json_decode(file_get_contents($argv[2]),true));
 
 $i=0;
 $currentSubject = "";
 $triples = array();
 $errors = array(); // array of subjects that failed to insert, even after retry...
-$loader = new TriplesUtil();
+$loader = new \Tripod\Mongo\TriplesUtil();
 
 while (($line = fgets(STDIN)) !== false) {
     $i++;

--- a/scripts/mongo/triplesToBSON.php
+++ b/scripts/mongo/triplesToBSON.php
@@ -15,13 +15,13 @@ if ($argc!=2)
 array_shift($argv);
 
 $config = json_decode(file_get_contents($argv[0]), true);
-MongoTripodConfig::setConfig($config);
+\Tripod\Mongo\Config::setConfig($config);
 
 $currentSubject = "";
 $triples = array();
 $docs = array();
 $errors = array(); // array of subjects that failed to insert, even after retry...
-$tu = new TriplesUtil();
+$tu = new \Tripod\Mongo\TriplesUtil();
 
 while (($line = fgets(STDIN)) !== false) {
     $line = rtrim($line);
@@ -36,7 +36,7 @@ while (($line = fgets(STDIN)) !== false) {
 
     if ($currentSubject!=$subject) // once subject changes, we have all triples for that subject, flush to Mongo
     {
-        print(json_encode($tu->getTArrayAbout($currentSubject,$triples,MongoTripodConfig::getInstance()->getDefaultContextAlias()))."\n");
+        print(json_encode($tu->getTArrayAbout($currentSubject,$triples,\Tripod\Mongo\Config::getInstance()->getDefaultContextAlias()))."\n");
         $currentSubject=$subject; // reset current subject to next subject
         $triples = array(); // reset triples
     }
@@ -45,7 +45,7 @@ while (($line = fgets(STDIN)) !== false) {
 }
 
 // last doc
-print(json_encode($tu->getTArrayAbout($currentSubject,$triples,MongoTripodConfig::getInstance()->getDefaultContextAlias()))."\n");
+print(json_encode($tu->getTArrayAbout($currentSubject,$triples,\Tripod\Mongo\Config::getInstance()->getDefaultContextAlias()))."\n");
 
 ?>
 

--- a/scripts/mongo/validateConfig.php
+++ b/scripts/mongo/validateConfig.php
@@ -19,7 +19,7 @@ php validateConfig.php -c/--config path/to/tripod-config.json [options]
 
 Options:
     -h --help               This help
-    -c --config             path to MongoTripodConfig configuration (required)
+    -c --config             path to Config configuration (required)
 END;
     echo $help;
 }
@@ -38,8 +38,8 @@ set_include_path(
     . PATH_SEPARATOR . $tripodBasePath.'/src/classes');
 
 require_once 'tripod.inc.php';
-require_once 'mongo/MongoTripod.class.php';
-require_once 'mongo/MongoTripodConfig.class.php';
+require_once 'mongo/Tripods.php';
+require_once 'mongo/TripodConfigs.php';
 
 MongoTripodConfig::setValidationLevel(MongoTripodConfig::VALIDATE_MAX);
 

--- a/scripts/mongo/validateConfig.php
+++ b/scripts/mongo/validateConfig.php
@@ -38,7 +38,7 @@ set_include_path(
     . PATH_SEPARATOR . $tripodBasePath.'/src/classes');
 
 require_once 'tripod.inc.php';
-require_once 'mongo/Tripod.class.php';
+require_once 'mongo/Driver.class.php';
 require_once 'mongo/Config.class.php';
 
 \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);

--- a/scripts/mongo/validateConfig.php
+++ b/scripts/mongo/validateConfig.php
@@ -38,19 +38,19 @@ set_include_path(
     . PATH_SEPARATOR . $tripodBasePath.'/src/classes');
 
 require_once 'tripod.inc.php';
-require_once 'mongo/Tripods.php';
-require_once 'mongo/TripodConfigs.php';
+require_once 'mongo/Tripod.class.php';
+require_once 'mongo/Config.class.php';
 
-MongoTripodConfig::setValidationLevel(MongoTripodConfig::VALIDATE_MAX);
+\Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
 
-MongoTripodConfig::setConfig(json_decode(file_get_contents($configLocation),true));
+\Tripod\Mongo\Config::setConfig(json_decode(file_get_contents($configLocation),true));
 
 try {
-    MongoTripodConfig::getInstance();
+    \Tripod\Mongo\Config::getInstance();
 
     echo "\nConfig OK\n";
 }
-catch(MongoTripodConfigException $e)
+catch(\Tripod\Exceptions\ConfigException $e)
 {
     echo "\nError: " . $e->getMessage() . "\n";
 }

--- a/scripts/mongo/worker.inc.php
+++ b/scripts/mongo/worker.inc.php
@@ -6,4 +6,4 @@ $logger = new \Monolog\Logger("TRIPOD-WORKER");
 $logger->pushHandler(new \Monolog\Handler\StreamHandler('php://stderr', Psr\Log\LogLevel::WARNING)); // resque too chatty on NOTICE & INFO. YMMV
 
 // this is so tripod itself uses the same logger
-MongoTripodBase::$logger = new \Monolog\Logger("TRIPOD-JOB",array(new \Monolog\Handler\StreamHandler('php://stderr', Psr\Log\LogLevel::DEBUG)));
+\Tripod\Mongo\TripodBase::$logger = new \Monolog\Logger("TRIPOD-JOB",array(new \Monolog\Handler\StreamHandler('php://stderr', Psr\Log\LogLevel::DEBUG)));

--- a/scripts/mongo/worker.inc.php
+++ b/scripts/mongo/worker.inc.php
@@ -6,4 +6,4 @@ $logger = new \Monolog\Logger("TRIPOD-WORKER");
 $logger->pushHandler(new \Monolog\Handler\StreamHandler('php://stderr', Psr\Log\LogLevel::WARNING)); // resque too chatty on NOTICE & INFO. YMMV
 
 // this is so tripod itself uses the same logger
-\Tripod\Mongo\TripodBase::$logger = new \Monolog\Logger("TRIPOD-JOB",array(new \Monolog\Handler\StreamHandler('php://stderr', Psr\Log\LogLevel::DEBUG)));
+\Tripod\Mongo\DriverBase::$logger = new \Monolog\Logger("TRIPOD-JOB",array(new \Monolog\Handler\StreamHandler('php://stderr', Psr\Log\LogLevel::DEBUG)));

--- a/src/IDriver.php
+++ b/src/IDriver.php
@@ -3,10 +3,10 @@
 namespace Tripod;
 
 /**
- * Class ITripod
+ * Class IDriver
  * @package Tripod
  */
-interface ITripod
+interface IDriver
 {
     // graph functions
 

--- a/src/ITripod.php
+++ b/src/ITripod.php
@@ -1,4 +1,11 @@
 <?php
+
+namespace Tripod;
+
+/**
+ * Class ITripod
+ * @package Tripod
+ */
 interface ITripod
 {
     // graph functions

--- a/src/ITripodStat.php
+++ b/src/ITripodStat.php
@@ -1,6 +1,23 @@
 <?php
+
+namespace Tripod;
+
+/**
+ * Class ITripodStat
+ * @package Tripod
+ */
 interface ITripodStat
 {
+    /**
+     * @param string $operation
+     * @return mixed
+     */
     public function increment($operation);
+
+    /**
+     * @param string $operation
+     * @param number $duration
+     * @return mixed
+     */
     public function timer($operation,$duration);
 }

--- a/src/classes/ChangeSet.class.php
+++ b/src/classes/ChangeSet.class.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Tripod;
+
 /**
  * Represents a changeset. Can be used to create a changeset based on the difference between two bounded descriptions. The descriptions must share the same subject URI.
  * Adapted from Moriarty's changeset
@@ -41,20 +43,21 @@ class ChangeSet extends ExtendedGraph {
      *   <li><em>o_lang</em> => the language of the literal if any</li>
      *   <li><em>o_datatype</em> => the data type URI of the literal if any</li>
      * </ul>
-     * @param array args an associative array of parameters to use when constructing the changeset
+     * @param array $a args an associative array of parameters to use when constructing the changeset
      */
     var $a;
     var $subjectIndex = array();
     var $_index = array();
 
-    function __construct($a = '') {
+    public function __construct($a = '') {
         parent::__construct();
         $this->a = $a;
         /* parse the before and after graphs if necessary*/
         foreach(array('before','after', 'before_rdfxml', 'after_rdfxml') as $rdf){
             if(!empty($a[$rdf]) ){
                 if(is_string($a[$rdf]) ){
-                    $parser = ARC2::getRDFParser();
+                    /** @var \ARC2_RDFParser $parser */
+                    $parser = \ARC2::getRDFParser();
                     $parser->parse(false, $a[$rdf]);
                     $a[$rdf] = $parser->getSimpleIndex(0);
                 } else if(
@@ -62,9 +65,12 @@ class ChangeSet extends ExtendedGraph {
                     isset($a[$rdf][0]) AND
                     isset($a[$rdf][0]['s'])
                 ) { //triples array
-                    $ser = ARC2::getTurtleSerializer();
+                    /** @var \ARC2_RDFSerializer $ser */
+                    $ser = \ARC2::getTurtleSerializer();
+                    /** @var string $turtle */
                     $turtle = $ser->getSerializedTriples($a[$rdf]);
-                    $parser = ARC2::getTurtleParser();
+                    /** @var \ARC2_RDFParser $parser */
+                    $parser = \ARC2::getTurtleParser();
                     $parser->parse(false, $turtle);
                     $a[$rdf] = $parser->getSimpleIndex(0);
 
@@ -77,11 +83,7 @@ class ChangeSet extends ExtendedGraph {
         $this->__init();
     }
 
-    function ChangeSet ($a = '') {
-        $this->__construct($a);
-    }
-
-    function __init() {
+    protected function __init() {
         $csIndex = array();
         $CSNS = 'http://purl.org/vocab/changeset/schema#';
 
@@ -97,7 +99,6 @@ class ChangeSet extends ExtendedGraph {
         } else {
             $removals = ExtendedGraph::diff($this->before, $this->after);
         }
-        // $removals = !empty($this->after)? ExtendedGraph::diff($this->before, $this->after) : $this->before;
 
         //remove etag triples
         foreach(array('removals' => $removals, 'additions'=> $additions) as $name => $graph){
@@ -112,13 +113,8 @@ class ChangeSet extends ExtendedGraph {
             }
         }
 
-//    print_r(array_keys($additions));
-//    print_r(array_keys($removals));
-//    print_r(array_merge(array_keys($additions), array_keys($removals)));
-
         // Get an array of all the subject uris
         $subjectIndex = !empty($this->a['subjectOfChange'])? array($this->a['subjectOfChange']) : array_unique(array_merge(array_keys($additions), array_keys($removals)));
-//    print_r($subjectIndex);
 
         // Get the metadata for all the changesets
         $date  = (!empty($this->a['createdDate']))? $this->a['createdDate'] : date(DATE_ATOM);
@@ -178,28 +174,20 @@ class ChangeSet extends ExtendedGraph {
             }
         }
 
-
-        // foreach($this->_index as $uri => $props){
-        //  if(
-        //      !isset($props[$CSNS.'removal'])
-        //      AND
-        //      !isset($props[$CSNS.'addition'])
-        //      ){
-        //        unset($this->_index[$uri]);
-        //    }
-        //
-        // }
-
         $this->_index = ExtendedGraph::merge($this->_index, $reifiedAdditions, $reifiedRemovals);
 
     }
 
     /**
      * adds a triple to the internal simpleIndex holding all the changesets and statements
+     * @param string $s Subject uri
+     * @param string $p Predicate URI
+     * @param string $o Object URI or literal value
+     * @param string $o_type
      * @return void
      * @author Keith
-     **/
-    function addT($s, $p, $o, $o_type='bnode'){
+     */
+    public function addT($s, $p, $o, $o_type='bnode'){
         if(is_array($o) AND isset($o[0]['type'])){
             foreach($o as $obj){
                 $this->addT($s, $p, $obj );
@@ -210,16 +198,26 @@ class ChangeSet extends ExtendedGraph {
         }
     }
 
-    function toRDFXML(){
-        $ser = ARC2::getRDFXMLSerializer();
+    /**
+     * @return string
+     */
+    public function toRDFXML(){
+        /** @var \ARC2_RDFSerializer $ser */
+        $ser = \ARC2::getRDFXMLSerializer();
         return $ser->getSerializedIndex($this->_index);
     }
 
-    function to_rdfxml(){
+    /**
+     * @return string
+     */
+    public function to_rdfxml(){
         return $this->toRDFXML();
     }
 
-    function has_changes(){
+    /**
+     * @return bool
+     */
+    public function has_changes(){
         foreach($this->_index as $uri => $properties){
             if(
                 isset($properties['http://purl.org/vocab/changeset/schema#addition'])
@@ -236,7 +234,7 @@ class ChangeSet extends ExtendedGraph {
      * Returns a unique array of the subjects of change in this changeset
      * @return array
      */
-    function get_subjects_of_change() {
+    public function get_subjects_of_change() {
         $subjects = array();
         /** @noinspection PhpParamsInspection */
         $changes = $this->get_subjects_of_type($this->qname_to_uri("cs:ChangeSet"));

--- a/src/classes/ExtendedGraph.class.php
+++ b/src/classes/ExtendedGraph.class.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Tripod;
+
 require_once(ARC_DIR.'ARC2.php');
 /**
  * This class is based on SimpleGraph, part of Moriaty: https://code.google.com/p/moriarty/
@@ -52,7 +54,10 @@ class ExtendedGraph
      */
     var $_labeller;
 
-    function __construct($graph=false){
+    /**
+     * @param string|\Tripod\ExtendedGraph $graph
+     */
+    public function __construct($graph=null){
         $this->_labeller = new Labeller();
         if($graph){
             if(is_string($graph)){
@@ -63,94 +68,93 @@ class ExtendedGraph
         }
     }
 
-    function __destruct(){
+    public function __destruct(){
         unset($this->_index);
         unset($this);
     }
 
-    function set_request_factory($request_factory) {
+    /**
+     * @todo: Is this used or needed?
+     * @param mixed $request_factory
+     */
+    public function set_request_factory($request_factory) {
         $this->request_factory = $request_factory;
     }
 
 
     /**
      * Map a portion of a URI to a short prefix for use when serialising the graph
-     * @param string prefix the namespace prefix to associate with the URI
-     * @param string uri the URI to associate with the prefix
+     * @param string $prefix the namespace prefix to associate with the URI
+     * @param string $uri the URI to associate with the prefix
      */
-    function set_namespace_mapping($prefix, $uri) {
+    public function set_namespace_mapping($prefix, $uri) {
         $this->_labeller->set_namespace_mapping($prefix, $uri);
     }
 
     /**
      * Convert a QName to a URI using registered namespace prefixes
-     * @param string qname the QName to convert
+     * @param string $qname the QName to convert
      * @return string the URI corresponding to the QName if a suitable prefix exists, null otherwise
      */
-    function qname_to_uri($qname) {
+    public function qname_to_uri($qname) {
         return $this->_labeller->qname_to_uri($qname);
     }
 
     /**
      * Convert a URI to a QName using registered namespace prefixes
-     * @param string uri the URI to convert
+     * @param string $uri the URI to convert
      * @return string the QName corresponding to the URI if a suitable prefix exists, null otherwise
      */
-    function uri_to_qname($uri) {
+    public function uri_to_qname($uri) {
         return $this->_labeller->uri_to_qname($uri);
     }
 
-    function get_prefix($ns) {
+    /**
+     * @param string $ns
+     * @return string
+     */
+    public function get_prefix($ns) {
         return $this->_labeller->get_prefix($ns);
     }
 
-    function add_labelling_property($p)  {
+    /**
+     * @param string $p @todo I think this should be a string?
+     */
+    public function add_labelling_property($p)  {
         $this->_labeller->add_labelling_property($p);
     }
 
-
-    function update_prefix_mappings() {
-        foreach ($this->_index as $s => $p_list) {
-            foreach ($p_list as $p => $v_list) {
-                $prefix = $this->_labeller->uri_to_qname($p);
-            }
-        }
-    }
-
-
-
-
     /**
      * Constructs an array containing the type of the resource and its value
-     * @param string resource a URI or blank node identifier (prefixed with _: e.g. _:name)
+     * @param string $resource a URI or blank node identifier (prefixed with _: e.g. _:name)
      * @return array an associative array with two keys: 'type' and 'value'. Type is either bnode or uri
      */
-    function make_resource_array($resource) {
+    public function make_resource_array($resource) {
         $resource_type = strpos($resource, '_:' ) === 0 ? 'bnode' : 'uri';
         return array('type' => $resource_type, 'value' => $resource);
     }
 
     /**
      * Adds a triple with a resource object to the graph
-     * @param string s the subject of the triple, either a URI or a blank node in the format _:name
-     * @param string p the predicate URI of the triple
-     * @param string o the object of the triple, either a URI or a blank node in the format _:name
+     * @param string $s the subject of the triple, either a URI or a blank node in the format _:name
+     * @param string $p the predicate URI of the triple
+     * @param string $o the object of the triple, either a URI or a blank node in the format _:name
      * @return boolean true if the triple was new, false if it already existed in the graph
      */
-    function add_resource_triple($s, $p, $o) {
+    public function add_resource_triple($s, $p, $o) {
         return $this->_add_triple($s, $p, array('type' => strpos($o, '_:' ) === 0 ? 'bnode' : 'uri', 'value' => $o));
     }
 
     /**
      * Adds a triple with a literal object to the graph
-     * @param string s the subject of the triple, either a URI or a blank node in the format _:name
-     * @param string p the predicate of the triple as a URI
-     * @param string o the object of the triple as a string
-     * @param string lang the language code of the triple's object (optional)
-     * @param string dt the datatype URI of the triple's object (optional)
+     * @param string $s the subject of the triple, either a URI or a blank node in the format _:name
+     * @param string $p the predicate of the triple as a URI
+     * @param string $o the object of the triple as a string
+     * @param string $lang the language code of the triple's object (optional)
+     * @param string $dt the datatype URI of the triple's object (optional)
      * @return boolean true if the triple was new, false if it already existed in the graph
      */
-    function add_literal_triple($s, $p, $o, $lang = null, $dt = null) {
+    public function add_literal_triple($s, $p, $o, $lang = null, $dt = null) {
         $o_info = array('type' => 'literal', 'value' => $o);
         if ( $lang != null ) {
             $o_info['lang'] = $lang;
@@ -161,7 +165,13 @@ class ExtendedGraph
         return $this->_add_triple($s, $p, $o_info);
     }
 
-    private function _add_triple($s, $p, $o_info) {
+    /**
+     * @param string $s
+     * @param string $p
+     * @param array $o_info
+     * @return bool
+     */
+    private function _add_triple($s, $p, Array $o_info) {
         if (!isset($this->_index[$s])) {
             $this->_index[$s] = array();
             $this->_index[$s][$p] = array( $o_info );
@@ -184,14 +194,14 @@ class ExtendedGraph
      * @deprecated this is deprecated
      */
     function get_triples() {
-        return ARC2::getTriplesFromIndex($this->_to_arc_index($this->_index));
+        return \ARC2::getTriplesFromIndex($this->_to_arc_index($this->_index));
     }
 
     /**
      * Get a copy of the graph's triple index
      * @see http://n2.talis.com/wiki/RDF_PHP_Specification
      */
-    function get_index() {
+    public function get_index() {
         return $this->_index;
     }
 
@@ -200,9 +210,9 @@ class ExtendedGraph
      * Serialise the graph to RDF/XML
      * @return string the RDF/XML version of the graph
      */
-    function to_rdfxml() {
-        $this->update_prefix_mappings();
-        $serializer = ARC2::getRDFXMLSerializer(
+    public function to_rdfxml() {
+        /** @var \ARC2_RDFSerializer $serializer */
+        $serializer = \ARC2::getRDFXMLSerializer(
             array(
                 'ns' => $this->_labeller->get_ns(),
             )
@@ -215,9 +225,9 @@ class ExtendedGraph
      * @see http://www.dajobe.org/2004/01/turtle/
      * @return string the Turtle version of the graph
      */
-    function to_turtle() {
-        $this->update_prefix_mappings();
-        $serializer = ARC2::getTurtleSerializer(
+    public function to_turtle() {
+        /** @var \ARC2_RDFSerializer $serializer */
+        $serializer = \ARC2::getTurtleSerializer(
             array(
                 'ns' => $this->_labeller->get_ns(),
             )
@@ -230,8 +240,9 @@ class ExtendedGraph
      * @see http://www.w3.org/TR/rdf-testcases/#ntriples
      * @return string the N-Triples version of the graph
      */
-    function to_ntriples() {
-        $serializer = ARC2::getComponent('NTriplesSerializer', array());
+    public function to_ntriples() {
+        /** @var \ARC2_RDFSerializer $serializer */
+        $serializer = \ARC2::getComponent('NTriplesSerializer', array());
         return $serializer->getSerializedIndex($this->_to_arc_index($this->_index));
     }
 
@@ -241,18 +252,18 @@ class ExtendedGraph
      * @see http://n2.talis.com/wiki/RDF_JSON_Specification
      * @return string the JSON version of the graph
      */
-    function to_json() {
+    public function to_json() {
         return json_encode($this->_index);
     }
 
 
     /**
      * Serialise the graph to HTML
+     * @param string|array|null $s
+     * @param bool $guess_labels
      * @return string a HTML version of the graph
      */
-    function to_html($s = null, $guess_labels = true) {
-
-        $this->update_prefix_mappings();
+    public function to_html($s = null, $guess_labels = true) {
         $h = '';
 
         if ($s) {
@@ -352,12 +363,13 @@ class ExtendedGraph
 
     /**
      * Fetch the first literal value for a given subject and predicate. If there are multiple possible values then one is selected at random.
-     * @param string s the subject to search for
-     * @param string p the predicate to search for, or an array of predicates
-     * @param string default a default value to use if no literal values are found
+     * @param string $s the subject to search for
+     * @param string $p the predicate to search for, or an array of predicates
+     * @param string $default a default value to use if no literal values are found
+     * @param string $preferred_language
      * @return string the first literal value found or the supplied default if no values were found
      */
-    function get_first_literal($s, $p, $default = null, $preferred_language = null) {
+    public function get_first_literal($s, $p, $default = null, $preferred_language = null) {
 
         $best_literal = $default;
         if ( array_key_exists($s, $this->_index)) {
@@ -406,12 +418,12 @@ class ExtendedGraph
 
     /**
      * Fetch the first resource value for a given subject and predicate. If there are multiple possible values then one is selected at random.
-     * @param string s the subject to search for
-     * @param string p the predicate to search for
-     * @param string default a default value to use if no literal values are found
+     * @param string $s the subject to search for
+     * @param string $p the predicate to search for
+     * @param string $default a default value to use if no literal values are found
      * @return string the first resource value found or the supplied default if no values were found
      */
-    function get_first_resource($s, $p, $default = null) {
+    public function get_first_resource($s, $p, $default = null) {
         if ( array_key_exists($s, $this->_index) && array_key_exists($p, $this->_index[$s]) ) {
             foreach ($this->_index[$s][$p] as $value) {
                 if ($value['type'] == 'uri' || $value['type'] == 'bnode' ) {
@@ -419,18 +431,16 @@ class ExtendedGraph
                 }
             }
         }
-        else {
-            return $default;
-        }
+        return $default;
     }
 
     /**
      * Remove a triple with a resource object from the graph
-     * @param string s the subject of the triple, either a URI or a blank node in the format _:name
-     * @param string p the predicate URI of the triple
-     * @param string o the object of the triple, either a URI or a blank node in the format _:name
+     * @param string $s the subject of the triple, either a URI or a blank node in the format _:name
+     * @param string $p the predicate URI of the triple
+     * @param string $o the object of the triple, either a URI or a blank node in the format _:name
      */
-    function remove_resource_triple( $s, $p, $o) {
+    public function remove_resource_triple( $s, $p, $o) {
         for ($i = count($this->_index[$s][$p]) - 1; $i >= 0; $i--) {
             if (($this->_index[$s][$p][$i]['type'] == 'uri' || $this->_index[$s][$p][$i]['type'] == 'bnode') && $this->_index[$s][$p][$i]['value'] == $o)  {
                 array_splice($this->_index[$s][$p], $i, 1);
@@ -446,7 +456,12 @@ class ExtendedGraph
 
     }
 
-    function remove_literal_triple( $s, $p, $o) {
+    /**
+     * @param string $s
+     * @param string $p
+     * @param string $o
+     */
+    public function remove_literal_triple($s, $p, $o) {
         for ($i = count($this->_index[$s][$p]) - 1; $i >= 0; $i--) {
             if ($this->_index[$s][$p][$i]['type'] == 'literal' && $this->_index[$s][$p][$i]['value'] == $o)  {
                 array_splice($this->_index[$s][$p], $i, 1);
@@ -464,19 +479,19 @@ class ExtendedGraph
 
     /**
      * Remove all triples having the supplied subject
-     * @param string s the subject of the triple, either a URI or a blank node in the format _:name
+     * @param string $s the subject of the triple, either a URI or a blank node in the format _:name
      */
-    function remove_triples_about($s) {
+    public function remove_triples_about($s) {
         unset($this->_index[$s]);
     }
 
 
     /**
      * Replace the triples in the graph with those parsed from the supplied RDF/XML
-     * @param string rdfxml the RDF/XML to parse
-     * @param string base the base URI against which relative URIs in the RDF/XML document will be resolved
+     * @param string $rdfxml the RDF/XML to parse
+     * @param string $base the base URI against which relative URIs in the RDF/XML document will be resolved
      */
-    function from_rdfxml($rdfxml, $base='') {
+    public function from_rdfxml($rdfxml, $base='') {
         if ($rdfxml) {
             $this->remove_all_triples();
             $this->add_rdfxml($rdfxml, $base);
@@ -486,9 +501,9 @@ class ExtendedGraph
     /**
      * Replace the triples in the graph with those parsed from the supplied JSON
      * @see http://n2.talis.com/wiki/RDF_JSON_Specification
-     * @param string json the JSON to parse
+     * @param string $json the JSON to parse
      */
-    function from_json($json) {
+    public function from_json($json) {
         if ($json) {
             $this->remove_all_triples();
             $this->_index = json_decode($json, true);
@@ -499,51 +514,55 @@ class ExtendedGraph
     /**
      * Add the triples parsed from the supplied JSON to the graph
      * @see http://n2.talis.com/wiki/RDF_JSON_Specification
-     * @param string json the JSON to parse
+     * @param string $json the JSON to parse
      */
-    function add_json($json) {
+    public function add_json($json) {
         if ($json) {
             $json_index = json_decode($json, true);
             $this->_index = $this->merge($this->_index, $json_index);
         }
     }
 
-    function get_parser_errors(){
+    /**
+     * @return array
+     */
+    public function get_parser_errors(){
         return $this->parser_errors;
     }
+
     /**
      * Add the triples parsed from the supplied RDF to the graph - let ARC guess the input
-     * @param string rdf the RDF to parse
-     * @param string base the base URI against which relative URIs in the RDF document will be resolved
+     * @param string $rdf the RDF to parse
+     * @param string $base the base URI against which relative URIs in the RDF document will be resolved
      * @author Keith Alexander
      */
-    function add_rdf($rdf=false, $base='') {
-        if ($rdf) {
-            $trimRdf = trim($rdf);
-            if($trimRdf[0]=='{'){ //lazy is-this-json assessment  - might be better to try json_decode - but more costly
-                $this->add_json($trimRdf);
-                unset($trimRdf);
-            } else {
-                $parser = ARC2::getRDFParser();
-                $parser->parse($base, $rdf);
-                $errors = $parser->getErrors();
-                if(!empty($errors)){
-                    $this->parser_errors[]=$errors;
-                }
-                $this->_add_arc2_triple_list($parser->getTriples());
-                unset($parser);
+    public function add_rdf($rdf, $base='') {
+        $trimRdf = trim($rdf);
+        if($trimRdf[0]=='{'){ //lazy is-this-json assessment  - might be better to try json_decode - but more costly
+            $this->add_json($trimRdf);
+            unset($trimRdf);
+        } else {
+            /** @var \ARC2_RDFParser $parser */
+            $parser = \ARC2::getRDFParser();
+            $parser->parse($base, $rdf);
+            $errors = $parser->getErrors();
+            if(!empty($errors)){
+                $this->parser_errors[]=$errors;
             }
+            $this->_add_arc2_triple_list($parser->getTriples());
+            unset($parser);
         }
     }
 
     /**
      * Add the triples parsed from the supplied RDF/XML to the graph
-     * @param string rdfxml the RDF/XML to parse
-     * @param string base the base URI against which relative URIs in the RDF/XML document will be resolved
+     * @param string $rdfxml the RDF/XML to parse
+     * @param string $base the base URI against which relative URIs in the RDF/XML document will be resolved
      */
-    function add_rdfxml($rdfxml, $base='') {
+    public function add_rdfxml($rdfxml, $base='') {
         if ($rdfxml) {
-            $parser = ARC2::getRDFXMLParser();
+            /** @var \ARC2_RDFXMLParser $parser */
+            $parser = \ARC2::getRDFXMLParser();
             $parser->parse($base, $rdfxml );
             $this->_add_arc2_triple_list($parser->getTriples());
             unset($parser);
@@ -553,10 +572,10 @@ class ExtendedGraph
     /**
      * Replace the triples in the graph with those parsed from the supplied Turtle
      * @see http://www.dajobe.org/2004/01/turtle/
-     * @param string turtle the Turtle to parse
-     * @param string base the base URI against which relative URIs in the Turtle document will be resolved
+     * @param string $turtle the Turtle to parse
+     * @param string $base the base URI against which relative URIs in the Turtle document will be resolved
      */
-    function from_turtle($turtle, $base='') {
+    public function from_turtle($turtle, $base='') {
         if ($turtle) {
             $this->remove_all_triples();
             $this->add_turtle($turtle, $base);
@@ -566,12 +585,13 @@ class ExtendedGraph
     /**
      * Add the triples parsed from the supplied Turtle to the graph
      * @see http://www.dajobe.org/2004/01/turtle/
-     * @param string turtle the Turtle to parse
-     * @param string base the base URI against which relative URIs in the Turtle document will be resolved
+     * @param string $turtle the Turtle to parse
+     * @param string $base the base URI against which relative URIs in the Turtle document will be resolved
      */
-    function add_turtle($turtle, $base='') {
+    public function add_turtle($turtle, $base='') {
         if ($turtle) {
-            $parser = ARC2::getTurtleParser();
+            /** @var \ARC2_TurtleParser $parser */
+            $parser = \ARC2::getTurtleParser();
             $parser->parse($base, $turtle );
             $this->_add_arc2_triple_list($parser->getTriples());
             unset($parser);
@@ -581,10 +601,10 @@ class ExtendedGraph
 
     /**
      * Replace the triples in the graph with those parsed from the supplied RDFa
-     * @param string html the HTML containing RDFa to parse
-     * @param string base the base URI against which relative URIs in the Turtle document will be resolved
+     * @param string $html the HTML containing RDFa to parse
+     * @param string $base the base URI against which relative URIs in the Turtle document will be resolved
      */
-    function from_rdfa($html, $base='') {
+    public function from_rdfa($html, $base='') {
         if ($html) {
             $this->remove_all_triples();
             $this->add_rdfa($html, $base);
@@ -592,12 +612,13 @@ class ExtendedGraph
     }
     /**
      * Add the triples parsed from the supplied RDFa to the graph
-     * @param string html the HTML containing RDFa to parse
-     * @param string base the base URI against which relative URIs in the Turtle document will be resolved
+     * @param string $html the HTML containing RDFa to parse
+     * @param string $base the base URI against which relative URIs in the Turtle document will be resolved
      */
-    function add_rdfa($html, $base='') {
+    public function add_rdfa($html, $base='') {
         if ($html) {
-            $parser = ARC2::getSemHTMLParser();
+            /** @var \ARC2_SemHTMLParser $parser */
+            $parser = \ARC2::getSemHTMLParser();
             $parser->parse($base, $html );
             $parser->extractRDF('rdfa');
             $this->_add_arc2_triple_list($parser->getTriples());
@@ -607,9 +628,10 @@ class ExtendedGraph
 
     /**
      * Add the triples in the supplied graph to the current graph
-     * @param ExtendedGraph g the graph to read
+     * @param ExtendedGraph $g the graph to read
+     * @return bool
      */
-    function add_graph($g) {
+    public function add_graph(ExtendedGraph $g) {
         $triples_were_added = false;
         $index = $g->get_index();
         foreach ($index as $s => $p_list) {
@@ -624,7 +646,9 @@ class ExtendedGraph
         return $triples_were_added;
     }
 
-
+    /**
+     * @param array $triples
+     */
     private function _add_arc2_triple_list(&$triples) {
         $bnode_index = array();
 
@@ -697,6 +721,10 @@ class ExtendedGraph
 
 
     // until ARC2 upgrades to support RDF/PHP we need to rename all types of "uri" to "iri"
+    /**
+     * @param array $index
+     * @return array
+     */
     private function _to_arc_index(&$index) {
         $ret = array();
 
@@ -723,12 +751,12 @@ class ExtendedGraph
 
     /**
      * Tests whether the graph contains the given triple
-     * @param string s the subject of the triple, either a URI or a blank node in the format _:name
-     * @param string p the predicate URI of the triple
-     * @param string o the object of the triple, either a URI or a blank node in the format _:name
+     * @param string $s the subject of the triple, either a URI or a blank node in the format _:name
+     * @param string $p the predicate URI of the triple
+     * @param string $o the object of the triple, either a URI or a blank node in the format _:name
      * @return boolean true if the triple exists in the graph, false otherwise
      */
-    function has_resource_triple($s, $p, $o) {
+    public function has_resource_triple($s, $p, $o) {
         if (array_key_exists($s, $this->_index) ) {
             if (array_key_exists($p, $this->_index[$s]) ) {
                 foreach ($this->_index[$s][$p] as $value) {
@@ -744,12 +772,14 @@ class ExtendedGraph
 
     /**
      * Tests whether the graph contains the given triple
-     * @param string s the subject of the triple, either a URI or a blank node in the format _:name
-     * @param string p the predicate URI of the triple
-     * @param string o the object of the triple as a literal value
+     * @param string $s the subject of the triple, either a URI or a blank node in the format _:name
+     * @param string $p the predicate URI of the triple
+     * @param string $o the object of the triple as a literal value
+     * @param string|null $lang the language of the object
+     * @param string|null $dt the datatype of the object
      * @return boolean true if the triple exists in the graph, false otherwise
      */
-    function has_literal_triple($s, $p, $o, $lang = null, $dt = null) {
+    public function has_literal_triple($s, $p, $o, $lang = null, $dt = null) {
         if (array_key_exists($s, $this->_index) ) {
             if (array_key_exists($p, $this->_index[$s]) ) {
                 foreach ($this->_index[$s][$p] as $value) {
@@ -773,11 +803,11 @@ class ExtendedGraph
 
     /**
      * Fetch the resource values for a given subject and predicate.
-     * @param string s the subject to search for
-     * @param string p the predicate to search for
+     * @param string $s the subject to search for
+     * @param string $p the predicate to search for
      * @return array list of URIs and blank nodes that are the objects of triples with the supplied subject and predicate
      */
-    function get_resource_triple_values($s, $p) {
+    public function get_resource_triple_values($s, $p) {
         $values = array();
         if (array_key_exists($s, $this->_index) ) {
             if (array_key_exists($p, $this->_index[$s]) ) {
@@ -793,11 +823,11 @@ class ExtendedGraph
 
     /**
      * Fetch the literal values for a given subject and predicate.
-     * @param string s the subject to search for
-     * @param string p the predicate to search for
+     * @param string $s the subject to search for
+     * @param string $p the predicate to search for
      * @return array list of literals that are the objects of triples with the supplied subject and predicate
      */
-    function get_literal_triple_values($s, $p) {
+    public function get_literal_triple_values($s, $p) {
         $values = array();
         if ( array_key_exists($s, $this->_index)) {
             if (is_array($p)) {
@@ -826,11 +856,11 @@ class ExtendedGraph
 
     /**
      * Fetch the values for a given subject and predicate.
-     * @param string s the subject to search for
-     * @param string p the predicate to search for
+     * @param string $s the subject to search for
+     * @param string $p the predicate to search for
      * @return array list of values of triples with the supplied subject and predicate
      */
-    function get_subject_property_values($s, $p) {
+    public function get_subject_property_values($s, $p) {
         $values = array();
         if (! is_array($p)) $p = array($p);
         if (array_key_exists($s, $this->_index) ) {
@@ -847,10 +877,10 @@ class ExtendedGraph
 
     /**
      * Fetch a subgraph where all triples have given subject
-     * @param string s the subject to search for
+     * @param string $s the subject to search for
      * @return ExtendedGraph triples with the supplied subject
      */
-    function get_subject_subgraph($s) {
+    public function get_subject_subgraph($s) {
         $sub = new ExtendedGraph();
         if (array_key_exists($s, $this->_index) ) {
             $sub->_index[$s] = $this->_index[$s];
@@ -862,40 +892,46 @@ class ExtendedGraph
      * Fetch an array of all the subjects
      * @return array
      */
-    function get_subjects() {
+    public function get_subjects() {
         return array_keys($this->_index);
     }
 
 
     /**
      * Fetch an array of all the subject that have and rdf type that matches that given
-     * @param $t the type to match
+     * @param string $t the type to match
      * @return array
      */
-    function get_subjects_of_type($t) {
+    public function get_subjects_of_type($t) {
         return $this->get_subjects_where_resource('http://www.w3.org/1999/02/22-rdf-syntax-ns#type', $t);
     }
 
     /**
      * Fetch an array of all the subjects where the predicate and object match a ?s $p $o triple in the graph and the object is a resource
-     * @param $p the predicate to match
-     * @param $o the resource object to match
+     * @param string $p the predicate to match
+     * @param string $o the resource object to match
      * @return array
      */
-    function get_subjects_where_resource($p, $o) {
+    public function get_subjects_where_resource($p, $o) {
         return array_merge($this->get_subjects_where($p, $o, 'uri'), $this->get_subjects_where($p, $o, 'bnode'));
     }
 
     /**
      * Fetch an array of all the subjects where the predicate and object match a ?s $p $o triple in the graph and the object is a literal value
-     * @param $p the predicate to match
-     * @param $o the resource object to match
+     * @param string $p the predicate to match
+     * @param string $o the resource object to match
      * @return array
      */
-    function get_subjects_where_literal($p, $o) {
+    public function get_subjects_where_literal($p, $o) {
         return $this->get_subjects_where($p, $o, 'literal');
     }
 
+    /**
+     * @param string $p
+     * @param string $o
+     * @param string $type
+     * @return array
+     */
     private function get_subjects_where($p, $o, $type)
     {
         $subjects = array();
@@ -918,11 +954,11 @@ class ExtendedGraph
 
     /**
      * Fetch the properties of a given subject and predicate.
-     * @param string s the subject to search for
-     * @param boolean distinct if true then duplicate properties are included only once (optional, default is true)
+     * @param string $s the subject to search for
+     * @param boolean $distinct if true then duplicate properties are included only once (optional, default is true)
      * @return array list of property URIs
      */
-    function get_subject_properties($s, $distinct = TRUE) {
+    public function get_subject_properties($s, $distinct = TRUE) {
         $values = array();
         if (array_key_exists($s, $this->_index) ) {
             foreach ($this->_index[$s] as $prop => $prop_values ) {
@@ -942,11 +978,11 @@ class ExtendedGraph
 
     /**
      * Tests whether the graph contains a triple with the given subject and predicate
-     * @param string s the subject of the triple, either a URI or a blank node in the format _:name
-     * @param string p the predicate URI of the triple
+     * @param string $s the subject of the triple, either a URI or a blank node in the format _:name
+     * @param string $p the predicate URI of the triple
      * @return boolean true if a matching triple exists in the graph, false otherwise
      */
-    function subject_has_property($s, $p) {
+    public function subject_has_property($s, $p) {
         if (array_key_exists($s, $this->_index) ) {
             return (array_key_exists($p, $this->_index[$s]) );
         }
@@ -955,27 +991,27 @@ class ExtendedGraph
 
     /**
      * Tests whether the graph contains a triple with the given subject
-     * @param string s the subject of the triple, either a URI or a blank node in the format _:name
+     * @param string $s the subject of the triple, either a URI or a blank node in the format _:name
      * @return boolean true if the graph contains any triples with the specified subject, false otherwise
      */
-    function has_triples_about($s) {
+    public function has_triples_about($s) {
         return array_key_exists($s, $this->_index);
     }
 
 
     /**
      * Removes all triples with the given subject and predicate
-     * @param string s the subject of the triple, either a URI or a blank node in the format _:name
-     * @param string p the predicate URI of the triple
+     * @param string $s the subject of the triple, either a URI or a blank node in the format _:name
+     * @param string $p the predicate URI of the triple
      */
-    function remove_property_values($s, $p) {
+    public function remove_property_values($s, $p) {
         unset($this->_index[$s][$p]);
     }
 
     /**
      * Clears all triples out of the graph
      */
-    function remove_all_triples() {
+    public function remove_all_triples() {
         $this->_index = array();
     }
 
@@ -983,21 +1019,38 @@ class ExtendedGraph
      * Tests whether the graph contains any triples
      * @return boolean true if the graph contains no triples, false otherwise
      */
-    function is_empty() {
+    public function is_empty() {
         return ( count($this->_index) == 0);
     }
 
 
-    function get_label($resource_uri, $capitalize = false, $use_qnames = FALSE) {
+    /**
+     * @param string $resource_uri
+     * @param bool $capitalize
+     * @param bool $use_qnames
+     * @return string
+     */
+    public function get_label($resource_uri, $capitalize = false, $use_qnames = FALSE) {
         return $this->_labeller->get_label($resource_uri, $this, $capitalize, $use_qnames);
     }
 
-    function get_inverse_label($resource_uri, $capitalize = false, $use_qnames = FALSE) {
+    /**
+     * @param string $resource_uri
+     * @param bool $capitalize
+     * @param bool $use_qnames
+     * @return string
+     */
+    public function get_inverse_label($resource_uri, $capitalize = false, $use_qnames = FALSE) {
         return $this->_labeller->get_inverse_label($resource_uri, $this, $capitalize, $use_qnames);
     }
 
-    function get_description($resource_uri = null) {
+    /**
+     * @param string|null $resource_uri
+     * @return string
+     */
+    public function get_description($resource_uri = null) {
         if ($resource_uri == null) {
+            // @todo: this is the only occurrence of this property, can we remove this?
             $resource_uri = $this->_primary_resource;
         }
         $text = $this->get_first_literal($resource_uri,'http://purl.org/dc/terms/description', '', 'en');
@@ -1019,9 +1072,12 @@ class ExtendedGraph
         return $text;
     }
 
-
-
-    function reify($resources, $nodeID_prefix='Statement')
+    /**
+     * @param array $resources
+     * @param string $nodeID_prefix
+     * @return array
+     */
+    public function reify(Array $resources, $nodeID_prefix='Statement')
     {
         $RDF = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#';
         $reified = array();
@@ -1056,7 +1112,7 @@ class ExtendedGraph
      * @return array
      * @author Keith
      **/
-    function diff(){
+    public function diff(){
         $indices = func_get_args();
         if(count($indices)==1){
             array_unshift($indices, $this->_index);
@@ -1107,7 +1163,7 @@ class ExtendedGraph
      * @author Keith
      **/
 
-    function merge(){
+    public function merge(){
 
         $old_bnodeids = array();
         $indices = func_get_args();
@@ -1179,7 +1235,11 @@ class ExtendedGraph
         return $current;
     }
 
-    function replace_resource($look_for, $replace_with) {
+    /**
+     * @param string $look_for
+     * @param string $replace_with
+     */
+    public function replace_resource($look_for, $replace_with) {
         $remove_list_resources = array();
         $remove_list_literals = array();
         $add_list_resources = array();
@@ -1284,12 +1344,15 @@ class ExtendedGraph
     }
 
     /**
+     * @todo: this also uses request_factory, is this still relevant?
+     *
      * Read RDF from the supplied URIs and add to the current graph
-     * @param Any uri_list a URI, or array of URIs to fetch
-     * @param boolean include_response when TRUE include RDF about each retrieval operation
+     * @param string|array $uri_list a URI, or array of URIs to fetch
+     * @param boolean $include_response when TRUE include RDF about each retrieval operation
      */
-    function read_data($uri_list, $include_response = FALSE) {
+    public function read_data($uri_list, $include_response = FALSE) {
         if (empty( $this->request_factory) ) {
+            // @todo:  What is this supposed to be called?
             $this->request_factory = new HttpRequestFactory();
         }
 
@@ -1329,7 +1392,11 @@ class ExtendedGraph
         }
     }
 
-    function get_list_values($listUri) {
+    /**
+     * @param string $listUri
+     * @return array
+     */
+    public function get_list_values($listUri) {
         $array = array();
         while(!empty($listUri) AND $listUri != RDF_NIL){
             $array[]=$this->get_first_resource($listUri, RDF_FIRST);
@@ -1352,6 +1419,9 @@ class ExtendedGraph
      */
     private static $labelProperties;
 
+    /**
+     * @param array $properties
+     */
     public static function initProperties(Array $properties)
     {
     	if (array_key_exists('labelProperties', $properties))
@@ -1362,6 +1432,8 @@ class ExtendedGraph
 
     /**
      * Replaces $uri1 with $uri2 in subject, predicate and object position
+     * @param string $uri1
+     * @param string $uri2
      */
     public function replace_uris($uri1, $uri2){
         $index = $this->get_index();
@@ -1387,7 +1459,13 @@ class ExtendedGraph
         $this->_index = $index;
     }
 
-    public function get_triple_count($s=false, $p=false, $o=false){
+    /**
+     * @param string|null $s
+     * @param string|null $p
+     * @param string|null $o
+     * @return int
+     */
+    public function get_triple_count($s=null, $p=null, $o=null){
         $index = $this->get_index();
 
         if (empty($index))
@@ -1438,7 +1516,7 @@ class ExtendedGraph
 
     /**
      * Fetch all the resource values for a given subject.
-     * @param string s the subject to search for
+     * @param string $s the subject to search for
      * @return array the resource values found
      */
     public function get_resources_for_subject($s) {
@@ -1455,12 +1533,19 @@ class ExtendedGraph
         return array_unique($resources);
     }
 
+    /**
+     * @param string $p
+     */
     public function remove_properties($p) {
         foreach($this->get_subjects() as $s){
             $this->remove_property_values($s, $p);
         }
     }
 
+    /**
+     * @param string $p
+     * @return array
+     */
     public function get_resource_properties($p) {
         $resources = array();
         foreach($this->get_subjects() as $s) {
@@ -1470,6 +1555,11 @@ class ExtendedGraph
         return $resources;
     }
 
+    /**
+     * @param string $p
+     * @param string $o
+     * @return array
+     */
     public function get_subjects_with_property_value($p, $o) {
         $subjects = array();
         foreach($this->get_subjects() as $s) {
@@ -1480,6 +1570,10 @@ class ExtendedGraph
         return $subjects;
     }
 
+    /**
+     * @param string $sequenceUri
+     * @return array
+     */
     public function get_sequence_values($sequenceUri)
     {
         $triples = $this->get_index();
@@ -1516,6 +1610,10 @@ class ExtendedGraph
         return $values;
     }
 
+    /**
+     * @param string $sequenceUri
+     * @return int
+     */
     public function get_next_sequence($sequenceUri)
     {
         $values = $this->get_sequence_values($sequenceUri);
@@ -1523,13 +1621,19 @@ class ExtendedGraph
         return count($values)+1;
     }
 
+    /**
+     * @param string $s
+     * @param string $o
+     */
     public function add_literal_to_sequence($s, $o)
     {
         $this->add_to_sequence($s, $o, 'literal');
     }
 
     /**
-     * Remove a resource from a specified sequence and reindex the sequence to remove hte gap.
+     * Remove a resource from a specified sequence and reindex the sequence to remove the gap.
+     * @param string $sequenceUri
+     * @param string $resourceValue
      */
     public function remove_resource_from_sequence($sequenceUri, $resourceValue)
     {
@@ -1556,11 +1660,20 @@ class ExtendedGraph
         }
     }
 
+    /**
+     * @param string $s
+     * @param string $o
+     */
     public function add_resource_to_sequence($s, $o)
     {
         $this->add_to_sequence($s, $o);
     }
 
+    /**
+     * @param string $s
+     * @param string $o
+     * @param int $position
+     */
     public function add_resource_to_sequence_in_position($s, $o, $position)
     {
         $sequenceValues = $this->get_sequence_values($s);
@@ -1589,6 +1702,11 @@ class ExtendedGraph
         }
     }
 
+    /**
+     * @param string $s
+     * @param string $o
+     * @param string $type
+     */
     private function add_to_sequence($s, $o, $type = 'resource')
     {
         $sequenceValue = $this->get_next_sequence($s);
@@ -1604,6 +1722,13 @@ class ExtendedGraph
         }
     }
 
+    /**
+     * @param string $s
+     * @param string $p
+     * @param string $oOldValue
+     * @param string $oNewValue
+     * @return bool
+     */
     function replace_literal_triple($s, $p, $oOldValue, $oNewValue)
     {
         if ($this->has_literal_triple($s, $p, $oOldValue))
@@ -1618,6 +1743,11 @@ class ExtendedGraph
         }
     }
 
+    /**
+     * @param string $s
+     * @param string $p
+     * @param string $o
+     */
     public function replace_resource_triples( $s, $p, $o) {
         if($this->subject_has_property($s, $p)) {
             $this->remove_property_values($s, $p);
@@ -1627,6 +1757,11 @@ class ExtendedGraph
         }
     }
 
+    /**
+     * @param string $s
+     * @param string $p
+     * @param string $o
+     */
     public function replace_literal_triples( $s, $p, $o) {
         if($this->subject_has_property($s, $p)) {
             $this->remove_property_values($s, $p);
@@ -1636,6 +1771,11 @@ class ExtendedGraph
         }
     }
 
+    /**
+     * @param string $uri
+     * @return string
+     * @throws \Tripod\Exceptions\Exception
+     */
     function get_label_for_uri($uri)
     {
         if(!isset($this->_index[$uri])){
@@ -1643,7 +1783,7 @@ class ExtendedGraph
         }
         if (!isset(self::$labelProperties))
         {
-            throw new TripodException('Please initialise ExtendedGraph::$labelProperties');
+            throw new \Tripod\Exceptions\Exception('Please initialise ExtendedGraph::$labelProperties');
         }
         foreach(self::$labelProperties as $p){
             if(isset($this->_index[$uri][$p])){
@@ -1654,7 +1794,11 @@ class ExtendedGraph
         return '';
     }
 
-    public function is_equal_to($otherGraph)
+    /**
+     * @param ExtendedGraph $otherGraph
+     * @return bool
+     */
+    public function is_equal_to(ExtendedGraph $otherGraph)
     {
         $diffThisAndThat = ExtendedGraph::diff($this->get_index(), $otherGraph->get_index());
         $diffThatAndThis = ExtendedGraph::diff($otherGraph->get_index(), $this->get_index());
@@ -1662,6 +1806,9 @@ class ExtendedGraph
         return (empty($diffThisAndThat) && empty($diffThatAndThis));
     }
 
+    /**
+     * @param string $type
+     */
     public function remove_subjects_of_type($type)
     {
         $subjects = $this->get_subjects_of_type($type);
@@ -1671,7 +1818,10 @@ class ExtendedGraph
         }
     }
 
-    public function from_graph($graph) {
+    /**
+     * @param ExtendedGraph $graph
+     */
+    public function from_graph(ExtendedGraph $graph) {
         if ($graph) {
             $this->remove_all_triples();
             $this->add_graph($graph);

--- a/src/classes/Labeller.class.php
+++ b/src/classes/Labeller.class.php
@@ -1,13 +1,21 @@
 <?php
 
+namespace Tripod;
+
 /**
  * Utility class for labelling properties
  * Based on Moriarty's Labeller
  * @see https://code.google.com/p/moriarty/source/browse/trunk/labeller.class.php
  */
 class Labeller {
+    /**
+     * @var array
+     */
     protected $_label_properties = array();
 
+    /**
+     * @var array
+     */
     protected $_ns = array (
         'rdf' => 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
         'rdfs' => 'http://www.w3.org/2000/01/rdf-schema#',
@@ -51,6 +59,10 @@ class Labeller {
         'gn' => 'http://www.geonames.org/ontology#',
         'cyc' => 'http://sw.opencyc.org/2009/04/07/concept/en/',
     );
+
+    /**
+     * @var array
+     */
     var $_labels = array(
         'http://www.w3.org/1999/02/22-rdf-syntax-ns#_1' => array('first', 'first', 'is first member of'),
         'http://www.w3.org/1999/02/22-rdf-syntax-ns#_2' => array('second', 'second', 'is second member of'),
@@ -135,7 +147,6 @@ class Labeller {
         'http://purl.org/dc/terms/language' => array('language','languages','is language of'),
         'http://purl.org/dc/terms/medium' => array('medium','media','is medium of'),
         'http://purl.org/dc/terms/modified' => array('date modified','dates modified','is date modified of'),
-        'http://purl.org/dc/terms/replaces' => array('replaces','replaces','replaced by'),
         'http://purl.org/dc/terms/references' => array('references','references','is referenced by'),
         'http://purl.org/dc/terms/replaces' => array('replaces','replaces','is replaced by'),
         'http://purl.org/dc/terms/requires' => array('requires','requires','is required by'),
@@ -282,19 +293,19 @@ class Labeller {
 
     /**
      * Map a portion of a URI to a short prefix for use when serialising the graph
-     * @param string prefix the namespace prefix to associate with the URI
-     * @param string uri the URI to associate with the prefix
+     * @param string $prefix the namespace prefix to associate with the URI
+     * @param string $uri the URI to associate with the prefix
      */
-    function set_namespace_mapping($prefix, $uri) {
+    public function set_namespace_mapping($prefix, $uri) {
         $this->_ns[$prefix] = $uri;
     }
 
     /**
      * Convert a QName to a URI using registered namespace prefixes
-     * @param string qname the QName to convert
+     * @param string $qname the QName to convert
      * @return string the URI corresponding to the QName if a suitable prefix exists, null otherwise
      */
-    function qname_to_uri($qname) {
+    public function qname_to_uri($qname) {
         if (preg_match("~^(.+):(.+)$~", $qname, $m)) {
             if ( isset($this->_ns[$m[1]])) {
                 return $this->_ns[$m[1]] . $m[2];
@@ -306,10 +317,10 @@ class Labeller {
 
     /**
      * Convert a URI to a QName using registered namespace prefixes
-     * @param string uri the URI to convert
+     * @param string $uri the URI to convert
      * @return string the QName corresponding to the URI if a suitable prefix exists, null otherwise
      */
-    function uri_to_qname($uri) {
+    public function uri_to_qname($uri) {
         if (preg_match('~^(.*[\/\#])([a-z0-9\-\_\:]+)$~i', $uri, $m)) {
             $ns = $m[1];
             $localname = $m[2];
@@ -321,7 +332,11 @@ class Labeller {
         return null;
     }
 
-    function get_prefix($ns) {
+    /**
+     * @param string $ns
+     * @return string
+     */
+    public function get_prefix($ns) {
         $prefix = array_search($ns, $this->_ns);
         if ( $prefix != null && $prefix !== FALSE) {
             return $prefix;
@@ -346,18 +361,30 @@ class Labeller {
 
 
         }
-        return $prefix;
     }
 
-    function add_labelling_property($p)  {
+    /**
+     * @param string $p
+     */
+    public function add_labelling_property($p)  {
         $this->_label_properties[] = $p;
     }
 
-    function get_ns() {
+    /**
+     * @return array
+     */
+    public function get_ns() {
         return $this->_ns;
     }
 
-    function get_label($uri, $g = null, $capitalize = false, $use_qnames = FALSE) {
+    /**
+     * @param string $uri
+     * @param ExtendedGraph|null $g
+     * @param bool $capitalize
+     * @param bool $use_qnames
+     * @return string
+     */
+    public function get_label($uri, $g = null, $capitalize = false, $use_qnames = FALSE) {
         if ($g) {
             $label = $g->get_first_literal($uri,'http://www.w3.org/2004/02/skos/core#prefLabel', '', 'en');
             if ( strlen($label) != 0) return $label;
@@ -443,8 +470,14 @@ class Labeller {
         return $uri;
     }
 
-
-    function get_plural_label($uri, $g = null, $capitalize = false, $use_qnames = FALSE) {
+    /**
+     * @param string $uri
+     * @param ExtendedGraph|null $g
+     * @param bool $capitalize
+     * @param bool $use_qnames
+     * @return string
+     */
+    public function get_plural_label($uri, $g = null, $capitalize = false, $use_qnames = FALSE) {
         if ($g) {
             $label = $g->get_first_literal($uri,'http://purl.org/net/vocab/2004/03/label#plural', '', 'en');
             if ( strlen($label) != 0) return $label;
@@ -478,7 +511,14 @@ class Labeller {
         }
     }
 
-    function get_inverse_label($uri, $g = null, $capitalize = false, $use_qnames = FALSE) {
+    /**
+     * @param string $uri
+     * @param ExtendedGraph|null $g
+     * @param bool $capitalize
+     * @param bool $use_qnames
+     * @return string
+     */
+    public function get_inverse_label($uri, $g = null, $capitalize = false, $use_qnames = FALSE) {
         if ($g) {
             $label = $g->get_first_literal($uri,'http://purl.org/net/vocab/2004/03/label#inverseSingular', '', 'en');
             if ( strlen($label) != 0) return $label;
@@ -509,8 +549,10 @@ class Labeller {
 
     }
 
-
-    function label_graph(&$graph) {
+    /**
+     * @param ExtendedGraph $graph
+     */
+    public function label_graph(ExtendedGraph &$graph) {
         $labelled_properties = array();
         $index = $graph->get_index();
         foreach ($index as $s => $p_list) {

--- a/src/classes/Timer.class.php
+++ b/src/classes/Timer.class.php
@@ -1,4 +1,11 @@
 <?php
+
+namespace Tripod;
+
+/**
+ * Class Timer
+ * @package Tripod
+ */
 class Timer
 {
     /**
@@ -39,18 +46,18 @@ class Timer
 
     /**
      * Calculate difference between start and end time of event and return in milli-seconds.
+     * @throws \Exception
      * @return number time difference in milliseconds between stat and end time of event
-     * @throws Exception, if either of or both  of start or stop method are not called before this method
      */
     public function result()
     {
         if (is_null($this->start_time))
         {
-            throw new Exception('Timer: start method not called !');
+            throw new \Exception('Timer: start method not called !');
         }
         else if (is_null($this->end_time))
         {
-            throw new Exception('Timer: stop method not called !');
+            throw new \Exception('Timer: stop method not called !');
         }
 
         if ($this->result==null)
@@ -68,17 +75,17 @@ class Timer
     /**
      * Calculate difference between start and end time of event and return in micro-seconds.
      * @return number time difference in micro seconds between stat and end time of event
-     * @throws Exception, if either of or both  of start or stop method are not called before this method
+     * @throws \Exception, if either of or both  of start or stop method are not called before this method
      */
     public function microResult()
     {
         if (is_null($this->start_time))
         {
-            throw new Exception('Timer: start method not called !');
+            throw new \Exception('Timer: start method not called !');
         }
         else if (is_null($this->end_time))
         {
-            throw new Exception('Timer: stop method not called !');
+            throw new \Exception('Timer: stop method not called !');
         }
 
         if ($this->micro_result==null)

--- a/src/classes/Timer.class.php
+++ b/src/classes/Timer.class.php
@@ -81,11 +81,11 @@ class Timer
     {
         if (is_null($this->start_time))
         {
-            throw new \Exception('Timer: start method not called !');
+            throw new \Tripod\Exceptions\TimerException('Timer: start method not called !');
         }
         else if (is_null($this->end_time))
         {
-            throw new \Exception('Timer: stop method not called !');
+            throw new \Tripod\Exceptions\TimerException('Timer: stop method not called !');
         }
 
         if ($this->micro_result==null)

--- a/src/classes/Timer.class.php
+++ b/src/classes/Timer.class.php
@@ -47,7 +47,7 @@ class Timer
     /**
      * Calculate difference between start and end time of event and return in milli-seconds.
      * @throws \Exception
-     * @return number time difference in milliseconds between stat and end time of event
+     * @return number time difference in milliseconds between start and end time of event
      */
     public function result()
     {
@@ -74,7 +74,7 @@ class Timer
 
     /**
      * Calculate difference between start and end time of event and return in micro-seconds.
-     * @return number time difference in micro seconds between stat and end time of event
+     * @return number time difference in micro seconds between start and end time of event
      * @throws \Exception, if either of or both  of start or stop method are not called before this method
      */
     public function microResult()

--- a/src/exceptions/CardinalityException.class.php
+++ b/src/exceptions/CardinalityException.class.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tripod\Exceptions;
+
+require_once TRIPOD_DIR . '/exceptions/Exception.class.php';
+
+/**
+ * @codeCoverageIgnore
+ */
+class CardinalityException extends Exception {}

--- a/src/exceptions/ConfigException.class.php
+++ b/src/exceptions/ConfigException.class.php
@@ -1,0 +1,12 @@
+<?php
+
+
+namespace Tripod\Exceptions;
+
+/**
+ * Class ConfigException
+ * @package Tripod
+ */
+class ConfigException extends Exception {
+
+}

--- a/src/exceptions/Exception.class.php
+++ b/src/exceptions/Exception.class.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Tripod\Exceptions;
+
+/**
+ * Class Exception
+ * @package Tripod
+ */
+class Exception extends \Exception {}

--- a/src/exceptions/LabellerException.class.php
+++ b/src/exceptions/LabellerException.class.php
@@ -1,16 +1,27 @@
 <?php
-require_once TRIPOD_DIR . '/exceptions/TripodException.class.php';
+
+namespace Tripod\Exceptions;
+
+require_once TRIPOD_DIR . '/exceptions/Exception.class.php';
 
 /**
  * @codeCoverageIgnore
  */
-class TripodLabellerException extends TripodException {
+class LabellerException extends Exception {
     private $target;
+
+    /**
+     * @param string $target
+     */
     public function __construct($target)
     {
         $this->target = $target;
         parent::__construct("Could not label: $target");
     }
+
+    /**
+     * @return string
+     */
     public function getTarget()
     {
         return $this->target;

--- a/src/exceptions/SearchException.class.php
+++ b/src/exceptions/SearchException.class.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tripod\Exceptions;
+
+// @codeCoverageIgnoreStart
+require_once TRIPOD_DIR . '/exceptions/Exception.class.php';
+
+/**
+ * Class SearchException
+ * @package Tripod
+ */
+class SearchException extends Exception {
+
+} // @codeCoverageIgnoreEnd

--- a/src/exceptions/TimerException.class.php
+++ b/src/exceptions/TimerException.class.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace Tripod\Exceptions;
+
+/**
+ * Class TimerException
+ * @package Tripod\Exceptions
+ */
+class TimerException extends Exception {}

--- a/src/exceptions/TripodCardinalityException.class.php
+++ b/src/exceptions/TripodCardinalityException.class.php
@@ -1,7 +1,0 @@
-<?php
-require_once TRIPOD_DIR . '/exceptions/TripodException.class.php';
-
-/**
- * @codeCoverageIgnore
- */
-class TripodCardinalityException extends TripodException {}

--- a/src/exceptions/TripodException.class.php
+++ b/src/exceptions/TripodException.class.php
@@ -1,2 +1,0 @@
-<?php
-class TripodException extends Exception {}

--- a/src/exceptions/TripodSearchException.class.php
+++ b/src/exceptions/TripodSearchException.class.php
@@ -1,7 +1,0 @@
-<?php
-// @codeCoverageIgnoreStart
-require_once TRIPOD_DIR . '/exceptions/TripodException.class.php';
-
-class TripodSearchException extends TripodException {
-
-} // @codeCoverageIgnoreEnd

--- a/src/exceptions/TripodViewException.class.php
+++ b/src/exceptions/TripodViewException.class.php
@@ -1,7 +1,0 @@
-<?php
-// @codeCoverageIgnoreStart
-require_once TRIPOD_DIR . '/exceptions/TripodException.class.php';
-
-class TripodViewException extends TripodException {
-
-} // @codeCoverageIgnoreEnd

--- a/src/exceptions/ViewException.class.php
+++ b/src/exceptions/ViewException.class.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tripod\Exceptions;
+
+// @codeCoverageIgnoreStart
+require_once TRIPOD_DIR . '/exceptions/Exception.class.php';
+
+/**
+ * Class ViewException
+ * @package Tripod
+ */
+class ViewException extends Exception {
+
+} // @codeCoverageIgnoreEnd

--- a/src/mongo/Config.class.php
+++ b/src/mongo/Config.class.php
@@ -407,7 +407,7 @@ class Config
                                  * checkModifierFunctions will check if each predicate modifier is valid - it will
                                  * check recursively through the predicate
                                  */
-                                $this->checkModifierFunctions($p, Tables::$predicateModifiers);
+                                $this->checkModifierFunctions($p, \Tripod\Mongo\Composites\Tables::$predicateModifiers);
                             }
                         }
                     }
@@ -450,7 +450,7 @@ class Config
                 throw new \Tripod\Exceptions\ConfigException("Table spec can only contain 'computed_fields' at the base level");
             }
 
-            $validComputingFieldFunctions = Tables::$computedFieldFunctions;
+            $validComputingFieldFunctions = \Tripod\Mongo\Composites\Tables::$computedFieldFunctions;
             if($validationLevel == self::VALIDATE_MAX)
             {
                 $availableFields = $this->getFieldNamesInSpec($spec);
@@ -565,7 +565,7 @@ class Config
         }
 
         $this->validateSpecVariableReplacement($spec['if'][0], $availableFields);
-        if(isset($spec['if'][1]) && !in_array($spec['if'][1], Tables::$conditionalOperators))
+        if(isset($spec['if'][1]) && !in_array($spec['if'][1], \Tripod\Mongo\Composites\Tables::$conditionalOperators))
         {
             throw new \Tripod\Exceptions\ConfigException("Invalid conditional operator '" . $spec['if'][1] . "' in conditional spec");
         }
@@ -583,7 +583,7 @@ class Config
             }
             elseif(is_array($spec['then']))
             {
-                $functions = array_intersect_key(array_keys($spec['then']), Tables::$computedFieldFunctions);
+                $functions = array_intersect_key(array_keys($spec['then']), \Tripod\Mongo\Composites\Tables::$computedFieldFunctions);
                 switch(count($functions))
                 {
                     case 0;
@@ -605,7 +605,7 @@ class Config
             }
             elseif(is_array($spec['else']))
             {
-                $functions = array_intersect_key(array_keys($spec['else']), Tables::$computedFieldFunctions);
+                $functions = array_intersect_key(array_keys($spec['else']), \Tripod\Mongo\Composites\Tables::$computedFieldFunctions);
                 switch(count($functions))
                 {
                     case 0;
@@ -684,7 +684,7 @@ class Config
         }
         if(is_array($spec[0]))
         {
-            if(count(array_keys($spec[0])) === 1 && count(array_intersect(array_keys($spec[0]), Tables::$computedFieldFunctions)) ===1)
+            if(count(array_keys($spec[0])) === 1 && count(array_intersect(array_keys($spec[0]), \Tripod\Mongo\Composites\Tables::$computedFieldFunctions)) ===1)
             {
                 $function = array_keys($spec[0]);
                 $this->validateComputedFieldSpec($function[0], $spec[0], $availableFields);
@@ -700,7 +700,7 @@ class Config
         }
         if(is_array($spec[2]))
         {
-            if(count(array_keys($spec[2])) === 1 && count(array_intersect(array_keys($spec[2]), Tables::$computedFieldFunctions)) ===1)
+            if(count(array_keys($spec[2])) === 1 && count(array_intersect(array_keys($spec[2]), \Tripod\Mongo\Composites\Tables::$computedFieldFunctions)) ===1)
             {
                 $function = array_keys($spec[2]);
                 $this->validateComputedFieldSpec($function[0], $spec[2], $availableFields);
@@ -714,7 +714,7 @@ class Config
         {
             $this->validateSpecVariableReplacement($spec[2], $availableFields);
         }
-        if(!in_array($spec[1], Tables::$arithmeticOperators))
+        if(!in_array($spec[1], \Tripod\Mongo\Composites\Tables::$arithmeticOperators))
         {
             throw new \Tripod\Exceptions\ConfigException("Invalid arithmetic operator '" . $spec[1] . "' in computed arithmetic spec");
         }
@@ -1014,16 +1014,16 @@ class Config
             {
                 // Check config
                 // Valid configs can be top level modifiers and their attributes inside - you can have a top level modifier
-                //      inside a top level modifier - that's why we also check TripodTables::$predicatesModifiers direct
-                if(!array_key_exists($k, $parent) && !array_key_exists($k, Tables::$predicateModifiers))
+                // inside a top level modifier - that's why we also check \Tripod\Mongo\Composites\Tables::$predicatesModifiers direct
+                if(!array_key_exists($k, $parent) && !array_key_exists($k, \Tripod\Mongo\Composites\Tables::$predicateModifiers))
                 {
                     throw new \Tripod\Exceptions\ConfigException("Invalid modifier: '".$k."' in key '".$parentKey."'");
                 }
 
                 // If this config value is a top level modifier, use that as the parent so that we can check the attributes
-                if(array_key_exists($k, Tables::$predicateModifiers))
+                if(array_key_exists($k, \Tripod\Mongo\Composites\Tables::$predicateModifiers))
                 {
-                    $this->checkModifierFunctions($v, Tables::$predicateModifiers[$k], $k);
+                    $this->checkModifierFunctions($v, \Tripod\Mongo\Composites\Tables::$predicateModifiers[$k], $k);
                 } else
                 {
                     $this->checkModifierFunctions($v, $parent[$k], $k);
@@ -1053,6 +1053,7 @@ class Config
         {
             return self::$config;
         }
+        return null;
     }
 
     /**

--- a/src/mongo/Driver.class.php
+++ b/src/mongo/Driver.class.php
@@ -10,7 +10,7 @@ $TOTAL_TIME=0;
  * Class Driver
  * @package Driver\Mongo
  */
-class Driver extends DriverBase implements \Tripod\ITripod
+class Driver extends DriverBase implements \Tripod\IDriver
 {
 
     /**

--- a/src/mongo/Driver.class.php
+++ b/src/mongo/Driver.class.php
@@ -7,24 +7,24 @@ namespace Tripod\Mongo;
 $TOTAL_TIME=0;
 
 /**
- * Class Tripod
- * @package Tripod\Mongo
+ * Class Driver
+ * @package Driver\Mongo
  */
-class Tripod extends TripodBase implements \Tripod\ITripod
+class Driver extends DriverBase implements \Tripod\ITripod
 {
 
     /**
-     * @var Views
+     * @var \Tripod\Mongo\Composites\Views
      */
     private $tripod_views = null;
 
     /**
-     * @var Tables
+     * @var \Tripod\Mongo\Composites\Tables
      */
     private $tripod_tables = null;
 
     /**
-     * @var SearchIndexer
+     * @var \Tripod\Mongo\Composites\SearchIndexer
      */
     private $search_indexer = null;
 
@@ -57,14 +57,14 @@ class Tripod extends TripodBase implements \Tripod\ITripod
     private $dataUpdater;
 
     /**
-     * Constructor for Tripod
+     * Constructor for Driver
      *
      * @param string $podName
      * @param string $storeName
      * @param array $opts an Array of options: <ul>
      * <li>defaultContext: (string) to use where a specific default context is not defined. Default is Null</li>
      * <li>async: (array) determines the async behaviour of views, tables and search. For each of these array keys, if set to true, generation of these elements will be done asyncronously on save. Default is array(OP_VIEWS=>false,OP_TABLES=>true,OP_SEARCH=>true)</li>
-     * <li>stat: this sets the stats object to use to record statistics around operations performed by Tripod. Default is null</li>
+     * <li>stat: this sets the stats object to use to record statistics around operations performed by Driver. Default is null</li>
      * <li>readPreference: The Read preference to set for Mongo: Default is Mongo:RP_PRIMARY_PREFERRED</li>
      * <li>retriesToGetLock: Retries to do when unable to get lock on a document, default is 20</li></ul>
      */
@@ -533,13 +533,13 @@ class Tripod extends TripodBase implements \Tripod\ITripod
     }
 
     /**
-     * @return Views
+     * @return \Tripod\Mongo\Composites\Views
      */
     public function getTripodViews()
     {
         if($this->tripod_views==null)
         {
-            $this->tripod_views = new Views(
+            $this->tripod_views = new \Tripod\Mongo\Composites\Views(
                 $this->storeName,
                 $this->collection,
                 $this->defaultContext,
@@ -550,13 +550,13 @@ class Tripod extends TripodBase implements \Tripod\ITripod
     }
 
     /**
-     * @return Tables
+     * @return \Tripod\Mongo\Composites\Tables
      */
     public function getTripodTables()
     {
         if ($this->tripod_tables==null)
         {
-            $this->tripod_tables = new Tables(
+            $this->tripod_tables = new \Tripod\Mongo\Composites\Tables(
                 $this->storeName,
                 $this->collection,
                 $this->defaultContext,
@@ -567,13 +567,13 @@ class Tripod extends TripodBase implements \Tripod\ITripod
     }
 
     /**
-     * @return SearchIndexer
+     * @return \Tripod\Mongo\Composites\SearchIndexer
      */
     public function getSearchIndexer()
     {
         if ($this->search_indexer==null)
         {
-            $this->search_indexer = new SearchIndexer($this);
+            $this->search_indexer = new \Tripod\Mongo\Composites\SearchIndexer($this);
         }
         return $this->search_indexer;
     }

--- a/src/mongo/IComposite.php
+++ b/src/mongo/IComposite.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Tripod\Mongo;
+namespace Tripod\Mongo\Composites;
 
 /**
  * Class IComposite
- * @package Tripod\Mongo
+ * @package Tripod\Mongo\Composites
  */
 interface IComposite
 {
@@ -24,8 +24,8 @@ interface IComposite
 
     /**
      * Invalidate/regenerate the composite based on the impacted subject
-     * @param ImpactedSubject $subject
+     * @param \Tripod\Mongo\ImpactedSubject $subject
      * @return void
      */
-    public function update(ImpactedSubject $subject);
+    public function update(\Tripod\Mongo\ImpactedSubject $subject);
 }

--- a/src/mongo/IComposite.php
+++ b/src/mongo/IComposite.php
@@ -1,4 +1,11 @@
 <?php
+
+namespace Tripod\Mongo;
+
+/**
+ * Class IComposite
+ * @package Tripod\Mongo
+ */
 interface IComposite
 {
     /**

--- a/src/mongo/ImpactedSubject.class.php
+++ b/src/mongo/ImpactedSubject.class.php
@@ -132,10 +132,10 @@ class ImpactedSubject
 
     /**
      * For mocking
-     * @return Tripod
+     * @return Driver
      */
     protected function getTripod()
     {
-        return new Tripod($this->getPodName(),$this->getStoreName(),array("readPreference"=>\MongoClient::RP_PRIMARY));
+        return new Driver($this->getPodName(),$this->getStoreName(),array("readPreference"=>\MongoClient::RP_PRIMARY));
     }
 }

--- a/src/mongo/ImpactedSubject.class.php
+++ b/src/mongo/ImpactedSubject.class.php
@@ -58,7 +58,7 @@ class ImpactedSubject
         }
         else
         {
-            throw new \Exception("Invalid operation: $operation");
+            throw new \Tripod\Exceptions\Exception("Invalid operation: $operation");
         }
 
         $this->storeName = $storeName;

--- a/src/mongo/ImpactedSubject.class.php
+++ b/src/mongo/ImpactedSubject.class.php
@@ -1,5 +1,6 @@
 <?php
 
+namespace Tripod\Mongo;
 /**
  * A subject that has been involved in an modification event (create/update, delete) and will therefore require
  * view, table and search doc generation
@@ -37,14 +38,14 @@ class ImpactedSubject
      * @param string $storeName
      * @param string $podName
      * @param array $specTypes
-     * @throws TripodException
-     * @throws Exception
+     * @throws \Tripod\Exceptions\Exception
+     * @throws \Exception
      */
     public function __construct(Array $resourceId, $operation, $storeName, $podName, Array $specTypes=array())
     {
         if (!is_array($resourceId) || !array_key_exists(_ID_RESOURCE,$resourceId) || !array_key_exists(_ID_CONTEXT,$resourceId))
         {
-            throw new TripodException('Parameter $resourceId needs to be of type array with ' . _ID_RESOURCE . ' and ' . _ID_CONTEXT . ' keys');
+            throw new \Tripod\Exceptions\Exception('Parameter $resourceId needs to be of type array with ' . _ID_RESOURCE . ' and ' . _ID_CONTEXT . ' keys');
         }
         else
         {
@@ -57,7 +58,7 @@ class ImpactedSubject
         }
         else
         {
-            throw new Exception("Invalid operation: $operation");
+            throw new \Exception("Invalid operation: $operation");
         }
 
         $this->storeName = $storeName;
@@ -131,10 +132,10 @@ class ImpactedSubject
 
     /**
      * For mocking
-     * @return MongoTripod
+     * @return Tripod
      */
     protected function getTripod()
     {
-        return new MongoTripod($this->getPodName(),$this->getStoreName(),array("readPreference"=>MongoClient::RP_PRIMARY));
+        return new Tripod($this->getPodName(),$this->getStoreName(),array("readPreference"=>\MongoClient::RP_PRIMARY));
     }
 }

--- a/src/mongo/Labeller.class.php
+++ b/src/mongo/Labeller.class.php
@@ -1,10 +1,20 @@
 <?php
+
+namespace Tripod\Mongo;
+
 /** @noinspection PhpIncludeInspection */
 require_once TRIPOD_DIR.'classes/Labeller.class.php';
-require_once TRIPOD_DIR.'exceptions/TripodLabellerException.class.php';
+require_once TRIPOD_DIR . 'exceptions/LabellerException.class.php';
 
-class MongoTripodLabeller extends Labeller {
+/**
+ * Class Labeller
+ * @package Tripod\Mongo
+ */
+class Labeller extends \Tripod\Labeller {
 
+    /**
+     * Constructor
+     */
     function __construct()
     {
         // only default minimal ns - make app define the rest
@@ -14,7 +24,7 @@ class MongoTripodLabeller extends Labeller {
             'owl' => 'http://www.w3.org/2002/07/owl#',
             'cs' => 'http://purl.org/vocab/changeset/schema#',
         );
-        $config = MongoTripodConfig::getInstance();
+        $config = Config::getInstance();
         $ns = $config->getNamespaces();
         foreach ($ns as $prefix=>$uri)
         {
@@ -32,7 +42,7 @@ class MongoTripodLabeller extends Labeller {
         {
             $retVal = $this->uri_to_qname($uri);
         }
-        catch (TripodLabellerException $e) {}
+        catch (\Tripod\Exceptions\LabellerException $e) {}
         return (empty($retVal)) ? $uri : $retVal;
     }
 
@@ -46,27 +56,37 @@ class MongoTripodLabeller extends Labeller {
         {
             $retVal = $this->qname_to_uri($qname);
         }
-        catch (TripodLabellerException $e) {}
+        catch (\Tripod\Exceptions\LabellerException $e) {}
         return (empty($retVal)) ? $qname : $retVal;
     }
 
+    /**
+     * @param string $qName
+     * @return string
+     * @throws \Tripod\Exceptions\LabellerException
+     */
     public function qname_to_uri($qName)
     {
         $retVal = parent::qname_to_uri($qName);
-        if (empty($retVal)) throw new TripodLabellerException($qName);
+        if (empty($retVal)) throw new \Tripod\Exceptions\LabellerException($qName);
         return $retVal;
     }
 
 
     // overrides the default behaviour of trying to return a ns even if the prefix is not registered - instead, throw exception
-    function get_prefix($ns) {
+    /**
+     * @param string $ns
+     * @return string
+     * @throws \Tripod\Exceptions\LabellerException
+     */
+    public function get_prefix($ns) {
         $prefix = array_search($ns, $this->_ns);
         if ( $prefix != null && $prefix !== FALSE) {
             return $prefix;
         }
         else
         {
-            throw new TripodLabellerException($ns);
+            throw new \Tripod\Exceptions\LabellerException($ns);
         }
     }
 }

--- a/src/mongo/MongoGraph.class.php
+++ b/src/mongo/MongoGraph.class.php
@@ -1,15 +1,24 @@
 <?php
+
+namespace Tripod\Mongo;
+
 require_once TRIPOD_DIR.'classes/ExtendedGraph.class.php';
 require_once TRIPOD_DIR.'mongo/MongoTripodConstants.php';
-require_once TRIPOD_DIR.'mongo/MongoTripodConfig.class.php';
-require_once TRIPOD_DIR.'mongo/MongoTripodLabeller.class.php';
-require_once TRIPOD_DIR . 'mongo/serializers/MongoTripodNQuadSerializer.class.php';
+require_once TRIPOD_DIR . 'mongo/Config.class.php';
+require_once TRIPOD_DIR . 'mongo/Labeller.class.php';
+require_once TRIPOD_DIR . 'mongo/serializers/NQuadSerializer.class.php';
 
-class MongoGraph extends ExtendedGraph {
-
+/**
+ * Class MongoGraph
+ * @package Tripod\Mongo
+ */
+class MongoGraph extends \Tripod\ExtendedGraph {
+    /**
+     * Constructor
+     */
     function __construct()
     {
-        $this->_labeller = new MongoTripodLabeller();
+        $this->_labeller = new Labeller();
     }
 
     /**
@@ -17,15 +26,15 @@ class MongoGraph extends ExtendedGraph {
      *  <s> <p> <o> <context> .
      * @param string $context the context for the graph your are serializing
      * @return string the nquad serialization of the graph
-     * @throws InvalidArgumentException if you do not specify a context
+     * @throws \InvalidArgumentException if you do not specify a context
      */
     function to_nquads($context)
     {
         if(empty($context)) {
-            throw new InvalidArgumentException("You must specify the context when serializing to nquads");
+            throw new \InvalidArgumentException("You must specify the context when serializing to nquads");
         }
 
-        $serializer = new MongoTripodNQuadSerializer();
+        $serializer = new NQuadSerializer();
         return $serializer->getSerializedIndex($this->_index, $this->_labeller->qname_to_alias($context));
     }
 
@@ -33,13 +42,13 @@ class MongoGraph extends ExtendedGraph {
      * Adds the tripod array(s) to this graph.
      * This method is used to add individual tripod documents, or a series of tripod array documents that are embedded in a view.
      * @param $tarray
-     * @throws TripodException
+     * @throws \Tripod\Exceptions\Exception
      */
     function add_tripod_array($tarray)
     {
         if (!is_array($tarray))
         {
-            throw new TripodException("Value passed to add_tripod_array is not of type array");
+            throw new \Tripod\Exceptions\Exception("Value passed to add_tripod_array is not of type array");
         }
         // need to convert from tripod storage format to rdf/json as php array format
         if (isset($tarray["value"][_GRAPHS]))
@@ -107,7 +116,10 @@ class MongoGraph extends ExtendedGraph {
         }
         return $doc;
     }
-    
+
+    /**
+     * @param array $tarray
+     */
     private function add_tarray_to_index($tarray)
     {
         $_i = array();
@@ -125,8 +137,8 @@ class MongoGraph extends ExtendedGraph {
     }
 
     /**
-     * Convert from MongoTripod value object format (comapct) to ExtendedGraph format (verbose)
-     * @param $mongoValueObject
+     * Convert from Tripod value object format (comapct) to ExtendedGraph format (verbose)
+     * @param array $mongoValueObject
      * @return array
      */
     private function toGraphValueObject($mongoValueObject)
@@ -163,8 +175,8 @@ class MongoGraph extends ExtendedGraph {
     }
 
     /**
-     * Convert from ExtendedGraph value object format (verbose) to MongoTripod format (compact)
-     * @param $simpleGraphValueObject
+     * Convert from ExtendedGraph value object format (verbose) to Tripod format (compact)
+     * @param array $simpleGraphValueObject
      * @return array
      */
     private function toMongoTripodValueObject($simpleGraphValueObject)
@@ -175,6 +187,11 @@ class MongoGraph extends ExtendedGraph {
             ($simpleGraphValueObject['type']=="literal") ? $simpleGraphValueObject['value'] : $this->_labeller->uri_to_alias($simpleGraphValueObject['value']));
     }
 
+    /**
+     * @param \Tripod\ExtendedGraph|null $graph
+     * @param string $contextAlias
+     * @return array|null
+     */
     private function index_to_tarray($graph=null,$contextAlias)
     {
         if ($graph==null) $graph = $this;

--- a/src/mongo/MongoTripodConstants.php
+++ b/src/mongo/MongoTripodConstants.php
@@ -13,7 +13,7 @@ define("SEARCH_PROVIDER_MONGO", 'MongoSearchProvider');
 define("SEARCH_PROVIDER_ELASTIC_SEARCH", 'es');
 
 
-// MongoTripod document properties
+// Tripod document properties
 define('_ID_KEY', '_id');
 define('_ID_RESOURCE','r');
 define('_ID_CONTEXT','c');
@@ -29,7 +29,7 @@ define('VALUE_LITERAL','l');
 define('_UPDATED_TS', '_uts');
 define('_CREATED_TS', '_cts');
 
-// operations that MongoTripod performs
+// operations that Tripod performs
 define('OP_VIEWS','generate_views');
 define('OP_TABLES','generate_table_rows');
 define('OP_SEARCH','generate_search_index_docs');

--- a/src/mongo/MongoTripodConstants.php
+++ b/src/mongo/MongoTripodConstants.php
@@ -9,7 +9,7 @@ define('AUDIT_MANUAL_ROLLBACKS_COLLECTION','audit_manual_rollbacks');
 
 // search
 define('SEARCH_INDEX_COLLECTION', 'search');
-define("SEARCH_PROVIDER_MONGO", 'MongoSearchProvider');
+define("SEARCH_PROVIDER_MONGO", '\Tripod\Mongo\MongoSearchProvider');
 define("SEARCH_PROVIDER_ELASTIC_SEARCH", 'es');
 
 

--- a/src/mongo/Tripod.class.php
+++ b/src/mongo/Tripod.class.php
@@ -291,7 +291,7 @@ class Tripod extends TripodBase implements \Tripod\ITripod
         if(class_exists($provider)){
             $timer = new \Tripod\Timer();
             $timer->start();
-            /** @var $searchProvider \Tripod\ITripodSearchProvider */
+            /** @var $searchProvider \Tripod\ISearchProvider */
             $searchProvider = new $provider($this);
             $results =  $searchProvider->search($q, $type, $indices, $fields, $limit, $offset);
             $timer->stop();

--- a/src/mongo/base/CompositeBase.class.php
+++ b/src/mongo/base/CompositeBase.class.php
@@ -1,12 +1,12 @@
 <?php
+
+namespace Tripod\Mongo;
+
 /**
- * Created by JetBrains PhpStorm.
- * User: chris
- * Date: 24/04/2015
- * Time: 15:05
- * To change this template use File | Settings | File Templates.
+ * Class CompositeBase
+ * @package Tripod\Mongo
  */
-abstract class CompositeBase extends MongoTripodBase implements IComposite
+abstract class CompositeBase extends TripodBase implements IComposite
 {
     /**
      * Returns an array of ImpactedSubjects based on the subjects and predicates of change
@@ -154,18 +154,18 @@ abstract class CompositeBase extends MongoTripodBase implements IComposite
         {
             $types[] = $this->labeller->qname_to_uri($rdfType);
         }
-        catch(TripodLabellerException $e) {}
+        catch(\Tripod\Exceptions\LabellerException $e) {}
         try
         {
             $types[] = $this->labeller->uri_to_alias($rdfType);
         }
-        catch(TripodLabellerException $e) {}
+        catch(\Tripod\Exceptions\LabellerException $e) {}
 
         $intersectingTypes = array_unique(array_intersect($types, $validTypes));
         if(!empty($intersectingTypes))
         {
             // Views should always invalidate
-            if($this instanceof MongoTripodViews)
+            if($this instanceof Views)
             {
                 return true;
             }

--- a/src/mongo/base/CompositeBase.class.php
+++ b/src/mongo/base/CompositeBase.class.php
@@ -1,18 +1,18 @@
 <?php
 
-namespace Tripod\Mongo;
+namespace Tripod\Mongo\Composites;
 
 /**
  * Class CompositeBase
- * @package Tripod\Mongo
+ * @package Tripod\Mongo\Composites
  */
-abstract class CompositeBase extends TripodBase implements IComposite
+abstract class CompositeBase extends \Tripod\Mongo\DriverBase implements \Tripod\Mongo\IComposite
 {
     /**
      * Returns an array of ImpactedSubjects based on the subjects and predicates of change
      * @param array $subjectsAndPredicatesOfChange
      * @param string $contextAlias
-     * @return ImpactedSubject[]
+     * @return \Tripod\Mongo\ImpactedSubject[]
      */
     public function getImpactedSubjects(Array $subjectsAndPredicatesOfChange,$contextAlias)
     {
@@ -111,7 +111,7 @@ abstract class CompositeBase extends TripodBase implements IComposite
             foreach($candidates[$podName] as $candidate)
             {
                 $specTypes = (isset($candidate['specTypes']) ? $candidate['specTypes'] : array());
-                $impactedSubjects[] = new ImpactedSubject($candidate['id'], $this->getOperationType(), $this->getStoreName(), $podName, $specTypes);
+                $impactedSubjects[] = new \Tripod\Mongo\ImpactedSubject($candidate['id'], $this->getOperationType(), $this->getStoreName(), $podName, $specTypes);
             }
         }
         return $impactedSubjects;
@@ -165,7 +165,7 @@ abstract class CompositeBase extends TripodBase implements IComposite
         if(!empty($intersectingTypes))
         {
             // Views should always invalidate
-            if($this instanceof Views)
+            if($this instanceof \Tripod\Mongo\Views)
             {
                 return true;
             }

--- a/src/mongo/base/CompositeBase.class.php
+++ b/src/mongo/base/CompositeBase.class.php
@@ -6,7 +6,7 @@ namespace Tripod\Mongo\Composites;
  * Class CompositeBase
  * @package Tripod\Mongo\Composites
  */
-abstract class CompositeBase extends \Tripod\Mongo\DriverBase implements \Tripod\Mongo\IComposite
+abstract class CompositeBase extends \Tripod\Mongo\DriverBase implements \Tripod\Mongo\Composites\IComposite
 {
     /**
      * Returns an array of ImpactedSubjects based on the subjects and predicates of change

--- a/src/mongo/base/DriverBase.class.php
+++ b/src/mongo/base/DriverBase.class.php
@@ -9,10 +9,10 @@ $TOTAL_TIME=0;
 use Monolog\Logger;
 
 /**
- * Class TripodBase
+ * Class DriverBase
  * @package Tripod\Mongo
  */
-abstract class TripodBase
+abstract class DriverBase
 {
     /**
      * @var \MongoCollection

--- a/src/mongo/base/JobBase.class.php
+++ b/src/mongo/base/JobBase.class.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Tripod\Mongo;
+namespace Tripod\Mongo\Jobs;
 /**
  * Todo: How to inject correct stat class... :-S
  */
-abstract class JobBase extends TripodBase
+abstract class JobBase extends \Tripod\Mongo\DriverBase
 {
     private $tripod;
 
@@ -12,11 +12,11 @@ abstract class JobBase extends TripodBase
      * For mocking
      * @param string $storeName
      * @param string $podName
-     * @return Tripod
+     * @return \Tripod\Mongo\Driver
      */
     protected function getTripod($storeName,$podName) {
         if ($this->tripod == null) {
-            $this->tripod = new Tripod(
+            $this->tripod = new \Tripod\Mongo\Driver(
                 $podName,
                 $storeName,
                 array(

--- a/src/mongo/base/JobBase.class.php
+++ b/src/mongo/base/JobBase.class.php
@@ -6,7 +6,7 @@ namespace Tripod\Mongo;
  */
 abstract class JobBase extends TripodBase
 {
-    private $mongoTripod;
+    private $tripod;
 
     /**
      * For mocking
@@ -14,9 +14,9 @@ abstract class JobBase extends TripodBase
      * @param string $podName
      * @return Tripod
      */
-    protected function getMongoTripod($storeName,$podName) {
-        if ($this->mongoTripod == null) {
-            $this->mongoTripod = new Tripod(
+    protected function getTripod($storeName,$podName) {
+        if ($this->tripod == null) {
+            $this->tripod = new Tripod(
                 $podName,
                 $storeName,
                 array(
@@ -25,7 +25,7 @@ abstract class JobBase extends TripodBase
                 )
             );
         }
-        return $this->mongoTripod;
+        return $this->tripod;
     }
 
     /**

--- a/src/mongo/base/JobBase.class.php
+++ b/src/mongo/base/JobBase.class.php
@@ -1,9 +1,10 @@
 <?php
 
+namespace Tripod\Mongo;
 /**
  * Todo: How to inject correct stat class... :-S
  */
-abstract class JobBase extends MongoTripodBase
+abstract class JobBase extends TripodBase
 {
     private $mongoTripod;
 
@@ -11,16 +12,16 @@ abstract class JobBase extends MongoTripodBase
      * For mocking
      * @param string $storeName
      * @param string $podName
-     * @return MongoTripod
+     * @return Tripod
      */
     protected function getMongoTripod($storeName,$podName) {
         if ($this->mongoTripod == null) {
-            $this->mongoTripod = new MongoTripod(
+            $this->mongoTripod = new Tripod(
                 $podName,
                 $storeName,
                 array(
                     'stat'=>$this->getStat(),
-                    'readPreference'=>MongoClient::RP_PRIMARY // important: make sure we always read from the primary
+                    'readPreference'=>\MongoClient::RP_PRIMARY // important: make sure we always read from the primary
                 )
             );
         }
@@ -35,7 +36,7 @@ abstract class JobBase extends MongoTripodBase
 
     /**
      * Validate the arguments for this job
-     * @throws Exception
+     * @throws \Exception
      */
     protected function validateArgs()
     {
@@ -45,7 +46,7 @@ abstract class JobBase extends MongoTripodBase
             {
                 $message = "Argument $arg was not present in supplied job args for job ".get_class($this);
                 $this->errorLog($message);
-                throw new Exception($message);
+                throw new \Exception($message);
             }
         }
     }
@@ -76,7 +77,7 @@ abstract class JobBase extends MongoTripodBase
      */
     protected function submitJob($queueName, $class, Array $data)
     {
-        Resque::enqueue($queueName, $class, $data);
+        \Resque::enqueue($queueName, $class, $data);
     }
 }
 

--- a/src/mongo/base/TripodBase.class.php
+++ b/src/mongo/base/TripodBase.class.php
@@ -1,15 +1,21 @@
 <?php
 
+namespace Tripod\Mongo;
+
 require_once TRIPOD_DIR.'ITripodStat.php';
 
 $TOTAL_TIME=0;
 
 use Monolog\Logger;
 
-abstract class MongoTripodBase
+/**
+ * Class TripodBase
+ * @package Tripod\Mongo
+ */
+abstract class TripodBase
 {
     /**
-     * @var MongoCollection
+     * @var \MongoCollection
      */
     protected $collection;
 
@@ -29,12 +35,12 @@ abstract class MongoTripodBase
     protected $defaultContext;
 
     /**
-     * @var iTripodStat
+     * @var \Tripod\iTripodStat
      */
     protected $stat = null;
 
     /**
-     * @var MongoDB
+     * @var \MongoDB
      */
     protected $db = null;
 
@@ -44,7 +50,7 @@ abstract class MongoTripodBase
     protected $readPreference;
 
     /**
-     * @return ITripodStat
+     * @return \Tripod\ITripodStat
      */
     public function getStat()
     {
@@ -52,30 +58,38 @@ abstract class MongoTripodBase
     }
 
     /**
-     * @var MongoTripodLabeller
+     * @var Labeller
      */
     protected $labeller;
 
     /**
-     * @var MongoTripodConfig
+     * @var Config
      */
     protected $config = null;
 
+    /**
+     * @param int $secs
+     * @return int
+     */
     protected function getExpirySecFromNow($secs)
     {
         return (time()+$secs);
     }
 
+    /**
+     * @param string|null $context
+     * @return mixed
+     */
     protected function getContextAlias($context=null)
     {
         $contextAlias = $this->labeller->uri_to_alias((empty($context)) ? $this->defaultContext : $context);
-        return (empty($contextAlias)) ? MongoTripodConfig::getInstance()->getDefaultContextAlias() : $contextAlias;
+        return (empty($contextAlias)) ? Config::getInstance()->getDefaultContextAlias() : $contextAlias;
     }
 
     /**
-     * @param $query
-     * @param $type
-     * @param MongoCollection|null $collection
+     * @param array $query
+     * @param string $type
+     * @param \MongoCollection|null $collection
      * @param array $includeProperties
      * @param int $cursorSize
      * @return MongoGraph
@@ -84,7 +98,7 @@ abstract class MongoTripodBase
     {
         $graph = new MongoGraph();
 
-        $t = new Timer();
+        $t = new \Tripod\Timer();
         $t->start();
 
         if ($collection==null)
@@ -120,7 +134,7 @@ abstract class MongoTripodBase
             if ($type==MONGO_VIEW && array_key_exists(_EXPIRES,$result['value']))
             {
                 // if expires < current date, regenerate view..
-                $currentDate = new MongoDate();
+                $currentDate = new \MongoDate();
                 if ($result['value'][_EXPIRES]<$currentDate)
                 {
                     // regenerate!
@@ -157,11 +171,17 @@ abstract class MongoTripodBase
         return $graph;
     }
 
+    /**
+     * @return string
+     */
     public function getStoreName()
     {
         return $this->storeName;
     }
 
+    /**
+     * @return string
+     */
     public function getPodName()
     {
         return $this->podName;
@@ -171,39 +191,60 @@ abstract class MongoTripodBase
 
     // @codeCoverageIgnoreStart
 
-    public function timingLog($type, $params)
+    /**
+     * @param string $type
+     * @param array|null $params
+     */
+    public function timingLog($type, $params=null)
     {
-        $this->log(Psr\Log\LogLevel::INFO,$type,$params); // todo: timing log is a bit weird. Should it infact go in a different channel? Is it just debug?
+        $this->log(\Psr\Log\LogLevel::INFO,$type,$params); // todo: timing log is a bit weird. Should it infact go in a different channel? Is it just debug?
     }
 
+    /**
+     * @param string $message
+     * @param array|null $params
+     */
     public function debugLog($message, $params=null)
     {
-        $this->log(Psr\Log\LogLevel::DEBUG,$message,$params);
+        $this->log(\Psr\Log\LogLevel::DEBUG,$message,$params);
     }
 
+    /**
+     * @param string $message
+     * @param array|null $params
+     */
     public function errorLog($message, $params=null)
     {
-        $this->log(Psr\Log\LogLevel::ERROR,$message,$params);
+        $this->log(\Psr\Log\LogLevel::ERROR,$message,$params);
     }
 
+    /**
+     * @param string $message
+     * @param array|null $params
+     */
     public function warningLog($message, $params=null)
     {
-        $this->log(Psr\Log\LogLevel::WARNING,$message,$params);
+        $this->log(\Psr\Log\LogLevel::WARNING,$message,$params);
     }
 
+    /**
+     * @param string $level
+     * @param string $message
+     * @param array|null $params
+     */
     private function log($level, $message,$params)
     {
         ($params==null) ? self::getLogger()->log($level, $message) : self::getLogger()->log($level, $message, $params);
     }
 
     /**
-     * @var Psr\Log\LoggerInterface
+     * @var \Psr\Log\LoggerInterface
      */
     public static $logger;
 
     /**
      * @static
-     * @return Psr\Log\LoggerInterface;
+     * @return \Psr\Log\LoggerInterface;
      */
     public static function getLogger()
     {
@@ -219,8 +260,8 @@ abstract class MongoTripodBase
 
     /**
      * Expands an RDF sequence into proper tripod join clauses
-     * @param $joins
-     * @param $source
+     * @param array $joins
+     * @param array $source
      */
     protected function expandSequence(&$joins, $source)
     {
@@ -251,7 +292,7 @@ abstract class MongoTripodBase
      *
      * @param array $id
      * @param array &$target
-     * @throws InvalidArgumentException
+     * @throws \InvalidArgumentException
      */
     protected function addIdToImpactIndex(array $id, &$target)
     {
@@ -274,7 +315,7 @@ abstract class MongoTripodBase
             {
                 if(!isset($i[_ID_RESOURCE]))
                 {
-                    throw new InvalidArgumentException("Invalid id format");
+                    throw new \InvalidArgumentException("Invalid id format");
                 }
                 $this->addIdToImpactIndex($i, $target);
             }
@@ -283,15 +324,15 @@ abstract class MongoTripodBase
 
     /**
      * For mocking
-     * @return MongoTripodConfig
+     * @return Config
      */
-    protected function getMongoTripodConfigInstance()
+    protected function getConfigInstance()
     {
-        return MongoTripodConfig::getInstance();
+        return Config::getInstance();
     }
 
     /**
-     * @return MongoDB
+     * @return\MongoDB
      */
     protected function getDatabase()
     {
@@ -307,7 +348,7 @@ abstract class MongoTripodBase
     }
 
     /**
-     * @return MongoCollection
+     * @return \MongoCollection
      */
     protected function getCollection()
     {
@@ -321,18 +362,37 @@ abstract class MongoTripodBase
 
 }
 
-final class NoStat implements ITripodStat
+/**
+ * Class NoStat
+ * @package Tripod\Mongo
+ */
+final class NoStat implements \Tripod\ITripodStat
 {
+    /**
+     * @var self
+     */
     public static $instance = null;
+
+    /**
+     * @param string $operation
+     */
     public function increment($operation)
     {
         // do nothing
     }
+
+    /**
+     * @param string $operation
+     * @param number $duration
+     */
     public function timer($operation, $duration)
     {
         // do nothing
     }
 
+    /**
+     * @return self
+     */
     public static function getInstance()
     {
         if (self::$instance == null)

--- a/src/mongo/delegates/SearchDocuments.class.php
+++ b/src/mongo/delegates/SearchDocuments.class.php
@@ -13,11 +13,10 @@ class SearchDocuments extends TripodBase
      * Tripod and should inherit connections set up there
      * @param string $storeName
      * @param \MongoCollection $collection
-     * @param $defaultContext
-     * @param null $stat
-     * @internal param \MongoDB $db
+     * @param string $defaultContext
+     * @param \Tripod\ITripodStat|null $stat
      */
-    function __construct($storeName, \MongoCollection $collection, $defaultContext, $stat=null)
+    public function __construct($storeName, \MongoCollection $collection, $defaultContext, $stat=null)
     {
         $this->labeller = new Labeller();
         $this->storeName = $storeName;

--- a/src/mongo/delegates/SearchDocuments.class.php
+++ b/src/mongo/delegates/SearchDocuments.class.php
@@ -6,7 +6,7 @@ namespace Tripod\Mongo;
  * Class SearchDocuments
  * @package Tripod\Mongo
  */
-class SearchDocuments extends TripodBase
+class SearchDocuments extends DriverBase
 {
     /**
      * Construct accepts actual objects rather than strings as this class is a delegate of

--- a/src/mongo/delegates/SearchDocuments.class.php
+++ b/src/mongo/delegates/SearchDocuments.class.php
@@ -1,19 +1,25 @@
 <?php
 
-class MongoTripodSearchDocuments extends MongoTripodBase
+namespace Tripod\Mongo;
+
+/**
+ * Class SearchDocuments
+ * @package Tripod\Mongo
+ */
+class SearchDocuments extends TripodBase
 {
     /**
      * Construct accepts actual objects rather than strings as this class is a delegate of
-     * MongoTripod and should inherit connections set up there
+     * Tripod and should inherit connections set up there
      * @param string $storeName
-     * @param MongoCollection $collection
+     * @param \MongoCollection $collection
      * @param $defaultContext
      * @param null $stat
      * @internal param \MongoDB $db
      */
-    function __construct($storeName, MongoCollection $collection, $defaultContext, $stat=null)
+    function __construct($storeName, \MongoCollection $collection, $defaultContext, $stat=null)
     {
-        $this->labeller = new MongoTripodLabeller();
+        $this->labeller = new Labeller();
         $this->storeName = $storeName;
         $this->collection = $collection;
         $this->podName = $collection->getName();
@@ -21,15 +27,22 @@ class MongoTripodSearchDocuments extends MongoTripodBase
         $this->stat = $stat;
     }
 
+    /**
+     * @param string $specId
+     * @param string $resource
+     * @param string $context
+     * @return array|null
+     * @throws \Exception
+     */
     public function generateSearchDocumentBasedOnSpecId($specId, $resource, $context)
     {
         if (empty($resource))
         {
-            throw new Exception("Resource must be specified");
+            throw new \Exception("Resource must be specified");
         }
         if (empty($context))
         {
-            throw new Exception("Context must be specified");
+            throw new \Exception("Context must be specified");
         }
 
         $searchSpec = $this->getSearchDocumentSpecification($specId);
@@ -62,7 +75,7 @@ class MongoTripodSearchDocuments extends MongoTripodBase
                 $indexRules['condition']['_id'] = array(
                     'r'=>$this->labeller->uri_to_alias($resource),
                     'c'=>$this->labeller->uri_to_alias($context));				
-                if (MongoTripodConfig::getInstance()->getCollectionForCBD($this->storeName, $irFrom)->find($indexRules['condition'])->hasNext())
+                if (Config::getInstance()->getCollectionForCBD($this->storeName, $irFrom)->find($indexRules['condition'])->hasNext())
                 {
                     // match found, add this spec id to those that should be generated
                    $proceedWithGeneration = true;
@@ -85,7 +98,7 @@ class MongoTripodSearchDocuments extends MongoTripodBase
             'c'=>$this->labeller->uri_to_alias($context)
         );
 
-        $sourceDocument = MongoTripodConfig::getInstance()->getCollectionForCBD($this->storeName, $from)->findOne(array('_id'=>$_id));
+        $sourceDocument = Config::getInstance()->getCollectionForCBD($this->storeName, $from)->findOne(array('_id'=>$_id));
 
         if(empty($sourceDocument)){
             $this->debugLog("Source document not found for $resource, cannot proceed");
@@ -99,12 +112,12 @@ class MongoTripodSearchDocuments extends MongoTripodBase
         $_id['type'] = $specId;
         $generatedDocument['_id'] = $_id;
 
-        MongoTripodConfig::getInstance()->getCollectionForSearchDocument(
+        Config::getInstance()->getCollectionForSearchDocument(
             $this->storeName,
             $specId)
             ->ensureIndex(array('_id.type'=>1),array('background'=>1));
 
-        MongoTripodConfig::getInstance()->getCollectionForSearchDocument(
+        Config::getInstance()->getCollectionForSearchDocument(
             $this->storeName,
             $specId)
             ->ensureIndex(array('_impactIndex'=>1),array('background'=>1));
@@ -122,26 +135,33 @@ class MongoTripodSearchDocuments extends MongoTripodBase
         return $generatedDocument;
     }
 
+    /**
+     * @param array $rdfTypes
+     * @param string $resource
+     * @param string $context
+     * @return array
+     * @throws \Exception
+     */
     public function generateSearchDocumentsBasedOnRdfTypes(Array $rdfTypes, $resource, $context)
     {
         if (empty($resource))
         {
-            throw new Exception("Resource must be specified");
+            throw new \Exception("Resource must be specified");
         }
         if (empty($context))
         {
-            throw new Exception("Context must be specified");
+            throw new \Exception("Context must be specified");
         }
 
         // this is what is returned
         $generatedSearchDocuments = array();
 
-        $timer =new Timer();
+        $timer =new \Tripod\Timer();
         $timer->start();
 
         foreach($rdfTypes as $rdfType)
         {
-            $specs = MongoTripodConfig::getInstance()->getSearchDocumentSpecifications($this->storeName, $rdfType);
+            $specs = Config::getInstance()->getSearchDocumentSpecifications($this->storeName, $rdfType);
 
             if(empty($specs)) continue; // no point doing anything else if there is no spec for the type
 
@@ -155,11 +175,17 @@ class MongoTripodSearchDocuments extends MongoTripodBase
         return $generatedSearchDocuments;
     }
 
+    /**
+     * @param array $source
+     * @param array $joins
+     * @param array $target
+     * @param string $from
+     */
     protected function doJoin($source, $joins, &$target, $from)
     {
         // expand sequences before proceeding
         $this->expandSequence($joins, $source);
-        $config = MongoTripodConfig::getInstance();
+        $config = Config::getInstance();
         foreach($joins as $predicate=>$rules){
             if(isset($source[$predicate])){
                 $joinUris = array();
@@ -207,7 +233,13 @@ class MongoTripodSearchDocuments extends MongoTripodBase
         }
     }
 
-    protected function addFields($source, $fieldsOrIndices, &$target, $isIndex=false)
+    /**
+     * @param array $source
+     * @param array $fieldsOrIndices
+     * @param array $target
+     * @param bool $isIndex
+     */
+    protected function addFields(Array $source, Array $fieldsOrIndices, Array &$target, $isIndex=false)
     {
         foreach($fieldsOrIndices as $f){
 
@@ -252,12 +284,21 @@ class MongoTripodSearchDocuments extends MongoTripodBase
             }
         }
     }
-    
+
+    /**
+     * @param $specId
+     * @return array|null
+     */
     protected function getSearchDocumentSpecification($specId)
     {
-    	return MongoTripodConfig::getInstance()->getSearchDocumentSpecification($this->storeName, $specId);
+    	return Config::getInstance()->getSearchDocumentSpecification($this->storeName, $specId);
     }
 
+    /**
+     * @param array $values
+     * @param array $field
+     * @param array $target
+     */
     private function addValuesToTarget($values, $field, &$target)
     {
         $objName = null;
@@ -306,6 +347,9 @@ class MongoTripodSearchDocuments extends MongoTripodBase
         }
     }
 
+    /**
+     * @return string
+     */
     public function getSearchCollectionName()
     {
         return SEARCH_INDEX_COLLECTION;

--- a/src/mongo/delegates/SearchIndexer.class.php
+++ b/src/mongo/delegates/SearchIndexer.class.php
@@ -12,7 +12,7 @@ use Tripod\Mongo\ImpactedSubject;
 use Tripod\Mongo\Labeller;
 /**
  * Class SearchIndexer
- * @package Tripod\Mongo
+ * @package Tripod\Mongo\Composites
  */
 class SearchIndexer extends CompositeBase
 {

--- a/src/mongo/delegates/SearchIndexer.class.php
+++ b/src/mongo/delegates/SearchIndexer.class.php
@@ -1,12 +1,15 @@
 <?php
 
-namespace Tripod\Mongo;
+namespace Tripod\Mongo\Composites;
 
 require_once TRIPOD_DIR . 'mongo/MongoTripodConstants.php';
 require_once TRIPOD_DIR . 'mongo/delegates/SearchDocuments.class.php';
 require_once TRIPOD_DIR . 'mongo/providers/MongoSearchProvider.class.php';
 require_once TRIPOD_DIR . 'exceptions/SearchException.class.php';
 
+use Tripod\Mongo\Config;
+use Tripod\Mongo\ImpactedSubject;
+use Tripod\Mongo\Labeller;
 /**
  * Class SearchIndexer
  * @package Tripod\Mongo
@@ -25,10 +28,10 @@ class SearchIndexer extends CompositeBase
     private $configuredProvider = null;
 
     /**
-     * @param Tripod $tripod
+     * @param \Tripod\Mongo\Driver $tripod
      * @throws \Tripod\Exceptions\SearchException
      */
-    public function __construct(Tripod $tripod)
+    public function __construct(\Tripod\Mongo\Driver $tripod)
     {
         $this->tripod = $tripod;
         $this->storeName = $tripod->getStoreName();
@@ -185,11 +188,11 @@ class SearchIndexer extends CompositeBase
     /**
      * @param \MongoCollection $collection
      * @param string $context
-     * @return SearchDocuments
+     * @return \Tripod\Mongo\SearchDocuments
      */
     protected function getSearchDocumentGenerator(\MongoCollection $collection, $context )
     {
-        return new SearchDocuments($this->storeName, $collection, $context, $this->tripod->getStat());
+        return new \Tripod\Mongo\SearchDocuments($this->storeName, $collection, $context, $this->tripod->getStat());
     }
 
     /**

--- a/src/mongo/delegates/SearchIndexer.class.php
+++ b/src/mongo/delegates/SearchIndexer.class.php
@@ -20,7 +20,7 @@ class SearchIndexer extends CompositeBase
     protected $stat = null;
 
     /**
-     * @var $configuredProvider \Tripod\ITripodSearchProvider
+     * @var $configuredProvider \Tripod\ISearchProvider
      */
     private $configuredProvider = null;
 
@@ -175,7 +175,7 @@ class SearchIndexer extends CompositeBase
     
 
     /**
-     * @return \Tripod\ITripodSearchProvider
+     * @return \Tripod\ISearchProvider
      */
     protected function getSearchProvider()
     {

--- a/src/mongo/delegates/Tables.class.php
+++ b/src/mongo/delegates/Tables.class.php
@@ -1,9 +1,13 @@
 <?php
 
-namespace Tripod\Mongo;
+namespace Tripod\Mongo\Composites;
 
 require_once TRIPOD_DIR . 'mongo/MongoTripodConstants.php';
-require_once TRIPOD_DIR . 'mongo/base/TripodBase.class.php';
+require_once TRIPOD_DIR . 'mongo/base/DriverBase.class.php';
+
+use Tripod\Mongo\Config;
+use Tripod\Mongo\ImpactedSubject;
+use Tripod\Mongo\Labeller;
 
 /**
  * Class Tables

--- a/src/mongo/delegates/Tables.class.php
+++ b/src/mongo/delegates/Tables.class.php
@@ -11,7 +11,7 @@ use Tripod\Mongo\Labeller;
 
 /**
  * Class Tables
- * @package Tripod\Mongo
+ * @package Tripod\Mongo\Composites
  */
 class Tables extends CompositeBase
 {

--- a/src/mongo/delegates/Tables.class.php
+++ b/src/mongo/delegates/Tables.class.php
@@ -65,11 +65,11 @@ class Tables extends CompositeBase
      * Tripod and should inherit connections set up there
      * @param string $storeName
      * @param \MongoCollection $collection
-     * @param $defaultContext
-     * @param $stat
+     * @param string $defaultContext
+     * @param \Tripod\ITripodStat|null $stat
      * todo: MongoCollection -> podName
      */
-    function __construct($storeName,\MongoCollection $collection,$defaultContext,$stat=null)
+    public function __construct($storeName,\MongoCollection $collection,$defaultContext,$stat=null)
     {
         $this->labeller = new Labeller();
         $this->storeName = $storeName;
@@ -82,7 +82,6 @@ class Tables extends CompositeBase
     }
 
     /**
-     * @todo Test that deleted subject works properly now that Subject->delete is removed
      * Receive update from subject
      * @param ImpactedSubject
      * @return void

--- a/src/mongo/delegates/Tables.class.php
+++ b/src/mongo/delegates/Tables.class.php
@@ -1,9 +1,15 @@
 <?php
 
-require_once TRIPOD_DIR . 'mongo/MongoTripodConstants.php';
-require_once TRIPOD_DIR . 'mongo/base/MongoTripodBase.class.php';
+namespace Tripod\Mongo;
 
-class MongoTripodTables extends CompositeBase
+require_once TRIPOD_DIR . 'mongo/MongoTripodConstants.php';
+require_once TRIPOD_DIR . 'mongo/base/TripodBase.class.php';
+
+/**
+ * Class Tables
+ * @package Tripod\Mongo
+ */
+class Tables extends CompositeBase
 {
     /**
      * Modifier config - list of allowed functions and their attributes that can be passed through in tablespecs.json
@@ -56,23 +62,23 @@ class MongoTripodTables extends CompositeBase
 
     /**
      * Construct accepts actual objects rather than strings as this class is a delegate of
-     * MongoTripod and should inherit connections set up there
+     * Tripod and should inherit connections set up there
      * @param string $storeName
-     * @param MongoCollection $collection
+     * @param \MongoCollection $collection
      * @param $defaultContext
      * @param $stat
      * todo: MongoCollection -> podName
      */
-    function __construct($storeName,MongoCollection $collection,$defaultContext,$stat=null)
+    function __construct($storeName,\MongoCollection $collection,$defaultContext,$stat=null)
     {
-        $this->labeller = new MongoTripodLabeller();
+        $this->labeller = new Labeller();
         $this->storeName = $storeName;
         $this->collection = $collection;
         $this->podName = $collection->getName();
-        $this->config = MongoTripodConfig::getInstance();
+        $this->config = Config::getInstance();
         $this->defaultContext = $this->labeller->uri_to_alias($defaultContext); // make sure default context is qnamed if applicable
         $this->stat = $stat;
-        $this->readPreference = MongoClient::RP_PRIMARY;  // todo: figure out where this should go.
+        $this->readPreference = \MongoClient::RP_PRIMARY;  // todo: figure out where this should go.
     }
 
     /**
@@ -111,11 +117,11 @@ class MongoTripodTables extends CompositeBase
 
         $tablePredicates = array();
 
-        foreach(MongoTripodConfig::getInstance()->getTableSpecifications($this->storeName) as $tableSpec)
+        foreach(Config::getInstance()->getTableSpecifications($this->storeName) as $tableSpec)
         {
             if(isset($tableSpec[_ID_KEY]))
             {
-                $tablePredicates[$tableSpec[_ID_KEY]] = MongoTripodConfig::getInstance()->getDefinedPredicatesInSpec($this->storeName, $tableSpec[_ID_KEY]);
+                $tablePredicates[$tableSpec[_ID_KEY]] = Config::getInstance()->getDefinedPredicatesInSpec($this->storeName, $tableSpec[_ID_KEY]);
             }
         }
 
@@ -199,6 +205,11 @@ class MongoTripodTables extends CompositeBase
         return $affectedTableRows;
     }
 
+    /**
+     * @param string $storeName
+     * @param string $tableSpecId
+     * @return array|null
+     */
     public function getSpecification($storeName, $tableSpecId)
     {
         return $this->config->getTableSpecification($storeName,$tableSpecId);
@@ -224,7 +235,7 @@ class MongoTripodTables extends CompositeBase
      */
     public function getTableRows($tableSpecId,$filter=array(),$sortBy=array(),$offset=0,$limit=10)
     {
-        $t = new Timer();
+        $t = new \Tripod\Timer();
         $t->start();
 
         $filter["_id." . _ID_TYPE] = $tableSpecId;
@@ -265,7 +276,7 @@ class MongoTripodTables extends CompositeBase
      */
     public function distinct($tableSpecId, $fieldName, array $filter=array())
     {
-        $t = new Timer();
+        $t = new \Tripod\Timer();
         $t->start();
 
         $filter['_id.'._ID_TYPE] = $tableSpecId;
@@ -329,7 +340,7 @@ class MongoTripodTables extends CompositeBase
      * @param string $tableId
      */
     public function deleteTableRowsByTableId($tableId) {
-        $tableSpec = MongoTripodConfig::getInstance()->getTableSpecification($this->storeName, $tableId);
+        $tableSpec = Config::getInstance()->getTableSpecification($this->storeName, $tableId);
         if ($tableSpec==null)
         {
             $this->debugLog("Could not find a table specification for $tableId");
@@ -400,14 +411,14 @@ class MongoTripodTables extends CompositeBase
 
         if(empty($specTypes))
         {
-            $tableSpecs = MongoTripodConfig::getInstance()->getTableSpecifications($this->storeName);
+            $tableSpecs = Config::getInstance()->getTableSpecifications($this->storeName);
         }
         else
         {
             $tableSpecs = array();
             foreach($specTypes as $specType)
             {
-                $spec = MongoTripodConfig::getInstance()->getTableSpecification($this->storeName, $specType);
+                $spec = Config::getInstance()->getTableSpecification($this->storeName, $specType);
                 if($spec)
                 {
                     $tableSpecs[$specType] = $spec;
@@ -447,10 +458,10 @@ class MongoTripodTables extends CompositeBase
      */
     public function generateTableRows($tableType,$resource=null,$context=null)
     {
-        $t = new Timer();
+        $t = new \Tripod\Timer();
         $t->start();
         $this->temporaryFields = array();
-        $tableSpec = MongoTripodConfig::getInstance()->getTableSpecification($this->storeName, $tableType);
+        $tableSpec = Config::getInstance()->getTableSpecification($this->storeName, $tableType);
         $collection = $this->config->getCollectionForTable($this->storeName, $tableType);
 
         if ($tableSpec==null)
@@ -591,17 +602,17 @@ class MongoTripodTables extends CompositeBase
      * @param array $equation
      * @param array $dest
      * @return float|int|null
-     * @throws InvalidArgumentException
+     * @throws \InvalidArgumentException
      */
     protected function computeArithmeticValue(array $equation, array &$dest)
     {
         if(count($equation) < 3)
         {
-            throw new InvalidArgumentException("Equations must consist of an array with 3 values");
+            throw new \InvalidArgumentException("Equations must consist of an array with 3 values");
         }
         if(!in_array($equation[1], self::$arithmeticOperators))
         {
-            throw new InvalidArgumentException("Invalid arithmetic operator");
+            throw new \InvalidArgumentException("Invalid arithmetic operator");
         }
 
         $left = $this->rewriteVariableValue($equation[0], $dest, 'numeric');
@@ -807,13 +818,13 @@ class MongoTripodTables extends CompositeBase
      * @param string $operator The comparison operator
      * @param mixed $right The right value of the condition
      * @return bool
-     * @throws InvalidArgumentException
+     * @throws \InvalidArgumentException
      */
     protected function doConditional($left, $operator, $right)
     {
         if((!empty($operator)) && !in_array($operator, self::$conditionalOperators))
         {
-            throw new InvalidArgumentException("Invalid conditional operator");
+            throw new \InvalidArgumentException("Invalid conditional operator");
         }
         elseif(!$operator)
         {
@@ -1047,7 +1058,7 @@ class MongoTripodTables extends CompositeBase
      * @param string $modifier
      * @param string $value
      * @param array $options
-     * @throws Exception
+     * @throws \Exception
      * @return mixed
      */
     private function applyModifier($modifier, $value, $options = array())
@@ -1072,19 +1083,26 @@ class MongoTripodTables extends CompositeBase
                     if(is_array($value)) $value = implode($options['glue'], $value);
                     break;
                 case 'date':
-                    if(is_string($value)) $value = new MongoDate(strtotime($value));
+                    if(is_string($value)) $value = new \MongoDate(strtotime($value));
                     break;
                 default:
-                    throw new Exception("Could not apply modifier:".$modifier);
+                    throw new \Exception("Could not apply modifier:".$modifier);
                     break;
             }
-        } catch(Exception $e)
+        } catch(\Exception $e)
         {
             throw $e;
         }
         return $value;
     }
 
+    /**
+     * @param array $source
+     * @param array $joins
+     * @param array $dest
+     * @param string $from
+     * @param string $contextAlias
+     */
     protected function doJoins($source,$joins,&$dest,$from,$contextAlias)
     {
         $this->expandSequence($joins,$source);
@@ -1211,7 +1229,7 @@ class MongoTripodTables extends CompositeBase
      * Apply a regex to the RDF property value defined in $value
      * @param $regex
      * @param $value
-     * @throws TripodException
+     * @throws \Tripod\Exceptions\Exception
      * @return int
      */
     private function applyRegexToValue($regex, $value)
@@ -1223,7 +1241,7 @@ class MongoTripodTables extends CompositeBase
         }
         else
         {
-            throw new TripodException("Was expecting either VALUE_URI or VALUE_LITERAL when applying regex to value - possible data corruption with: ".var_export($value,true));
+            throw new \Tripod\Exceptions\Exception("Was expecting either VALUE_URI or VALUE_LITERAL when applying regex to value - possible data corruption with: ".var_export($value,true));
         }
     }
 }

--- a/src/mongo/delegates/Updates.class.php
+++ b/src/mongo/delegates/Updates.class.php
@@ -13,7 +13,7 @@ class Updates extends TripodBase {
     /**
      * $var TransactionLog
      */
-    private $transaction_log = null;
+    private $transactionLog = null;
 
     /**
      * @var Labeller
@@ -1117,11 +1117,11 @@ class Updates extends TripodBase {
      */
     public function getTransactionLog()
     {
-        if($this->transaction_log==null)
+        if($this->transactionLog==null)
         {
-            $this->transaction_log = new TransactionLog();
+            $this->transactionLog = new TransactionLog();
         }
-        return $this->transaction_log;
+        return $this->transactionLog;
     }
 
     /**
@@ -1129,7 +1129,7 @@ class Updates extends TripodBase {
      */
     public function setTransactionLog(TransactionLog $transactionLog)
     {
-        $this->transaction_log = $transactionLog;
+        $this->transactionLog = $transactionLog;
     }
 
 

--- a/src/mongo/delegates/Updates.class.php
+++ b/src/mongo/delegates/Updates.class.php
@@ -8,7 +8,7 @@ require_once TRIPOD_DIR . 'mongo/Config.class.php';
  * Class Updates
  * @package Tripod\Mongo
  */
-class Updates extends TripodBase {
+class Updates extends DriverBase {
 
     /**
      * $var TransactionLog
@@ -33,7 +33,7 @@ class Updates extends TripodBase {
     private $originalDbReadPreference = array();
 
     /**
-     * @var Tripod
+     * @var Driver
      */
     protected $tripod;
 
@@ -59,10 +59,10 @@ class Updates extends TripodBase {
     protected $locksCollection;
 
     /**
-     * @param Tripod $tripod
+     * @param Driver $tripod
      * @param array $opts
      */
-    public function __construct(Tripod $tripod,$opts=array())
+    public function __construct(Driver $tripod,$opts=array())
     {
         $this->tripod = $tripod;
         $this->storeName = $tripod->getStoreName();
@@ -308,7 +308,7 @@ class Updates extends TripodBase {
 
             $this->debugLog(MONGO_LOCK,
                 array(
-                    'description'=>'Tripod::storeChanges - Unlocking documents, apply change-set completed',
+                    'description'=>'Driver::storeChanges - Unlocking documents, apply change-set completed',
                     'transaction_id'=>$transaction_id,
                 )
             );
@@ -361,7 +361,7 @@ class Updates extends TripodBase {
                     // Error log here
                     $this->errorLog(MONGO_ROLLBACK,
                         array(
-                            'description' => 'Tripod::rollbackTransaction - Error updating transaction',
+                            'description' => 'Driver::rollbackTransaction - Error updating transaction',
                             'exception_message' => $exception->getMessage(),
                             'transaction_id' => $transaction_id,
                             'mongoDriverError' => $this->getDatabase()->lastError()
@@ -375,7 +375,7 @@ class Updates extends TripodBase {
         {
             $this->errorLog(MONGO_ROLLBACK,
                 array(
-                    'description'=>'Tripod::rollbackTransaction - Unlocking documents',
+                    'description'=>'Driver::rollbackTransaction - Unlocking documents',
                     'exception_message' => $exception->getMessage(),
                     'transaction_id'=>$transaction_id,
                     'mongoDriverError' => $this->getDatabase()->lastError()
@@ -597,7 +597,7 @@ class Updates extends TripodBase {
                 {
                     $this->errorLog(MONGO_WRITE,
                         array(
-                            'description'=>'Tripod::storeChanges - Update failed we did not find a matching document (transaction_id - ' .$transaction_id .')',
+                            'description'=>'Driver::storeChanges - Update failed we did not find a matching document (transaction_id - ' .$transaction_id .')',
                             $result
                         )
                     );
@@ -741,7 +741,7 @@ class Updates extends TripodBase {
                 "podName" => $this->podName,
                 "contextAlias" => $contextAlias
             );
-            $this->submitJob(Config::getDiscoverQueueName(),"\Tripod\Mongo\DiscoverImpactedSubjects",$data);
+            $this->submitJob(Config::getDiscoverQueueName(),"\Tripod\Mongo\Jobs\DiscoverImpactedSubjects",$data);
         }
     }
 
@@ -804,7 +804,7 @@ class Updates extends TripodBase {
             {
                 $this->debugLog(MONGO_LOCK,
                     array(
-                        'description'=>'Tripod::lockAllDocuments - Attempting to get lock',
+                        'description'=>'Driver::lockAllDocuments - Attempting to get lock',
                         'transaction_id'=>$transaction_id,
                         'subject'=>$s,
                         'attempt' => $retry
@@ -816,7 +816,7 @@ class Updates extends TripodBase {
 
                     $this->debugLog(MONGO_LOCK,
                         array(
-                            'description'=>'Tripod::lockAllDocuments - Got the lock',
+                            'description'=>'Driver::lockAllDocuments - Got the lock',
                             'transaction_id'=>$transaction_id,
                             'subject'=>$s,
                             'retry' => $retry
@@ -838,7 +838,7 @@ class Updates extends TripodBase {
 
                 $this->debugLog(MONGO_LOCK,
                     array(
-                        'description'=>"Tripod::lockAllDocuments - Unable to lock all ". count($subjectsOfChange) ."  documents, unlocked  " . count($lockedSubjects) . " locked documents",
+                        'description'=>"Driver::lockAllDocuments - Unable to lock all ". count($subjectsOfChange) ."  documents, unlocked  " . count($lockedSubjects) . " locked documents",
                         'transaction_id'=>$transaction_id,
                         'documentsToLock' => implode(",", $subjectsOfChange),
                         'documentsLocked' => implode(",", $lockedSubjects),
@@ -904,7 +904,7 @@ class Updates extends TripodBase {
             catch(\Exception $e) { //simply send false as status as we are unable to create audit entry
                 $this->errorLog(MONGO_LOCK,
                     array(
-                        'description'=>'Tripod::removeInertLocks - failed',
+                        'description'=>'Driver::removeInertLocks - failed',
                         'transaction_id'=>$transaction_id,
                         'exception-message' => $e->getMessage()
                     )
@@ -927,7 +927,7 @@ class Updates extends TripodBase {
             }
             catch(\Exception $e) {
                 $logInfo = array(
-                    'description'=>'Tripod::removeInertLocks - failed',
+                    'description'=>'Driver::removeInertLocks - failed',
                     'transaction_id'=>$transaction_id,
                     'exception-message' => $e->getMessage()
                 );
@@ -961,7 +961,7 @@ class Updates extends TripodBase {
         if(!$res["ok"] || $res['err']!=NULL){
             $this->errorLog(MONGO_LOCK,
                 array(
-                    'description'=>'Tripod::unlockAllDocuments - Failed to unlock documents (transaction_id - ' .$transaction_id .')',
+                    'description'=>'Driver::unlockAllDocuments - Failed to unlock documents (transaction_id - ' .$transaction_id .')',
                     'mongoDriverError' => $this->getLocksDatabase()->lastError(),
                     $res
                 )
@@ -1011,7 +1011,7 @@ class Updates extends TripodBase {
             catch(\Exception $e) { //Subject is already locked or unable to lock
                 $this->debugLog(MONGO_LOCK,
                     array(
-                        'description'=>'Tripod::lockSingleDocument - failed with exception',
+                        'description'=>'Driver::lockSingleDocument - failed with exception',
                         'transaction_id'=>$transaction_id,
                         'subject'=>$s,
                         'exception-message' => $e->getMessage()
@@ -1039,7 +1039,7 @@ class Updates extends TripodBase {
                 catch(\Exception $e){
                     $this->errorLog(MONGO_LOCK,
                         array(
-                            'description'=>'Tripod::lockSingleDocument - failed when creating new document',
+                            'description'=>'Driver::lockSingleDocument - failed when creating new document',
                             'transaction_id'=>$transaction_id,
                             'subject'=>$s,
                             'exception-message' => $e->getMessage(),
@@ -1165,12 +1165,12 @@ class Updates extends TripodBase {
     }
 
     /**
-     * Creates a new Tripod instance
+     * Creates a new Driver instance
      * @param array $data
-     * @return Tripod
+     * @return Driver
      */
     protected function getTripod($data) {
-        return new Tripod(
+        return new Driver(
             $data['collection'],
             $data['database'],
             array('stat'=>$this->stat));

--- a/src/mongo/delegates/Updates.class.php
+++ b/src/mongo/delegates/Updates.class.php
@@ -1,16 +1,22 @@
 <?php
 
-require_once TRIPOD_DIR . 'mongo/MongoTripodConfig.class.php';
+namespace Tripod\Mongo;
 
-class MongoTripodUpdates extends MongoTripodBase {
+require_once TRIPOD_DIR . 'mongo/Config.class.php';
+
+/**
+ * Class Updates
+ * @package Tripod\Mongo
+ */
+class Updates extends TripodBase {
 
     /**
-     * $var MongoTransactionLog
+     * $var TransactionLog
      */
     private $transaction_log = null;
 
     /**
-     * @var MongoTripodLabeller
+     * @var Labeller
      */
     protected $labeller;
 
@@ -27,7 +33,7 @@ class MongoTripodUpdates extends MongoTripodBase {
     private $originalDbReadPreference = array();
 
     /**
-     * @var MongoTripod
+     * @var Tripod
      */
     protected $tripod;
 
@@ -43,35 +49,35 @@ class MongoTripodUpdates extends MongoTripodBase {
     private $async = null;
 
     /**
-     * @var MongoDB
+     * @var \MongoDB
      */
     protected $locksDb;
 
     /**
-     * @var MongoCollection
+     * @var \MongoCollection
      */
     protected $locksCollection;
 
     /**
-     * @param MongoTripod $tripod
+     * @param Tripod $tripod
      * @param array $opts
      */
-    public function __construct(MongoTripod $tripod,$opts=array())
+    public function __construct(Tripod $tripod,$opts=array())
     {
         $this->tripod = $tripod;
         $this->storeName = $tripod->getStoreName();
         $this->podName = $tripod->getPodName();
         $this->stat = $tripod->getStat();
-        $this->labeller = new MongoTripodLabeller();
+        $this->labeller = new Labeller();
         $opts = array_merge(array(
                 'defaultContext'=>null,
                 OP_ASYNC=>array(OP_VIEWS=>false,OP_TABLES=>true,OP_SEARCH=>true),
                 'stat'=>null,
-                'readPreference'=>MongoClient::RP_PRIMARY_PREFERRED,
+                'readPreference'=>\MongoClient::RP_PRIMARY_PREFERRED,
                 'retriesToGetLock' => 20)
             ,$opts);
         $this->readPreference = $opts['readPreference'];
-        $this->config = $this->getMongoTripodConfigInstance();
+        $this->config = $this->getConfigInstance();
 
         // default context
         $this->defaultContext = $opts['defaultContext'];
@@ -108,16 +114,16 @@ class MongoTripodUpdates extends MongoTripodBase {
 
     /**
      * Create and apply a changeset which is the delta between $oldGraph and $newGraph
-     * @param ExtendedGraph $oldGraph
-     * @param ExtendedGraph $newGraph
+     * @param \Tripod\ExtendedGraph $oldGraph
+     * @param \Tripod\ExtendedGraph $newGraph
      * @param string|null $context
      * @param string|null $description
-     * @throws Exception
+     * @throws \Exception
      * @return bool
      */
     public function saveChanges(
-        ExtendedGraph $oldGraph,
-        ExtendedGraph $newGraph,
+        \Tripod\ExtendedGraph $oldGraph,
+        \Tripod\ExtendedGraph $newGraph,
         $context=null,
         $description=null)
     {
@@ -125,9 +131,9 @@ class MongoTripodUpdates extends MongoTripodBase {
         try{
             $contextAlias = $this->getContextAlias($context);
 
-            if (!MongoTripodConfig::getInstance()->isPodWithinStore($this->getStoreName(),$this->getPodName()))
+            if (!Config::getInstance()->isPodWithinStore($this->getStoreName(),$this->getPodName()))
             {
-                throw new TripodException("database:collection " . $this->getStoreName() . ":" . $this->getPodName(). " is not referenced within config, so cannot be written to");
+                throw new \Tripod\Exceptions\Exception("database:collection " . $this->getStoreName() . ":" . $this->getPodName(). " is not referenced within config, so cannot be written to");
             }
 
             $this->validateGraphCardinality($newGraph);
@@ -135,7 +141,7 @@ class MongoTripodUpdates extends MongoTripodBase {
             $oldIndex = $oldGraph->get_index();
             $newIndex = $newGraph->get_index();
             $args = array('before' => $oldIndex, 'after' => $newIndex, 'changeReason' => $description);
-            $cs = new ChangeSet($args);
+            $cs = new \Tripod\ChangeSet($args);
 
             if ($cs->has_changes())
             {
@@ -149,7 +155,7 @@ class MongoTripodUpdates extends MongoTripodBase {
                 $this->queueAsyncOperations($subjectsAndPredicatesOfChange,$contextAlias);
             }
         }
-        catch(Exception $e){
+        catch(\Exception $e){
             // ensure we reset the original read preference in the event of an exception
             $this->resetOriginalReadPreference();
             throw $e;
@@ -168,18 +174,18 @@ class MongoTripodUpdates extends MongoTripodBase {
     {
         // Set db preference
         $dbPref = $this->getDatabase()->getReadPreference();
-        if($dbPref['type'] !== MongoClient::RP_PRIMARY){
+        if($dbPref['type'] !== \MongoClient::RP_PRIMARY){
             $this->originalDbReadPreference = $this->db->getReadPreference();
             $tagsets = (isset($dbPref['tagsets']) ? $dbPref['tagsets'] : array());
-            $this->db->setReadPreference(MongoClient::RP_PRIMARY, $tagsets);
+            $this->db->setReadPreference(\MongoClient::RP_PRIMARY, $tagsets);
         }
 
         $collPref = $this->getCollection()->getReadPreference();
         // Set collection preference
-        if($collPref['type'] !== MongoClient::RP_PRIMARY){
+        if($collPref['type'] !== \MongoClient::RP_PRIMARY){
             $this->originalCollectionReadPreference = $this->collection->getReadPreference();
             $tagsets = (isset($collPref['tagsets']) ? $collPref['tagsets'] : array());
-            $this->collection->setReadPreference(MongoClient::RP_PRIMARY, $tagsets);
+            $this->collection->setReadPreference(\MongoClient::RP_PRIMARY, $tagsets);
         }
     }
 
@@ -213,12 +219,12 @@ class MongoTripodUpdates extends MongoTripodBase {
     /**
      * Ensure that the graph we want to persist has data with valid cardinality.
      *
-     * @param ExtendedGraph $graph
-     * @throws TripodCardinalityException
+     * @param \Tripod\ExtendedGraph $graph
+     * @throws \Tripod\Exceptions\CardinalityException
      */
-    protected function validateGraphCardinality(ExtendedGraph $graph)
+    protected function validateGraphCardinality(\Tripod\ExtendedGraph $graph)
     {
-        $config = MongoTripodConfig::getInstance();
+        $config = Config::getInstance();
         $cardinality = $config->getCardinality($this->getStoreName(), $this->getPodName());
         $namespaces = $config->getNamespaces();
         $graphSubjects = $graph->get_subjects();
@@ -234,7 +240,7 @@ class MongoTripodUpdates extends MongoTripodBase {
             if (!array_key_exists($namespace, $namespaces))
             {
                 //TODO This may be changed to a namespace exception at some point...
-                throw new TripodCardinalityException("Namespace '{$namespace}' not defined for qname: {$qname}");
+                throw new \Tripod\Exceptions\CardinalityException("Namespace '{$namespace}' not defined for qname: {$qname}");
             }
 
             // NB: The only constraint we currently support is a value of 1 to enforce one triple per subject/predicate.
@@ -251,7 +257,7 @@ class MongoTripodUpdates extends MongoTripodBase {
                         {
                             $v[] = $predicateValue['value'];
                         }
-                        throw new TripodCardinalityException("Cardinality failed on {$subjectUri} for '{$qname}' - should only have 1 value and has: ".implode(', ', $v));
+                        throw new \Tripod\Exceptions\CardinalityException("Cardinality failed on {$subjectUri} for '{$qname}' - should only have 1 value and has: ".implode(', ', $v));
                     }
                 }
             }
@@ -260,14 +266,14 @@ class MongoTripodUpdates extends MongoTripodBase {
 
 
     /**
-     * @param ChangeSet $cs Change-set to apply
+     * @param \Tripod\ChangeSet $cs Change-set to apply
      * @param string $contextAlias
-     * @throws TripodException
+     * @throws \Tripod\Exceptions\Exception
      * @return array An array of subjects and predicates that have been changed
      */
-    protected function storeChanges(ChangeSet $cs, $contextAlias)
+    protected function storeChanges(\Tripod\ChangeSet $cs, $contextAlias)
     {
-        $t = new Timer();
+        $t = new \Tripod\Timer();
         $t->start();
 
         $subjectsOfChange = $cs->get_subjects_of_change();
@@ -294,15 +300,15 @@ class MongoTripodUpdates extends MongoTripodBase {
 
             if(empty($originalCBDs)) // didn't get lock on documents
             {
-                $this->getTransactionLog()->failTransaction($transaction_id, new Exception('Did not obtain locks on documents'));
-                throw new Exception('Did not obtain locks on documents');
+                $this->getTransactionLog()->failTransaction($transaction_id, new \Exception('Did not obtain locks on documents'));
+                throw new \Exception('Did not obtain locks on documents');
             }
 
             $changes = $this->applyChangeSet($cs,$originalCBDs,$contextAlias, $transaction_id);
 
             $this->debugLog(MONGO_LOCK,
                 array(
-                    'description'=>'MongoTripod::storeChanges - Unlocking documents, apply change-set completed',
+                    'description'=>'Tripod::storeChanges - Unlocking documents, apply change-set completed',
                     'transaction_id'=>$transaction_id,
                 )
             );
@@ -316,7 +322,7 @@ class MongoTripodUpdates extends MongoTripodBase {
 
             return $changes['subjectsAndPredicatesOfChange'];
         }
-        catch(Exception $e)
+        catch(\Exception $e)
         {
             $this->getStat()->increment(MONGO_ROLLBACK);
             $this->errorLog(MONGO_ROLLBACK,
@@ -330,18 +336,18 @@ class MongoTripodUpdates extends MongoTripodBase {
             );
             $this->rollbackTransaction($transaction_id, $originalCBDs, $e);
 
-            throw new TripodException('Error storing changes: '.$e->getMessage()." >>>" . $e->getTraceAsString());
+            throw new \Tripod\Exceptions\Exception('Error storing changes: '.$e->getMessage()." >>>" . $e->getTraceAsString());
         }
     }
 
     /**
      * @param string $transaction_id id of the transaction
      * @param array $originalCBDs containing the original CBDS
-     * @param Exception $exception
-     * @throws Exception
+     * @param \Exception $exception
+     * @throws \Exception
      * @return bool
      */
-    protected function rollbackTransaction($transaction_id, $originalCBDs, Exception $exception)
+    protected function rollbackTransaction($transaction_id, $originalCBDs, \Exception $exception)
     {
         // set transaction to cancelling
         $this->getTransactionLog()->cancelTransaction($transaction_id, $exception);
@@ -355,13 +361,13 @@ class MongoTripodUpdates extends MongoTripodBase {
                     // Error log here
                     $this->errorLog(MONGO_ROLLBACK,
                         array(
-                            'description' => 'MongoTripod::rollbackTransaction - Error updating transaction',
+                            'description' => 'Tripod::rollbackTransaction - Error updating transaction',
                             'exception_message' => $exception->getMessage(),
                             'transaction_id' => $transaction_id,
                             'mongoDriverError' => $this->getDatabase()->lastError()
                         )
                     );
-                    throw new Exception("Failed to restore Original CBDS for transaction: {$transaction_id} stopped at ".$g[_ID_KEY]);
+                    throw new \Exception("Failed to restore Original CBDS for transaction: {$transaction_id} stopped at ".$g[_ID_KEY]);
                 }
             }
         }
@@ -369,7 +375,7 @@ class MongoTripodUpdates extends MongoTripodBase {
         {
             $this->errorLog(MONGO_ROLLBACK,
                 array(
-                    'description'=>'MongoTripod::rollbackTransaction - Unlocking documents',
+                    'description'=>'Tripod::rollbackTransaction - Unlocking documents',
                     'exception_message' => $exception->getMessage(),
                     'transaction_id'=>$transaction_id,
                     'mongoDriverError' => $this->getDatabase()->lastError()
@@ -404,14 +410,14 @@ class MongoTripodUpdates extends MongoTripodBase {
 
     /**
      * Adds/updates/deletes the graph in the database
-     * @param ChangeSet $cs
+     * @param \Tripod\ChangeSet $cs
      * @param array $originalCBDs
      * @param string $contextAlias
      * @param string $transaction_id
      * @return array
-     * @throws Exception
+     * @throws \Exception
      */
-    protected function applyChangeSet(ChangeSet $cs, $originalCBDs, $contextAlias, $transaction_id)
+    protected function applyChangeSet(\Tripod\ChangeSet $cs, $originalCBDs, $contextAlias, $transaction_id)
     {
         $subjectsAndPredicatesOfChange = array();
         if (preg_match('/^CBD_/',$this->getCollection()->getName()))
@@ -475,7 +481,7 @@ class MongoTripodUpdates extends MongoTripodBase {
                     if (!$valueExists)
                     {
                         $this->errorLog("Removal value {$subjectOfChange} {$predicate} {$object[0]['value']} does not appear in target document to be updated",array("targetGraph"=>$targetGraph->to_ntriples()));
-                        throw new Exception("Removal value {$subjectOfChange} {$predicate} {$object[0]['value']} does not appear in target document to be updated");
+                        throw new \Exception("Removal value {$subjectOfChange} {$predicate} {$object[0]['value']} does not appear in target document to be updated");
                     }
                     else if ($isUri)
                     {
@@ -488,7 +494,6 @@ class MongoTripodUpdates extends MongoTripodBase {
 
                     }
 
-                    //$criteria[$targetGraph->uri_to_qname($predicate)] = array('$elemMatch'=>$object[0]);
                 }
 
                 foreach ($additions as $r)
@@ -528,7 +533,7 @@ class MongoTripodUpdates extends MongoTripodBase {
                 }
 
                 // update datestamps
-                $_updated_ts = new MongoDate();
+                $_updated_ts = new \MongoDate();
 
                 if($targetGraph->is_empty())
                 {
@@ -546,7 +551,7 @@ class MongoTripodUpdates extends MongoTripodBase {
                     $newDocument[_VERSION] = $_new_version;
                     $newDocument[_UPDATED_TS] = $_updated_ts;
                     if($_new_version == 0) {
-                        $newDocument[_CREATED_TS] = new MongoDate();
+                        $newDocument[_CREATED_TS] = new \MongoDate();
                     } else {
                         if(isset($doc[_CREATED_TS])) {
                             $newDocument[_CREATED_TS] = $doc[_CREATED_TS];
@@ -570,7 +575,7 @@ class MongoTripodUpdates extends MongoTripodBase {
 
                 try{
                     $result = $this->getDatabase()->command($command);
-                } catch (Exception $e) {
+                } catch (\Exception $e) {
 
                     $this->errorLog(MONGO_WRITE,
                         array(
@@ -579,24 +584,24 @@ class MongoTripodUpdates extends MongoTripodBase {
                             'mongoDriverError' => $this->getDatabase()->lastError()
                         )
                     );
-                    throw new Exception($e);
+                    throw new \Exception($e);
                 }
 
                 if (!$result["ok"])
                 {
                     $this->errorLog("Update failed with err.", $result);
-                    throw new Exception("Update failed with err {$result['err']}");
+                    throw new \Exception("Update failed with err {$result['err']}");
                 }
 
                 if($result['value']==null)
                 {
                     $this->errorLog(MONGO_WRITE,
                         array(
-                            'description'=>'MongoTripod::storeChanges - Update failed we did not find a matching document (transaction_id - ' .$transaction_id .')',
+                            'description'=>'Tripod::storeChanges - Update failed we did not find a matching document (transaction_id - ' .$transaction_id .')',
                             $result
                         )
                     );
-                    throw new Exception("Update failed we did not find a matching document");
+                    throw new \Exception("Update failed we did not find a matching document");
                 }
             }
 
@@ -615,13 +620,13 @@ class MongoTripodUpdates extends MongoTripodBase {
                 if (!$result["ok"])
                 {
                     $this->errorLog("Delete failed with err.", $result);
-                    throw new Exception("Delete failed with err {$result['err']}");
+                    throw new \Exception("Delete failed with err {$result['err']}");
                 }
 
                 if($result['value']==null)
                 {
                     $this->errorLog("Delete failed we did not find a matching document.", $result);
-                    throw new Exception("Delete failed we did not find a matching document");
+                    throw new \Exception("Delete failed we did not find a matching document");
                 }
 
             }
@@ -633,7 +638,7 @@ class MongoTripodUpdates extends MongoTripodBase {
         }
         else
         {
-            throw new Exception("Attempted to update a non-CBD collection");
+            throw new \Exception("Attempted to update a non-CBD collection");
         }
     }
 
@@ -694,7 +699,7 @@ class MongoTripodUpdates extends MongoTripodBase {
                 foreach($opSubjects as $subject)
                 {
                     /* @var $subject ImpactedSubject */
-                    $t = new Timer();
+                    $t = new \Tripod\Timer();
                     $t->start();
 
                     $composite->update($subject);
@@ -731,12 +736,12 @@ class MongoTripodUpdates extends MongoTripodBase {
             $data = array(
                 "changes" => $subjectsAndPredicatesOfChange,
                 "operations" => $operations,
-                "tripodConfig" => MongoTripodConfig::getConfig(),
+                "tripodConfig" => Config::getConfig(),
                 "storeName" => $this->storeName,
                 "podName" => $this->podName,
                 "contextAlias" => $contextAlias
             );
-            $this->submitJob(MongoTripodConfig::getDiscoverQueueName(),"DiscoverImpactedSubjects",$data);
+            $this->submitJob(Config::getDiscoverQueueName(),"\Tripod\Mongo\DiscoverImpactedSubjects",$data);
         }
     }
 
@@ -748,7 +753,7 @@ class MongoTripodUpdates extends MongoTripodBase {
      */
     protected function submitJob($queueName, $class, Array $data)
     {
-        Resque::enqueue($queueName, $class, $data);
+        \Resque::enqueue($queueName, $class, $data);
     }
 
     //////// LOCKS \\\\\\\\
@@ -765,8 +770,8 @@ class MongoTripodUpdates extends MongoTripodBase {
         if(!empty($fromDateTime) || !empty($tillDateTime)){
             $query[_LOCKED_FOR_TRANS_TS] = array();
 
-            if(!empty($fromDateTime)) $query[_LOCKED_FOR_TRANS_TS]['$gte'] = new MongoDate(strtotime($fromDateTime));
-            if(!empty($tillDateTime)) $query[_LOCKED_FOR_TRANS_TS]['$lte'] = new MongoDate(strtotime($tillDateTime));
+            if(!empty($fromDateTime)) $query[_LOCKED_FOR_TRANS_TS]['$gte'] = new \MongoDate(strtotime($fromDateTime));
+            if(!empty($tillDateTime)) $query[_LOCKED_FOR_TRANS_TS]['$lte'] = new \MongoDate(strtotime($tillDateTime));
         }
         $docs = $this->getLocksCollection()->find($query)->sort(array(_LOCKED_FOR_TRANS => 1));
 
@@ -787,7 +792,7 @@ class MongoTripodUpdates extends MongoTripodBase {
      * @param string $transaction_id id for this transaction
      * @param string $contextAlias
      * @return array|null returns an array of CBDs, each CBD is the version at the time at which the lock was attained
-     * @throws Exception
+     * @throws \Exception
      */
     protected function lockAllDocuments($subjectsOfChange, $transaction_id, $contextAlias)
     {
@@ -799,7 +804,7 @@ class MongoTripodUpdates extends MongoTripodBase {
             {
                 $this->debugLog(MONGO_LOCK,
                     array(
-                        'description'=>'MongoTripod::lockAllDocuments - Attempting to get lock',
+                        'description'=>'Tripod::lockAllDocuments - Attempting to get lock',
                         'transaction_id'=>$transaction_id,
                         'subject'=>$s,
                         'attempt' => $retry
@@ -811,7 +816,7 @@ class MongoTripodUpdates extends MongoTripodBase {
 
                     $this->debugLog(MONGO_LOCK,
                         array(
-                            'description'=>'MongoTripod::lockAllDocuments - Got the lock',
+                            'description'=>'Tripod::lockAllDocuments - Got the lock',
                             'transaction_id'=>$transaction_id,
                             'subject'=>$s,
                             'retry' => $retry
@@ -833,7 +838,7 @@ class MongoTripodUpdates extends MongoTripodBase {
 
                 $this->debugLog(MONGO_LOCK,
                     array(
-                        'description'=>"MongoTripod::lockAllDocuments - Unable to lock all ". count($subjectsOfChange) ."  documents, unlocked  " . count($lockedSubjects) . " locked documents",
+                        'description'=>"Tripod::lockAllDocuments - Unable to lock all ". count($subjectsOfChange) ."  documents, unlocked  " . count($lockedSubjects) . " locked documents",
                         'transaction_id'=>$transaction_id,
                         'documentsToLock' => implode(",", $subjectsOfChange),
                         'documentsLocked' => implode(",", $lockedSubjects),
@@ -861,7 +866,7 @@ class MongoTripodUpdates extends MongoTripodBase {
      * @param string $transaction_id
      * @param string $reason
      * @return bool
-     * @throws Exception, if something goes wrong when unlocking documents, or creating audit entries.
+     * @throws \Exception, if something goes wrong when unlocking documents, or creating audit entries.
      */
     public function removeInertLocks($transaction_id, $reason)
     {
@@ -893,13 +898,13 @@ class MongoTripodUpdates extends MongoTripodBase {
                     )
                 );
                 if(!$result["ok"] || $result['err']!=NULL){
-                    throw new Exception("Failed to create audit entry with error message- " . $result['err']);
+                    throw new \Exception("Failed to create audit entry with error message- " . $result['err']);
                 }
             }
-            catch(Exception $e) { //simply send false as status as we are unable to create audit entry
+            catch(\Exception $e) { //simply send false as status as we are unable to create audit entry
                 $this->errorLog(MONGO_LOCK,
                     array(
-                        'description'=>'MongoTripod::removeInertLocks - failed',
+                        'description'=>'Tripod::removeInertLocks - failed',
                         'transaction_id'=>$transaction_id,
                         'exception-message' => $e->getMessage()
                     )
@@ -917,12 +922,12 @@ class MongoTripodUpdates extends MongoTripodBase {
                 $result = $auditCollection->update(array(_ID_KEY => $auditDocumentId), array('$set' => array("status" => AUDIT_STATUS_COMPLETED, _UPDATED_TS => $this->getMongoDate())));
                 if($result['err']!=NULL )
                 {
-                    throw new Exception("Failed to update audit entry with error message- " . $result['err']);
+                    throw new \Exception("Failed to update audit entry with error message- " . $result['err']);
                 }
             }
-            catch(Exception $e) {
+            catch(\Exception $e) {
                 $logInfo = array(
-                    'description'=>'MongoTripod::removeInertLocks - failed',
+                    'description'=>'Tripod::removeInertLocks - failed',
                     'transaction_id'=>$transaction_id,
                     'exception-message' => $e->getMessage()
                 );
@@ -946,7 +951,7 @@ class MongoTripodUpdates extends MongoTripodBase {
      * Unlocks documents locked by current transaction
      * @param string $transaction_id id for this transaction
      * @return bool
-     * @throws Exception is thrown if for any reason the update to mongo fails
+     * @throws \Exception is thrown if for any reason the update to mongo fails
      */
     protected function unlockAllDocuments($transaction_id)
     {
@@ -956,12 +961,12 @@ class MongoTripodUpdates extends MongoTripodBase {
         if(!$res["ok"] || $res['err']!=NULL){
             $this->errorLog(MONGO_LOCK,
                 array(
-                    'description'=>'MongoTripod::unlockAllDocuments - Failed to unlock documents (transaction_id - ' .$transaction_id .')',
+                    'description'=>'Tripod::unlockAllDocuments - Failed to unlock documents (transaction_id - ' .$transaction_id .')',
                     'mongoDriverError' => $this->getLocksDatabase()->lastError(),
                     $res
                 )
             );
-            throw new Exception("Failed to unlock documents as part of transaction : ".$transaction_id);
+            throw new \Exception("Failed to unlock documents as part of transaction : ".$transaction_id);
         }
         return true;
     }
@@ -994,19 +999,19 @@ class MongoTripodUpdates extends MongoTripodBase {
                     array(
                         _ID_KEY => array(_ID_RESOURCE => $this->labeller->uri_to_alias($s), _ID_CONTEXT => $contextAlias),
                         _LOCKED_FOR_TRANS => $transaction_id,
-                        _LOCKED_FOR_TRANS_TS=>new MongoDate()
+                        _LOCKED_FOR_TRANS_TS=>new \MongoDate()
                     ),
                     array("w" => 1)
                 );
 
                 if(!$result["ok"] || $result['err']!=NULL){
-                    throw new Exception("Failed to lock document with error message- " . $result['err']);
+                    throw new \Exception("Failed to lock document with error message- " . $result['err']);
                 }
             }
-            catch(Exception $e) { //Subject is already locked or unable to lock
+            catch(\Exception $e) { //Subject is already locked or unable to lock
                 $this->debugLog(MONGO_LOCK,
                     array(
-                        'description'=>'MongoTripod::lockSingleDocument - failed with exception',
+                        'description'=>'Tripod::lockSingleDocument - failed with exception',
                         'transaction_id'=>$transaction_id,
                         'subject'=>$s,
                         'exception-message' => $e->getMessage()
@@ -1027,14 +1032,14 @@ class MongoTripodUpdates extends MongoTripodBase {
                     );
 
                     if(!$result["ok"] || $result['err']!=NULL){
-                        throw new Exception("Failed to create new document with error message- " . $result['err']);
+                        throw new \Exception("Failed to create new document with error message- " . $result['err']);
                     }
                     $document  = $this->getCollection()->findOne(array(_ID_KEY => array(_ID_RESOURCE => $this->labeller->uri_to_alias($s), _ID_CONTEXT => $contextAlias)));
                 }
-                catch(Exception $e){
+                catch(\Exception $e){
                     $this->errorLog(MONGO_LOCK,
                         array(
-                            'description'=>'MongoTripod::lockSingleDocument - failed when creating new document',
+                            'description'=>'Tripod::lockSingleDocument - failed when creating new document',
                             'transaction_id'=>$transaction_id,
                             'subject'=>$s,
                             'exception-message' => $e->getMessage(),
@@ -1051,7 +1056,7 @@ class MongoTripodUpdates extends MongoTripodBase {
     /// Collection methods
 
     /**
-     * @return MongoCollection
+     * @return \MongoCollection
      */
     protected function getAuditManualRollbacksCollection()
     {
@@ -1060,27 +1065,27 @@ class MongoTripodUpdates extends MongoTripodBase {
     
     /**
      * For mocking
-     * @return MongoTripodConfig
+     * @return Config
      */
-    protected function getMongoTripodConfigInstance()
+    protected function getConfigInstance()
     {
-        return MongoTripodConfig::getInstance();
+        return Config::getInstance();
     }
 
     /**
-     * @return MongoId
+     * @return \MongoId
      */
     protected function generateIdForNewMongoDocument()
     {
-        return new MongoId();
+        return new \MongoId();
     }
 
     /**
-     * @return MongoDate
+     * @return \MongoDate
      */
     protected function getMongoDate()
     {
-        return new MongoDate();
+        return new \MongoDate();
     }
 
 
@@ -1108,21 +1113,21 @@ class MongoTripodUpdates extends MongoTripodBase {
     // getters and setters for the delegates
 
     /**
-     * @return MongoTransactionLog
+     * @return TransactionLog
      */
     public function getTransactionLog()
     {
         if($this->transaction_log==null)
         {
-            $this->transaction_log = new MongoTransactionLog();
+            $this->transaction_log = new TransactionLog();
         }
         return $this->transaction_log;
     }
 
     /**
-     * @param MongoTransactionLog $transactionLog
+     * @param TransactionLog $transactionLog
      */
-    public function setTransactionLog(MongoTransactionLog $transactionLog)
+    public function setTransactionLog(TransactionLog $transactionLog)
     {
         $this->transaction_log = $transactionLog;
     }
@@ -1160,12 +1165,12 @@ class MongoTripodUpdates extends MongoTripodBase {
     }
 
     /**
-     * Creates a new MongoTripod instance
+     * Creates a new Tripod instance
      * @param array $data
-     * @return MongoTripod
+     * @return Tripod
      */
-    protected function getMongoTripod($data) {
-        return new MongoTripod(
+    protected function getTripod($data) {
+        return new Tripod(
             $data['collection'],
             $data['database'],
             array('stat'=>$this->stat));
@@ -1191,11 +1196,11 @@ class MongoTripodUpdates extends MongoTripodBase {
     protected function getContextAlias($context=null)
     {
         $contextAlias = $this->labeller->uri_to_alias((empty($context)) ? $this->defaultContext : $context);
-        return (empty($contextAlias)) ? MongoTripodConfig::getInstance()->getDefaultContextAlias() : $contextAlias;
+        return (empty($contextAlias)) ? Config::getInstance()->getDefaultContextAlias() : $contextAlias;
     }
 
     /**
-     * @return MongoDB
+     * @return \MongoDB
      */
     protected function getLocksDatabase()
     {
@@ -1207,7 +1212,7 @@ class MongoTripodUpdates extends MongoTripodBase {
     }
 
     /**
-     * @return MongoCollection
+     * @return \MongoCollection
      */
     protected function getLocksCollection()
     {

--- a/src/mongo/delegates/Views.class.php
+++ b/src/mongo/delegates/Views.class.php
@@ -1,30 +1,39 @@
 <?php
 
-require_once TRIPOD_DIR . 'mongo/base/MongoTripodBase.class.php';
+namespace Tripod\Mongo;
 
-class MongoTripodViews extends CompositeBase
+require_once TRIPOD_DIR . 'mongo/base/TripodBase.class.php';
+
+/**
+ * Class Views
+ * @package Tripod\Mongo
+ */
+class Views extends CompositeBase
 {
 
     /**
      * Construct accepts actual objects rather than strings as this class is a delegate of
-     * MongoTripod and should inherit connections set up there
+     * Tripod and should inherit connections set up there
      * @param string $storeName
-     * @param MongoCollection $collection
+     * @param \MongoCollection $collection
      * @param $defaultContext
      * @param null $stat
      */
-    function __construct($storeName, MongoCollection $collection,$defaultContext,$stat=null) // todo: $collection -> podname
+    function __construct($storeName, \MongoCollection $collection,$defaultContext,$stat=null) // todo: $collection -> podname
     {
         $this->storeName = $storeName;
-        $this->labeller = new MongoTripodLabeller();
+        $this->labeller = new Labeller();
         $this->collection = $collection;
         $this->podName = $collection->getName();
         $this->defaultContext = $defaultContext;
-        $this->config = MongoTripodConfig::getInstance();
+        $this->config = Config::getInstance();
         $this->stat = $stat;
-        $this->readPreference = MongoClient::RP_PRIMARY; // todo: figure out where this should go.
+        $this->readPreference = \MongoClient::RP_PRIMARY; // todo: figure out where this should go.
     }
 
+    /**
+     * @return string
+     */
     public function getOperationType()
     {
         return OP_VIEWS;
@@ -87,6 +96,11 @@ class MongoTripodViews extends CompositeBase
         return $affectedViews;
     }
 
+    /**
+     * @param string $storeName
+     * @param string $viewSpecId
+     * @return array|null
+     */
     public function getSpecification($storeName, $viewSpecId)
     {
         return $this->config->getViewSpecification($storeName,$viewSpecId);
@@ -117,7 +131,7 @@ class MongoTripodViews extends CompositeBase
                 $query['value.'._GRAPHS.'.'.$predicate] = $object;
             }
         }
-        $viewCollection = $this->getMongoTripodConfigInstance()->getCollectionForView($this->storeName, $viewType);
+        $viewCollection = $this->getConfigInstance()->getCollectionForView($this->storeName, $viewType);
         return $this->fetchGraph($query,MONGO_VIEW,$viewCollection);
     }
 
@@ -142,7 +156,7 @@ class MongoTripodViews extends CompositeBase
         $graph = $this->fetchGraph($query,MONGO_VIEW,$viewCollection);
         if ($graph->is_empty())
         {
-            $viewSpec = MongoTripodConfig::getInstance()->getViewSpecification($this->storeName, $viewType);
+            $viewSpec = Config::getInstance()->getViewSpecification($this->storeName, $viewType);
             if($viewSpec == null)
             {
                 return new MongoGraph();
@@ -194,11 +208,11 @@ class MongoTripodViews extends CompositeBase
             $regrabResources = array();
             foreach($missingSubjects as $missingSubject)
             {
-                $viewSpec = $this->getMongoTripodConfigInstance()->getViewSpecification($this->storeName, $viewType);
+                $viewSpec = $this->getConfigInstance()->getViewSpecification($this->storeName, $viewType);
                 $fromCollection = $this->getFromCollectionForViewSpec($viewSpec);
 
                 $missingSubjectAlias = $this->labeller->uri_to_alias($missingSubject);
-                $doc = $this->getMongoTripodConfigInstance()->getCollectionForCBD($this->storeName, $fromCollection)
+                $doc = $this->getConfigInstance()->getCollectionForCBD($this->storeName, $fromCollection)
                     ->findOne(array( "_id" => array("r"=>$missingSubjectAlias,"c"=>$contextAlias)));
 
                 if($doc == NULL)
@@ -227,6 +241,12 @@ class MongoTripodViews extends CompositeBase
         return $g;
     }
 
+    /**
+     * @param string|array $resourceUriOrArray
+     * @param string $context
+     * @param string $viewType
+     * @return array
+     */
     private function createTripodViewIdsFromResourceUris($resourceUriOrArray,$context,$viewType)
     {
         $contextAlias = $this->getContextAlias($context);
@@ -254,7 +274,7 @@ class MongoTripodViews extends CompositeBase
             $resourceAlias = $this->labeller->uri_to_alias($resource);
 
             // delete any views this resource is involved in. It's type may have changed so it's not enough just to regen it with it's new type below.
-            foreach (MongoTripodConfig::getInstance()->getViewSpecifications($this->storeName) as $type=>$spec)
+            foreach (Config::getInstance()->getViewSpecifications($this->storeName) as $type=>$spec)
             {
                 if($spec['from']==$this->podName){
                     $this->config->getCollectionForView($this->storeName, $type)
@@ -297,7 +317,7 @@ class MongoTripodViews extends CompositeBase
      * @param $rdfType
      * @param null $resource
      * @param null $context
-     * @throws Exception
+     * @throws \Exception
      * @return mixed
      */
     public function generateViewsForResourcesOfType($rdfType,$resource=null,$context=null)
@@ -305,7 +325,7 @@ class MongoTripodViews extends CompositeBase
         $rdfType = $this->labeller->qname_to_alias($rdfType);
         $rdfTypeAlias = $this->labeller->uri_to_alias($rdfType);
         $foundSpec = false;
-        $viewSpecs = MongoTripodConfig::getInstance()->getViewSpecifications($this->storeName);
+        $viewSpecs = Config::getInstance()->getViewSpecifications($this->storeName);
         foreach($viewSpecs as $key=>$viewSpec)
         {
             // check for rdfType and rdfTypeAlias
@@ -328,10 +348,9 @@ class MongoTripodViews extends CompositeBase
     /**
      * This method will delete all views where the _id.type of the viewmatches the specified $viewId
      * @param $viewId
-     * @internal param $tableId
      */
     public function deleteViewsByViewId($viewId){
-        $viewSpec = MongoTripodConfig::getInstance()->getViewSpecification($this->storeName, $viewId);
+        $viewSpec = Config::getInstance()->getViewSpecification($this->storeName, $viewId);
         if ($viewSpec==null)
         {
             $this->debugLog("Could not find a view specification with viewId '$viewId'");
@@ -347,13 +366,13 @@ class MongoTripodViews extends CompositeBase
      * @param $viewId
      * @param null $resource
      * @param null $context
-     * @throws TripodViewException
+     * @throws \Tripod\Exceptions\ViewException
      * @return array
      */
     public function generateView($viewId,$resource=null,$context=null)
     {
         $contextAlias = $this->getContextAlias($context);
-        $viewSpec = MongoTripodConfig::getInstance()->getViewSpecification($this->storeName, $viewId);
+        $viewSpec = Config::getInstance()->getViewSpecification($this->storeName, $viewId);
         if ($viewSpec==null)
         {
             $this->debugLog("Could not find a view specification for $resource with viewId '$viewId'");
@@ -361,7 +380,7 @@ class MongoTripodViews extends CompositeBase
         }
         else
         {
-            $t = new Timer();
+            $t = new \Tripod\Timer();
             $t->start();
 
             $from = $this->getFromCollectionForViewSpec($viewSpec);
@@ -369,7 +388,7 @@ class MongoTripodViews extends CompositeBase
 
             if (!isset($viewSpec['joins']))
             {
-                throw new TripodViewException('Could not find any joins in view specification - usecase better served with select()');
+                throw new \Tripod\Exceptions\ViewException('Could not find any joins in view specification - usecase better served with select()');
             }
 
             // ensure both the ID field and the impactIndex indexes are correctly set up
@@ -419,7 +438,7 @@ class MongoTripodViews extends CompositeBase
                 if (isset($viewSpec['ttl']))
                 {
                     $buildImpactIndex=false;
-                    $value[_EXPIRES] = new MongoDate($this->getExpirySecFromNow($viewSpec['ttl']));
+                    $value[_EXPIRES] = new \MongoDate($this->getExpirySecFromNow($viewSpec['ttl']));
                 }
                 else
                 {
@@ -677,11 +696,11 @@ class MongoTripodViews extends CompositeBase
 
     /**
      * @param string $viewSpecId
-     * @return MongoCollection
+     * @return \MongoCollection
      */
     protected function getCollectionForViewSpec($viewSpecId)
     {
-        return $this->getMongoTripodConfigInstance()->getCollectionForView($this->storeName, $viewSpecId);
+        return $this->getConfigInstance()->getCollectionForView($this->storeName, $viewSpecId);
     }
 
 }

--- a/src/mongo/delegates/Views.class.php
+++ b/src/mongo/delegates/Views.class.php
@@ -10,7 +10,7 @@ use Tripod\Mongo\Labeller;
 
 /**
  * Class Views
- * @package Tripod\Mongo
+ * @package Tripod\Mongo\Composites
  */
 class Views extends CompositeBase
 {

--- a/src/mongo/delegates/Views.class.php
+++ b/src/mongo/delegates/Views.class.php
@@ -1,8 +1,12 @@
 <?php
 
-namespace Tripod\Mongo;
+namespace Tripod\Mongo\Composites;
 
-require_once TRIPOD_DIR . 'mongo/base/TripodBase.class.php';
+require_once TRIPOD_DIR . 'mongo/base/DriverBase.class.php';
+
+use Tripod\Mongo\Config;
+use Tripod\Mongo\ImpactedSubject;
+use Tripod\Mongo\Labeller;
 
 /**
  * Class Views
@@ -110,7 +114,7 @@ class Views extends CompositeBase
      * Return all views, restricted by $filter conditions, for given $viewType
      * @param array $filter - an array, keyed by predicate, to filter by
      * @param $viewType
-     * @return MongoGraph
+     * @return \Tripod\Mongo\MongoGraph
      */
     public function getViews(Array $filter,$viewType)
     {
@@ -140,12 +144,12 @@ class Views extends CompositeBase
      * @param $resource
      * @param $viewType
      * @param null $context
-     * @return MongoGraph
+     * @return \Tripod\Mongo\MongoGraph
      */
     public function getViewForResource($resource,$viewType,$context=null)
     {
         if(empty($resource)){
-            return new MongoGraph();
+            return new \Tripod\Mongo\MongoGraph();
         }
 
         $resourceAlias = $this->labeller->uri_to_alias($resource);
@@ -159,7 +163,7 @@ class Views extends CompositeBase
             $viewSpec = Config::getInstance()->getViewSpecification($this->storeName, $viewType);
             if($viewSpec == null)
             {
-                return new MongoGraph();
+                return new \Tripod\Mongo\MongoGraph();
             }
 
             $fromCollection = $this->getFromCollectionForViewSpec($viewSpec);
@@ -171,7 +175,7 @@ class Views extends CompositeBase
             {
                 // if you are trying to generate a view for a document that doesnt exist in the collection
                 // then we can just return an empty graph
-                return new MongoGraph();
+                return new \Tripod\Mongo\MongoGraph();
             }
 
             // generate view then try again
@@ -186,7 +190,7 @@ class Views extends CompositeBase
      * @param array $resources
      * @param $viewType
      * @param null $context
-     * @return MongoGraph
+     * @return \Tripod\Mongo\MongoGraph
      */
     public function getViewForResources(Array $resources,$viewType,$context=null)
     {

--- a/src/mongo/jobs/ApplyOperation.class.php
+++ b/src/mongo/jobs/ApplyOperation.class.php
@@ -1,9 +1,15 @@
 <?php
 
+namespace Tripod\Mongo;
+
+/**
+ * Class ApplyOperation
+ * @package Tripod\Mongo
+ */
 class ApplyOperation extends JobBase {
     /**
      * Run the ApplyOperation job
-     * @throws Exception
+     * @throws \Exception
      */
     public function perform()
     {
@@ -11,13 +17,13 @@ class ApplyOperation extends JobBase {
         {
             $this->debugLog("ApplyOperation::perform() start");
 
-            $timer = new Timer();
+            $timer = new \Tripod\Timer();
             $timer->start();
 
             $this->validateArgs();
 
             // set the config to what is received
-            MongoTripodConfig::setConfig($this->args["tripodConfig"]);
+            Config::setConfig($this->args["tripodConfig"]);
 
             $subject = $this->createImpactedSubject($this->args['subject']);
 
@@ -29,7 +35,7 @@ class ApplyOperation extends JobBase {
 
             $this->debugLog("ApplyOperation::perform() done in {$timer->result()}ms");
         }
-        catch (Exception $e)
+        catch (\Exception $e)
         {
             $this->errorLog("Caught exception in ".get_class($this).": ".$e->getMessage());
             throw $e;

--- a/src/mongo/jobs/ApplyOperation.class.php
+++ b/src/mongo/jobs/ApplyOperation.class.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Tripod\Mongo;
+namespace Tripod\Mongo\Jobs;
 
 /**
  * Class ApplyOperation
- * @package Tripod\Mongo
+ * @package Tripod\Mongo\Jobs
  */
 class ApplyOperation extends JobBase {
     /**
@@ -23,7 +23,7 @@ class ApplyOperation extends JobBase {
             $this->validateArgs();
 
             // set the config to what is received
-            Config::setConfig($this->args["tripodConfig"]);
+            \Tripod\Mongo\Config::setConfig($this->args["tripodConfig"]);
 
             $subject = $this->createImpactedSubject($this->args['subject']);
 
@@ -45,11 +45,11 @@ class ApplyOperation extends JobBase {
     /**
      * For mocking
      * @param array $args
-     * @return ImpactedSubject
+     * @return \Tripod\Mongo\ImpactedSubject
      */
     protected function createImpactedSubject(array $args)
     {
-        return new ImpactedSubject(
+        return new \Tripod\Mongo\ImpactedSubject(
             $args["resourceId"],
             $args["operation"],
             $args["storeName"],

--- a/src/mongo/jobs/DiscoverImpactedSubjects.class.php
+++ b/src/mongo/jobs/DiscoverImpactedSubjects.class.php
@@ -27,7 +27,7 @@ class DiscoverImpactedSubjects extends JobBase {
             // set the config to what is received
             Config::setConfig($this->args["tripodConfig"]);
 
-            $tripod = $this->getMongoTripod($this->args["storeName"],$this->args["podName"]);
+            $tripod = $this->getTripod($this->args["storeName"],$this->args["podName"]);
 
             $operations = $this->args['operations'];
             $modifiedSubjects = array();

--- a/src/mongo/jobs/DiscoverImpactedSubjects.class.php
+++ b/src/mongo/jobs/DiscoverImpactedSubjects.class.php
@@ -1,10 +1,16 @@
 <?php
 
+namespace Tripod\Mongo;
+
+/**
+ * Class DiscoverImpactedSubjects
+ * @package Tripod\Mongo
+ */
 class DiscoverImpactedSubjects extends JobBase {
 
     /**
      * Run the DiscoverImpactedSubjects job
-     * @throws Exception
+     * @throws \Exception
      */
     public function perform()
     {
@@ -13,13 +19,13 @@ class DiscoverImpactedSubjects extends JobBase {
 
             $this->debugLog("DiscoverImpactedSubjects::perform() start");
 
-            $timer = new Timer();
+            $timer = new \Tripod\Timer();
             $timer->start();
 
             $this->validateArgs();
 
             // set the config to what is received
-            MongoTripodConfig::setConfig($this->args["tripodConfig"]);
+            Config::setConfig($this->args["tripodConfig"]);
 
             $tripod = $this->getMongoTripod($this->args["storeName"],$this->args["podName"]);
 
@@ -39,7 +45,7 @@ class DiscoverImpactedSubjects extends JobBase {
                 foreach ($modifiedSubjects as $subject) {
                     $resourceId = $subject->getResourceId();
                     $this->debugLog("Adding operation {$subject->getOperation()} for subject {$resourceId[_ID_RESOURCE]} to queue ".MongoTripodConfig::getApplyQueueName());
-                    $this->submitJob(MongoTripodConfig::getApplyQueueName(),"ApplyOperation",array(
+                    $this->submitJob(Config::getApplyQueueName(),"\Tripod\Mongo\ApplyOperation",array(
                         "subject"=>$subject->toArray(),
                         "tripodConfig"=>$this->args["tripodConfig"]
                     ));
@@ -52,7 +58,7 @@ class DiscoverImpactedSubjects extends JobBase {
             $this->debugLog("DiscoverImpactedSubjects::perform() done in {$timer->result()}ms");
 
         }
-        catch(Exception $e)
+        catch(\Exception $e)
         {
             $this->errorLog("Caught exception in ".get_class($this).": ".$e->getMessage());
             throw $e;

--- a/src/mongo/jobs/DiscoverImpactedSubjects.class.php
+++ b/src/mongo/jobs/DiscoverImpactedSubjects.class.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Tripod\Mongo;
+namespace Tripod\Mongo\Jobs;
 
 /**
  * Class DiscoverImpactedSubjects
- * @package Tripod\Mongo
+ * @package Tripod\Mongo\Jobs
  */
 class DiscoverImpactedSubjects extends JobBase {
 
@@ -25,7 +25,7 @@ class DiscoverImpactedSubjects extends JobBase {
             $this->validateArgs();
 
             // set the config to what is received
-            Config::setConfig($this->args["tripodConfig"]);
+            \Tripod\Mongo\Config::setConfig($this->args["tripodConfig"]);
 
             $tripod = $this->getTripod($this->args["storeName"],$this->args["podName"]);
 
@@ -41,11 +41,11 @@ class DiscoverImpactedSubjects extends JobBase {
             }
 
             if(!empty($modifiedSubjects)){
-                /* @var $subject ImpactedSubject */
+                /* @var $subject \Tripod\Mongo\ImpactedSubject */
                 foreach ($modifiedSubjects as $subject) {
                     $resourceId = $subject->getResourceId();
-                    $this->debugLog("Adding operation {$subject->getOperation()} for subject {$resourceId[_ID_RESOURCE]} to queue ".Config::getApplyQueueName());
-                    $this->submitJob(Config::getApplyQueueName(),"\Tripod\Mongo\ApplyOperation",array(
+                    $this->debugLog("Adding operation {$subject->getOperation()} for subject {$resourceId[_ID_RESOURCE]} to queue ".\Tripod\Mongo\Config::getApplyQueueName());
+                    $this->submitJob(\Tripod\Mongo\Config::getApplyQueueName(),"\Tripod\Mongo\Jobs\ApplyOperation",array(
                         "subject"=>$subject->toArray(),
                         "tripodConfig"=>$this->args["tripodConfig"]
                     ));

--- a/src/mongo/jobs/DiscoverImpactedSubjects.class.php
+++ b/src/mongo/jobs/DiscoverImpactedSubjects.class.php
@@ -44,7 +44,7 @@ class DiscoverImpactedSubjects extends JobBase {
                 /* @var $subject ImpactedSubject */
                 foreach ($modifiedSubjects as $subject) {
                     $resourceId = $subject->getResourceId();
-                    $this->debugLog("Adding operation {$subject->getOperation()} for subject {$resourceId[_ID_RESOURCE]} to queue ".MongoTripodConfig::getApplyQueueName());
+                    $this->debugLog("Adding operation {$subject->getOperation()} for subject {$resourceId[_ID_RESOURCE]} to queue ".Config::getApplyQueueName());
                     $this->submitJob(Config::getApplyQueueName(),"\Tripod\Mongo\ApplyOperation",array(
                         "subject"=>$subject->toArray(),
                         "tripodConfig"=>$this->args["tripodConfig"]

--- a/src/mongo/providers/ISearchProvider.php
+++ b/src/mongo/providers/ISearchProvider.php
@@ -3,10 +3,10 @@
 namespace Tripod;
 
 /**
- * Class ITripodSearchProvider
+ * Class ISearchProvider
  * @package Tripod
  */
-interface ITripodSearchProvider
+interface ISearchProvider
 {
     /**
      * Indexes the given document

--- a/src/mongo/providers/ITripodSearchProvider.php
+++ b/src/mongo/providers/ITripodSearchProvider.php
@@ -1,10 +1,17 @@
 <?php
+
+namespace Tripod;
+
+/**
+ * Class ITripodSearchProvider
+ * @package Tripod
+ */
 interface ITripodSearchProvider
 {
     /**
      * Indexes the given document
      * @param array $document the document to index
-     * @throws TripodSearchException if there was an error indexing the document
+     * @throws \Tripod\Exceptions\SearchException if there was an error indexing the document
      * @return mixed
      */
     public function indexDocument($document);
@@ -15,7 +22,7 @@ interface ITripodSearchProvider
      * @param string $resource
      * @param string $context
      * @param array | string | null $specId
-     * @throws TripodSearchException if there was an error removing the document
+     * @throws \Tripod\Exceptions\SearchException if there was an error removing the document
      * @return mixed
      */
     public function deleteDocument($resource, $context, $specId=array());
@@ -49,7 +56,7 @@ interface ITripodSearchProvider
      * @param int $limit  the number of results to return per page
      * @param int $offset  the offset to skip to
      * @return mixed  a structure representing the search results
-     * @throws TripodSearchException if there was an error performing the search, or if the parameters are invalid
+     * @throws \Tripod\Exceptions\SearchException if there was an error performing the search, or if the parameters are invalid
      */
     public function search($q, $type, $indices=array(), $fields=array(), $limit=10, $offset=0);
     
@@ -59,7 +66,7 @@ interface ITripodSearchProvider
      * If type id is not specified this method will throw an exception.      
      * @param string $typeId search type id
      * @return bool|array  response returned by mongo
-     * @throws TripodException if there was an error performing the operation
+     * @throws \Tripod\Exceptions\Exception if there was an error performing the operation
      */
     public function deleteSearchDocumentsByTypeId($typeId);
 }

--- a/src/mongo/providers/MongoSearchProvider.class.php
+++ b/src/mongo/providers/MongoSearchProvider.class.php
@@ -14,7 +14,7 @@ require_once TRIPOD_DIR.'classes/Timer.class.php';
 class MongoSearchProvider implements \Tripod\ISearchProvider
 {
     /**
-     * @var Tripod
+     * @var Driver
      */
     private $tripod = null;
 
@@ -36,9 +36,9 @@ class MongoSearchProvider implements \Tripod\ISearchProvider
     protected $config;
 
     /**
-     * @param Tripod $tripod
+     * @param Driver $tripod
      */
-    public function __construct(Tripod $tripod)
+    public function __construct(Driver $tripod)
     {
         $this->tripod = $tripod;
         $this->storeName = $tripod->getStoreName();

--- a/src/mongo/providers/MongoSearchProvider.class.php
+++ b/src/mongo/providers/MongoSearchProvider.class.php
@@ -4,14 +4,14 @@ namespace Tripod\Mongo;
 
 require_once TRIPOD_DIR.'mongo/MongoTripodConstants.php';
 require_once TRIPOD_DIR . 'mongo/delegates/SearchDocuments.class.php';
-require_once TRIPOD_DIR.'mongo/providers/ITripodSearchProvider.php';
+require_once TRIPOD_DIR . 'mongo/providers/ISearchProvider.php';
 require_once TRIPOD_DIR.'classes/Timer.class.php';
 
 /**
  * Class MongoSearchProvider
  * @package Tripod\Mongo
  */
-class MongoSearchProvider implements \Tripod\ITripodSearchProvider
+class MongoSearchProvider implements \Tripod\ISearchProvider
 {
     /**
      * @var Tripod

--- a/src/mongo/serializers/NQuadSerializer.class.php
+++ b/src/mongo/serializers/NQuadSerializer.class.php
@@ -1,9 +1,11 @@
 <?php
+
+namespace Tripod\Mongo;
 /**
  * This class is a modified version of the ARC2_NTriplesSerializer; which I have modified to generated N-Quads as per:
  * http://sw.deri.org/2008/07/n-quads/
  */
-class MongoTripodNQuadSerializer
+class NQuadSerializer
 {
     private $raw;
     private $esc_chars;
@@ -14,6 +16,10 @@ class MongoTripodNQuadSerializer
         $this->raw = 0;
     }
 
+    /**
+     * @param string|array $v
+     * @return string
+     */
     public function getTerm($v)
     {
         if (!is_array($v)) {
@@ -46,20 +52,20 @@ class MongoTripodNQuadSerializer
             $quot = $quot . $quot . $quot;
         }
 
-//        var_dump($v['value']);echo "\n";
-
         $suffix = isset($v['lang']) && $v['lang'] ? '@' . $v['lang'] : '';
         $suffix = isset($v['datatype']) && $v['datatype'] ? '^^' . $this->getTerm($v['datatype']) : $suffix;
-        //return $quot . "object" . utf8_encode($v['value']) . $quot . $suffix;
-        //echo "\n\n${v['value']}\n\n";
 
         $escaped = $this->escape($v['value']);
-//        var_dump($escaped);echo "\n\n";
 
 
         return $quot . $escaped . $quot . $suffix;
     }
 
+    /**
+     * @param array $index
+     * @param string $context
+     * @return string
+     */
     public function getSerializedIndex($index, $context)
     {
         $r = '';
@@ -92,39 +98,33 @@ class MongoTripodNQuadSerializer
         return $r . $nl;
     }
 
-    /*  */
-
+    /**
+     * @param string $v
+     * @return string
+     */
     function escape($v)
     {
         $r = '';
         $v = (strpos(utf8_decode(str_replace('?', '', $v)), '?') === false) ? utf8_decode($v) : $v;
         if ($this->raw) {
-//            echo "Returning RAW $v \n";
             return $v;
         }
-
-//        $dump = false;
-//        if(strpos($v, 'LAW')!==FALSE){
-//            $dump=true;
-//        }
 
         for ($i = 0, $i_max = strlen($v); $i < $i_max; $i++) {
             $c = $v[$i];
             if (!isset($this->esc_chars[$c])) {
                 $this->esc_chars[$c] = $this->getEscapedChar($c, $this->getCharNo($c));
-//                if($dump){
-//                    var_dump($c);
-//                    var_dump($this->getCharNo($c));
-//                    var_dump($this->esc_chars[$c]);echo "\n\n";
-//                }
             }
             $r .= $this->esc_chars[$c];
         }
         return $r;
     }
 
-    /*  */
 
+    /**
+     * @param string $c
+     * @return int
+     */
     function getCharNo($c)
     {
         $c_utf = utf8_encode($c);
@@ -147,6 +147,11 @@ class MongoTripodNQuadSerializer
         return $r;
     }
 
+    /**
+     * @param string $c
+     * @param int $no
+     * @return string
+     */
     function getEscapedChar($c, $no)
     { /*see http://www.w3.org/TR/rdf-testcases/#ntrip_strings */
         if ($no < 9) return "\\u" . sprintf('%04X', $no); /* #x0-#x8 (0-8) */

--- a/src/mongo/util/IndexUtils.class.php
+++ b/src/mongo/util/IndexUtils.class.php
@@ -81,7 +81,7 @@ class IndexUtils
                     }
                     $collection->ensureIndex($indexes, array("background"=>$background));
                 }
-            }   
+            }
         }
     }
 }

--- a/src/mongo/util/IndexUtils.class.php
+++ b/src/mongo/util/IndexUtils.class.php
@@ -11,28 +11,32 @@ require_once(TRIPOD_DIR . "mongo/Config.class.php");
 class IndexUtils
 {
     /**
-     * Ensures the index for the given $dbName. As a consequence, sets the global
+     * Ensures the index for the given $storeName. As a consequence, sets the global
      * MongoCursor timeout to -1 for this thread, so use with caution from anything
      * other than a setup script
      * @param bool $reindex - force a reindex of existing data
-     * @param null $dbName - database name to ensure indexes for
+     * @param null $storeName - database name to ensure indexes for
      * @param bool $background - index in the background (default) or lock DB whilst indexing
      */
-    public function ensureIndexes($reindex=false,$dbName=null,$background=true)
+    public function ensureIndexes($reindex=false,$storeName=null,$background=true)
     {
         //MongoCursor::$timeout = -1; // set this otherwise you'll see timeout errors for large indexes
 
         $config = Config::getInstance();
-        $dbs = ($dbName==null) ? $config->getDbs() : array($dbName);
-        foreach ($dbs as $dbName)
+        $dbs = ($storeName==null) ? $config->getDbs() : array($storeName);
+        foreach ($dbs as $storeName)
         {
-            $collections = Config::getInstance()->getIndexesGroupedByCollection($dbName);
+            $collections = Config::getInstance()->getIndexesGroupedByCollection($storeName);
             foreach ($collections as $collectionName=>$indexes)
             {
-
+                // Don't do this for composites, which could be anywhere
+                if(in_array($collectionName, array(TABLE_ROWS_COLLECTION,VIEWS_COLLECTION,SEARCH_INDEX_COLLECTION)))
+                {
+                    continue;
+                }
                 if ($reindex)
                 {
-                    $config->getCollectionForCBD($dbName, $collectionName)->deleteIndexes();
+                    $config->getCollectionForCBD($storeName, $collectionName)->deleteIndexes();
                 }
                 foreach ($indexes as $indexName=>$fields)
                 {
@@ -40,26 +44,44 @@ class IndexUtils
                     if (is_numeric($indexName))
                     {
                         // no name
-                        $config->getCollectionForCBD($dbName, $collectionName)->ensureIndex($fields,array("background"=>$background));
+                        $config->getCollectionForCBD($storeName, $collectionName)->ensureIndex($fields,array("background"=>$background));
                     }
                     else
                     {
-                        $config->getCollectionForCBD($dbName, $collectionName)->ensureIndex($fields,array('name'=>$indexName,"background"=>$background));
+                        $config->getCollectionForCBD($storeName, $collectionName)->ensureIndex($fields,array('name'=>$indexName,"background"=>$background));
                     }
                 }
             }
-            // finally, for views, make sure type is indexed
-            $dataSources = array();
-            foreach($config->getViewSpecifications($dbName) as $viewId=>$spec)
+
+            // Index views
+            foreach($config->getViewSpecifications($storeName) as $viewId=>$spec)
             {
-                $dataSources[] = $spec['to'];
+                $collection = Config::getInstance()->getCollectionForView($storeName, $viewId);
+                if($collection)
+                {
+                    $indexes = array("_id.type"=>1);
+                    if(isset($spec['ensureIndexes']))
+                    {
+                        $indexes = array_merge($indexes, $spec['ensureIndexes']);
+                    }
+                    $collection->ensureIndex($indexes, array("background"=>$background));
+                }
             }
-            foreach(array_unique($dataSources) as $dataSource)
+
+            // Index table rows
+            foreach($config->getTableSpecifications($storeName) as $tableId=>$spec)
             {
-                $config->getDatabase($dbName, $dataSource)
-                    ->selectCollection(VIEWS_COLLECTION)
-                    ->ensureIndex(array("_id.type"=>1),array("background"=>$background));
-            }
+                $collection = Config::getInstance()->getCollectionForTable($storeName, $tableId);
+                if($collection)
+                {
+                    $indexes = array("_id.type"=>1);
+                    if(isset($spec['ensureIndexes']))
+                    {
+                        $indexes = array_merge($indexes, $spec['ensureIndexes']);
+                    }
+                    $collection->ensureIndex($indexes, array("background"=>$background));
+                }
+            }   
         }
     }
 }

--- a/src/mongo/util/IndexUtils.class.php
+++ b/src/mongo/util/IndexUtils.class.php
@@ -1,6 +1,13 @@
 <?php
-require_once(TRIPOD_DIR."mongo/MongoTripodConfig.class.php");
 
+namespace Tripod\Mongo;
+
+require_once(TRIPOD_DIR . "mongo/Config.class.php");
+
+/**
+ * Class IndexUtils
+ * @package Tripod\Mongo
+ */
 class IndexUtils
 {
     /**
@@ -15,11 +22,11 @@ class IndexUtils
     {
         //MongoCursor::$timeout = -1; // set this otherwise you'll see timeout errors for large indexes
 
-        $config = MongoTripodConfig::getInstance();
+        $config = Config::getInstance();
         $dbs = ($dbName==null) ? $config->getDbs() : array($dbName);
         foreach ($dbs as $dbName)
         {
-            $collections = MongoTripodConfig::getInstance()->getIndexesGroupedByCollection($dbName);
+            $collections = Config::getInstance()->getIndexesGroupedByCollection($dbName);
             foreach ($collections as $collectionName=>$indexes)
             {
 

--- a/src/mongo/util/IndexUtils.class.php
+++ b/src/mongo/util/IndexUtils.class.php
@@ -64,6 +64,10 @@ class IndexUtils
                     {
                         $indexes = array_merge($indexes, $spec['ensureIndexes']);
                     }
+                    if ($reindex)
+                    {
+                        $collection->deleteIndexes();
+                    }
                     $collection->ensureIndex($indexes, array("background"=>$background));
                 }
             }
@@ -78,6 +82,10 @@ class IndexUtils
                     if(isset($spec['ensureIndexes']))
                     {
                         $indexes = array_merge($indexes, $spec['ensureIndexes']);
+                    }
+                    if ($reindex)
+                    {
+                        $collection->deleteIndexes();
                     }
                     $collection->ensureIndex($indexes, array("background"=>$background));
                 }

--- a/src/tripod.inc.php
+++ b/src/tripod.inc.php
@@ -12,29 +12,32 @@ if(!defined('ARC_DIR')) define('ARC_DIR', TRIPOD_DIR. '../vendor/semsol/arc2/' )
 //require_once ARC_DIR.'ARC2.php';
 
 require_once TRIPOD_DIR.'classes/Timer.class.php';
-require_once TRIPOD_DIR.'exceptions/TripodException.class.php';
-require_once TRIPOD_DIR.'exceptions/TripodSearchException.class.php';
-require_once TRIPOD_DIR.'exceptions/TripodCardinalityException.class.php';
+require_once TRIPOD_DIR . 'exceptions/Exception.class.php';
+require_once TRIPOD_DIR . 'exceptions/SearchException.class.php';
+require_once TRIPOD_DIR . 'exceptions/CardinalityException.class.php';
+require_once TRIPOD_DIR . 'exceptions/ConfigException.class.php';
+require_once TRIPOD_DIR . 'exceptions/LabellerException.class.php';
+require_once TRIPOD_DIR . 'exceptions/ViewException.class.php';
 require_once TRIPOD_DIR.'mongo/MongoTripodConstants.php';
 require_once TRIPOD_DIR.'mongo/MongoGraph.class.php';
 require_once TRIPOD_DIR.'mongo/ImpactedSubject.class.php';
-require_once TRIPOD_DIR.'mongo/base/MongoTripodBase.class.php';
+require_once TRIPOD_DIR . 'mongo/base/TripodBase.class.php';
 require_once TRIPOD_DIR.'mongo/IComposite.php';
 require_once TRIPOD_DIR.'mongo/base/CompositeBase.class.php';
-require_once TRIPOD_DIR.'mongo/delegates/MongoTransactionLog.class.php';
-require_once TRIPOD_DIR.'mongo/delegates/MongoTripodUpdates.class.php';
-require_once TRIPOD_DIR.'mongo/delegates/MongoTripodViews.class.php';
-require_once TRIPOD_DIR.'mongo/delegates/MongoTripodTables.class.php';
-require_once TRIPOD_DIR.'mongo/delegates/MongoTripodSearchIndexer.class.php';
+require_once TRIPOD_DIR . 'mongo/delegates/TransactionLog.class.php';
+require_once TRIPOD_DIR . 'mongo/delegates/Updates.class.php';
+require_once TRIPOD_DIR . 'mongo/delegates/Views.class.php';
+require_once TRIPOD_DIR . 'mongo/delegates/Tables.class.php';
+require_once TRIPOD_DIR . 'mongo/delegates/SearchIndexer.class.php';
 require_once TRIPOD_DIR.'ITripod.php';
 require_once TRIPOD_DIR.'classes/ChangeSet.class.php';
-require_once TRIPOD_DIR.'/mongo/MongoTripod.class.php';
+require_once TRIPOD_DIR . '/mongo/Tripod.class.php';
 
 require_once TRIPOD_DIR.'/mongo/base/JobBase.class.php';
 require_once TRIPOD_DIR . '/mongo/jobs/DiscoverImpactedSubjects.class.php';
 require_once TRIPOD_DIR.'/mongo/jobs/ApplyOperation.class.php';
 
-Resque::setBackend(MongoTripodConfig::getResqueServer());
+Resque::setBackend(\Tripod\Mongo\Config::getResqueServer());
 
 define('RDF_TYPE', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type');
 define('RDF_SUBJECT', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#subject');

--- a/src/tripod.inc.php
+++ b/src/tripod.inc.php
@@ -21,7 +21,7 @@ require_once TRIPOD_DIR . 'exceptions/ViewException.class.php';
 require_once TRIPOD_DIR.'mongo/MongoTripodConstants.php';
 require_once TRIPOD_DIR.'mongo/MongoGraph.class.php';
 require_once TRIPOD_DIR.'mongo/ImpactedSubject.class.php';
-require_once TRIPOD_DIR . 'mongo/base/TripodBase.class.php';
+require_once TRIPOD_DIR . 'mongo/base/DriverBase.class.php';
 require_once TRIPOD_DIR.'mongo/IComposite.php';
 require_once TRIPOD_DIR.'mongo/base/CompositeBase.class.php';
 require_once TRIPOD_DIR . 'mongo/delegates/TransactionLog.class.php';
@@ -31,7 +31,7 @@ require_once TRIPOD_DIR . 'mongo/delegates/Tables.class.php';
 require_once TRIPOD_DIR . 'mongo/delegates/SearchIndexer.class.php';
 require_once TRIPOD_DIR.'ITripod.php';
 require_once TRIPOD_DIR.'classes/ChangeSet.class.php';
-require_once TRIPOD_DIR . '/mongo/Tripod.class.php';
+require_once TRIPOD_DIR . '/mongo/Driver.class.php';
 
 require_once TRIPOD_DIR.'/mongo/base/JobBase.class.php';
 require_once TRIPOD_DIR . '/mongo/jobs/DiscoverImpactedSubjects.class.php';

--- a/src/tripod.inc.php
+++ b/src/tripod.inc.php
@@ -29,7 +29,7 @@ require_once TRIPOD_DIR . 'mongo/delegates/Updates.class.php';
 require_once TRIPOD_DIR . 'mongo/delegates/Views.class.php';
 require_once TRIPOD_DIR . 'mongo/delegates/Tables.class.php';
 require_once TRIPOD_DIR . 'mongo/delegates/SearchIndexer.class.php';
-require_once TRIPOD_DIR.'ITripod.php';
+require_once TRIPOD_DIR . 'IDriver.php';
 require_once TRIPOD_DIR.'classes/ChangeSet.class.php';
 require_once TRIPOD_DIR . '/mongo/Driver.class.php';
 

--- a/test/locks/index.php
+++ b/test/locks/index.php
@@ -6,7 +6,8 @@ set_include_path(
 );
 
 require_once 'tripod.inc.php';
-require_once 'Tripod.class.phpquire_once 'Logger.php';
+require_once 'Driver.class.php';
+require_once 'Logger.php';
 
 
 $config = json_decode(file_get_contents('tripod-config.json'), true);

--- a/test/locks/index.php
+++ b/test/locks/index.php
@@ -6,12 +6,11 @@ set_include_path(
 );
 
 require_once 'tripod.inc.php';
-require_once 'MongoTripod.class.php';
-require_once 'Logger.php';
+require_once 'Tripod.class.phpquire_once 'Logger.php';
 
 
 $config = json_decode(file_get_contents('tripod-config.json'), true);
-MongoTripodConfig::setConfig($config);
+Config::setConfig($config);
 
 $tripod = new MongoTripod('CBD_nodes', 'life', array('retriesToGetLock' => 5000));
 MongoTripod::$logger = Logger::getLogger();

--- a/test/locks/testMultiDocUpdate.php
+++ b/test/locks/testMultiDocUpdate.php
@@ -10,14 +10,15 @@ set_include_path(
 );
 
 require_once 'tripod.inc.php';
-require_once 'Tripod.class.phpquire_once 'Logger.php';
+require_once 'Driver.class.php';
+require_once 'Logger.php';
 
 
 $config = json_decode(file_get_contents('tripod-config.json'), true);
-Config::setConfig($config);
+\Tripod\Mongo\Config::setConfig($config);
 
-$tripod = new MongoTripod('CBD_nodes', 'life', array('retriesToGetLock' => 5000));
-MongoTripod::$logger = Logger::getLogger();
+$tripod = new \Tripod\Mongo\Driver('CBD_nodes', 'life', array('retriesToGetLock' => 5000));
+\Tripod\Mongo\Driver::$logger = Logger::getLogger();
 
 $resources =array(
     "http://life.ac.uk/",
@@ -29,12 +30,12 @@ $resources =array(
 
 $g = $tripod->describeResources($resources);
 
-$oldGraph = new ExtendedGraph();
+$oldGraph = new \Tripod\ExtendedGraph();
 $oldGraph->from_graph($g);
 
 foreach($resources as $r){
     $g->add_literal_triple($r, 'http://purl.org/dc/terms/text', 'Time in micro-seconds : ' .microtime());
-    $g->add_literal_triple($r, 'http://purl.org/dc/terms/description', 'Testing concurrent multi doc update in Tripod');
+    $g->add_literal_triple($r, 'http://purl.org/dc/terms/description', 'Testing concurrent multi doc update in Driver');
 }
 
 try{

--- a/test/locks/testMultiDocUpdate.php
+++ b/test/locks/testMultiDocUpdate.php
@@ -10,12 +10,11 @@ set_include_path(
 );
 
 require_once 'tripod.inc.php';
-require_once 'MongoTripod.class.php';
-require_once 'Logger.php';
+require_once 'Tripod.class.phpquire_once 'Logger.php';
 
 
 $config = json_decode(file_get_contents('tripod-config.json'), true);
-MongoTripodConfig::setConfig($config);
+Config::setConfig($config);
 
 $tripod = new MongoTripod('CBD_nodes', 'life', array('retriesToGetLock' => 5000));
 MongoTripod::$logger = Logger::getLogger();

--- a/test/performance/MongoTripodConfigTest.php
+++ b/test/performance/MongoTripodConfigTest.php
@@ -6,11 +6,11 @@ set_include_path(
     . PATH_SEPARATOR . dirname(dirname(dirname(__FILE__))).'/src');
 
 require_once('tripod.inc.php');
-require_once TRIPOD_DIR.'mongo/MongoTripodConfig.class.php';
-require_once TRIPOD_DIR.'mongo/base/MongoTripodBase.class.php';
+require_once TRIPOD_DIR . 'mongo/Config.class.php';
+require_once TRIPOD_DIR . 'mongo/base/TripodBase.class.php';
 
 /**
- * A quick performance test to see what amount of time in consumed in specific methods of MongoTripodConfig class
+ * A quick performance test to see what amount of time in consumed in specific methods of Config class
  *
  * Class MongoTripodConfigTest
  */
@@ -60,7 +60,7 @@ class MongoTripodConfigTest extends PHPUnit_Framework_TestCase
      * Note: Current version of this test tried to create 1000 objects within 6000ms which is reasonable at this time.
      *       Any change to this class if make it a more a big number it should be validated and tested to ensure performance impact.
      *
-     * Create some instances of TripodConfig to see what amount of time is taken in creating instance and processing in constructor.
+     * Create some instances of Config to see what amount of time is taken in creating instance and processing in constructor.
      */
     public function testCreateMongoTripodConfigObject()
     {
@@ -68,15 +68,15 @@ class MongoTripodConfigTest extends PHPUnit_Framework_TestCase
 
         //Let's try to create 1000 objects to see how much time they take.
         for($i =0; $i < self::BENCHMARK_OBJECT_CREATE_ITERATIONS; $i++) {
-            MongoTripodConfig::setConfig($this->config);
-            $instance = MongoTripodConfig::getInstance();
+            \Tripod\Mongo\Config::setConfig($this->config);
+            $instance = \Tripod\Mongo\Config::getInstance();
         }
 
         $testEndTime = microtime();
         $this->assertLessThan(
             self::BENCHMARK_OBJECT_CREATE_TIME,
             $this->getTimeDifference($testStartTime, $testEndTime),
-            "It should always take less than " . self::BENCHMARK_OBJECT_CREATE_TIME . "ms to create " . self::BENCHMARK_OBJECT_CREATE_ITERATIONS . " objects of MongoTripodConfig class"
+            "It should always take less than " . self::BENCHMARK_OBJECT_CREATE_TIME . "ms to create " . self::BENCHMARK_OBJECT_CREATE_ITERATIONS . " objects of Config class"
         );
     }
 

--- a/test/performance/MongoTripodConfigTest.php
+++ b/test/performance/MongoTripodConfigTest.php
@@ -7,7 +7,7 @@ set_include_path(
 
 require_once('tripod.inc.php');
 require_once TRIPOD_DIR . 'mongo/Config.class.php';
-require_once TRIPOD_DIR . 'mongo/base/TripodBase.class.php';
+require_once TRIPOD_DIR . 'mongo/base/DriverBase.class.php';
 
 /**
  * A quick performance test to see what amount of time in consumed in specific methods of Config class

--- a/test/performance/rest-interface/index.php
+++ b/test/performance/rest-interface/index.php
@@ -31,14 +31,14 @@ $app->group('/1', function() use ($app) {
     {
         $app->get('/views/:viewId/:encodedFqUri', function($storeName, $viewSpecId, $encodedFqUri) use ($app)
         {
-            MongoTripodConfig::setConfig(json_decode(file_get_contents('./config/tripod-config-'.$storeName .'.json'), true));
+            \Tripod\Mongo\Config::setConfig(json_decode(file_get_contents('./config/tripod-config-'.$storeName .'.json'), true));
             $i = 0;
             do
             {
-                $viewSpec = MongoTripodConfig::getInstance()->getViewSpecification($storeName, $viewSpecId);
+                $viewSpec = \Tripod\Mongo\Config::getInstance()->getViewSpecification($storeName, $viewSpecId);
                 if(!$viewSpec)
                 {
-                    $viewSpec = MongoTripodConfig::getInstance()->getViewSpecification($viewSpecId);
+                    $viewSpec = \Tripod\Mongo\Config::getInstance()->getViewSpecification($viewSpecId);
                 }
                 $podName = isset($viewSpec['from']) ? $viewSpec['from'] : null;
                 $tripodOptions['stat'] = getStat($app);
@@ -75,7 +75,7 @@ $app->group('/1', function() use ($app) {
         {
             $app->group('/graph', function() use ($app) {
                 $app->get('/:encodedFqUri', function($storeName, $podName, $encodedFqUri) use ($app) {
-                    MongoTripodConfig::setConfig(json_decode(file_get_contents('./config/tripod-config-'.$storeName .'.json'), true));
+                    \Tripod\Mongo\Config::setConfig(json_decode(file_get_contents('./config/tripod-config-'.$storeName .'.json'), true));
                     $tripodOptions['stat'] = getStat($app);
 
                     $contentType = $app->request()->getMediaType();
@@ -133,7 +133,7 @@ $app->group('/1', function() use ($app) {
 
             $app->group('/change', function() use ($app) {
                 $app->post('/', function($storeName, $podName) use ($app) {
-                  MongoTripodConfig::setConfig(json_decode(file_get_contents('./config/tripod-config-'.$storeName .'.json'), true));
+                  \Tripod\Mongo\Config::setConfig(json_decode(file_get_contents('./config/tripod-config-'.$storeName .'.json'), true));
                     $app->response()->setStatus(500);
                     $tripodOptions['stat'] = getStat($app);
                     $tripod = new MongoTripod($podName, $storeName, $tripodOptions);

--- a/test/performance/rest-interface/src/Stat.class.php
+++ b/test/performance/rest-interface/src/Stat.class.php
@@ -46,7 +46,7 @@ class Stat implements ITripodStat {
          * 2. a) If you get so many error emails for invalid duration, there should be time difference between servers causing this,
          *    b) Time difference on servers can be an issue with items being processed queue processor,
          *       where start time is captured on server intercepting user request, end time is captured on server running queue processor.
-         * 3. $duration will be 0 for some cases with MongoTripod::select queries where you do count or records does not exists or same query is repeated more than once in single request.
+         * 3. $duration will be 0 for some cases with Tripod::select queries where you do count or records does not exists or same query is repeated more than once in single request.
          */
         if($duration < 0) {
             $this->errorLog(

--- a/test/performance/rest-interface/src/Stat.class.php
+++ b/test/performance/rest-interface/src/Stat.class.php
@@ -46,7 +46,7 @@ class Stat implements ITripodStat {
          * 2. a) If you get so many error emails for invalid duration, there should be time difference between servers causing this,
          *    b) Time difference on servers can be an issue with items being processed queue processor,
          *       where start time is captured on server intercepting user request, end time is captured on server running queue processor.
-         * 3. $duration will be 0 for some cases with Tripod::select queries where you do count or records does not exists or same query is repeated more than once in single request.
+         * 3. $duration will be 0 for some cases with Driver::select queries where you do count or records does not exists or same query is repeated more than once in single request.
          */
         if($duration < 0) {
             $this->errorLog(

--- a/test/performance/rest-interface/utils/queueStats.inc.php
+++ b/test/performance/rest-interface/utils/queueStats.inc.php
@@ -7,7 +7,7 @@ if(!(isset($queueOptions['host']) && isset($queueOptions['port']) && isset($queu
     throw new InvalidArgumentException("Must include 'host', 'port', and 'env'");
 }
 require_once dirname(dirname(__FILE__)) . '/src/Stat.class.php';
-$qConfig = MongoTripodConfig::getInstance()->getQueueConfig();
+$qConfig = \Tripod\Mongo\Config::getInstance()->getQueueConfig();
 StatConfig::setConfig(array('host'=>$queueOptions['host'],'port'=>$queueOptions['port']));
 $stat = new Stat($qConfig['database']);
 $stat->setStatEnvName($queueOptions['env']);

--- a/test/unit/ExtendedGraphTest.php
+++ b/test/unit/ExtendedGraphTest.php
@@ -7,7 +7,9 @@ set_include_path(
 
 require_once('tripod.inc.php');
 require_once 'src/classes/ExtendedGraph.class.php';
-require_once 'src/exceptions/TripodException.class.php';
+require_once 'src/exceptions/Exception.class.php';
+
+use \Tripod\ExtendedGraph;
 
 class ExtendedGraphTest extends PHPUnit_Framework_TestCase
 {
@@ -342,7 +344,7 @@ class ExtendedGraphTest extends PHPUnit_Framework_TestCase
 
     public function testGetLabelForUriLabelPropsNotInitialised(){
     	ExtendedGraph::initProperties(array('labelProperties' => null));
-        $this->setExpectedException('TripodException','Please initialise ExtendedGraph::$labelProperties');
+        $this->setExpectedException('Exception','Please initialise ExtendedGraph::$labelProperties');
         $graph = new ExtendedGraph();
 
         $label = "Wuthering Heights";

--- a/test/unit/TimerTest.php
+++ b/test/unit/TimerTest.php
@@ -7,6 +7,8 @@ set_include_path(
 
 require_once 'src/classes/Timer.class.php';
 
+use \Tripod\Timer;
+
 class TimerTest extends PHPUnit_Framework_TestCase
 {
     protected function setUp()

--- a/test/unit/mongo/ApplyOperationTest.php
+++ b/test/unit/mongo/ApplyOperationTest.php
@@ -13,9 +13,9 @@ class ApplyOperationTest extends MongoTripodTestBase
     {
         $this->setArgs();
         unset($this->args['tripodConfig']);
-        $job = new \Tripod\Mongo\ApplyOperation();
+        $job = new \Tripod\Mongo\Jobs\ApplyOperation();
         $job->args = $this->args;
-        $this->setExpectedException('Exception', "Argument tripodConfig was not present in supplied job args for job Tripod\Mongo\ApplyOperation");
+        $this->setExpectedException('Exception', "Argument tripodConfig was not present in supplied job args for job Tripod\Mongo\Jobs\ApplyOperation");
         $job->perform();
     }
 
@@ -23,16 +23,16 @@ class ApplyOperationTest extends MongoTripodTestBase
     {
         $this->setArgs();
         unset($this->args['subject']);
-        $job = new \Tripod\Mongo\ApplyOperation();
+        $job = new \Tripod\Mongo\Jobs\ApplyOperation();
         $job->args = $this->args;
-        $this->setExpectedException('Exception', "Argument subject was not present in supplied job args for job Tripod\Mongo\ApplyOperation");
+        $this->setExpectedException('Exception', "Argument subject was not present in supplied job args for job Tripod\Mongo\Jobs\ApplyOperation");
         $job->perform();
     }
 
     public function testApplyViewOperation()
     {
         $this->setArgs();
-        $applyOperation = $this->getMockBuilder('\Tripod\Mongo\ApplyOperation')
+        $applyOperation = $this->getMockBuilder('\Tripod\Mongo\Jobs\ApplyOperation')
             ->setMethods(array('createImpactedSubject'))
             ->getMock();
 
@@ -52,12 +52,12 @@ class ApplyOperationTest extends MongoTripodTestBase
                 )
             )->getMock();
 
-        $tripod = $this->getMockBuilder('\Tripod\Mongo\Tripod')
+        $tripod = $this->getMockBuilder('\Tripod\Mongo\Driver')
             ->setMethods(array('getComposite'))
             ->setConstructorArgs(array('CBD_testing', 'tripod_php_testing'))
             ->getMock();
 
-        $views = $this->getMockBuilder('\Tripod\Mongo\Views')
+        $views = $this->getMockBuilder('\Tripod\Mongo\Composites\Views')
             ->setMethods(array('update'))
             ->setConstructorArgs(array(
                 'tripod_php_testing',
@@ -88,7 +88,7 @@ class ApplyOperationTest extends MongoTripodTestBase
     public function testApplyTableOperation()
     {
         $this->setArgs();
-        $applyOperation = $this->getMockBuilder('\Tripod\Mongo\ApplyOperation')
+        $applyOperation = $this->getMockBuilder('\Tripod\Mongo\Jobs\ApplyOperation')
             ->setMethods(array('createImpactedSubject'))
             ->getMock();
 
@@ -121,12 +121,12 @@ class ApplyOperationTest extends MongoTripodTestBase
                 )
             )->getMock();
 
-        $tripod = $this->getMockBuilder('\Tripod\Mongo\Tripod')
+        $tripod = $this->getMockBuilder('\Tripod\Mongo\Driver')
             ->setMethods(array('getComposite'))
             ->setConstructorArgs(array('CBD_testing', 'tripod_php_testing'))
             ->getMock();
 
-        $tables = $this->getMockBuilder('\Tripod\Mongo\Tables')
+        $tables = $this->getMockBuilder('\Tripod\Mongo\Composites\Tables')
             ->setMethods(array('update'))
             ->setConstructorArgs(array(
                 'tripod_php_testing',
@@ -157,7 +157,7 @@ class ApplyOperationTest extends MongoTripodTestBase
     public function testApplySearchOperation()
     {
         $this->setArgs();
-        $applyOperation = $this->getMockBuilder('\Tripod\Mongo\ApplyOperation')
+        $applyOperation = $this->getMockBuilder('\Tripod\Mongo\Jobs\ApplyOperation')
             ->setMethods(array('createImpactedSubject'))
             ->getMock();
 
@@ -190,12 +190,12 @@ class ApplyOperationTest extends MongoTripodTestBase
                 )
             )->getMock();
 
-        $tripod = $this->getMockBuilder('\Tripod\Mongo\Tripod')
+        $tripod = $this->getMockBuilder('\Tripod\Mongo\Driver')
             ->setMethods(array('getComposite'))
             ->setConstructorArgs(array('CBD_testing', 'tripod_php_testing'))
             ->getMock();
 
-        $search = $this->getMockBuilder('\Tripod\Mongo\SearchIndexer')
+        $search = $this->getMockBuilder('\Tripod\Mongo\Composites\SearchIndexer')
             ->setMethods(array('update'))
             ->setConstructorArgs(array($tripod))
             ->getMock();

--- a/test/unit/mongo/ApplyOperationTest.php
+++ b/test/unit/mongo/ApplyOperationTest.php
@@ -2,9 +2,9 @@
 
 require_once 'MongoTripodTestBase.php';
 
-use \Tripod\Mongo\ApplyOperation;
-use \Tripod\Mongo\ImpactedSubject;
-
+/**
+ * Class ApplyOperationTest
+ */
 class ApplyOperationTest extends MongoTripodTestBase
 {
     protected $args = array();
@@ -13,9 +13,9 @@ class ApplyOperationTest extends MongoTripodTestBase
     {
         $this->setArgs();
         unset($this->args['tripodConfig']);
-        $job = new ApplyOperation();
+        $job = new \Tripod\Mongo\ApplyOperation();
         $job->args = $this->args;
-        $this->setExpectedException('Exception', "Argument tripodConfig was not present in supplied job args for job ApplyOperation");
+        $this->setExpectedException('Exception', "Argument tripodConfig was not present in supplied job args for job Tripod\Mongo\ApplyOperation");
         $job->perform();
     }
 
@@ -23,22 +23,22 @@ class ApplyOperationTest extends MongoTripodTestBase
     {
         $this->setArgs();
         unset($this->args['subject']);
-        $job = new ApplyOperation();
+        $job = new \Tripod\Mongo\ApplyOperation();
         $job->args = $this->args;
-        $this->setExpectedException('Exception', "Argument subject was not present in supplied job args for job ApplyOperation");
+        $this->setExpectedException('Exception', "Argument subject was not present in supplied job args for job Tripod\Mongo\ApplyOperation");
         $job->perform();
     }
 
     public function testApplyViewOperation()
     {
         $this->setArgs();
-        $applyOperation = $this->getMockBuilder('ApplyOperation')
+        $applyOperation = $this->getMockBuilder('\Tripod\Mongo\ApplyOperation')
             ->setMethods(array('createImpactedSubject'))
             ->getMock();
 
         $applyOperation->args = $this->args;
 
-        $subject = $this->getMockBuilder('ImpactedSubject')
+        $subject = $this->getMockBuilder('\Tripod\Mongo\ImpactedSubject')
             ->setMethods(array('getTripod'))
             ->setConstructorArgs(
                 array(
@@ -52,12 +52,12 @@ class ApplyOperationTest extends MongoTripodTestBase
                 )
             )->getMock();
 
-        $tripod = $this->getMockBuilder('Tripod')
+        $tripod = $this->getMockBuilder('\Tripod\Mongo\Tripod')
             ->setMethods(array('getComposite'))
             ->setConstructorArgs(array('CBD_testing', 'tripod_php_testing'))
             ->getMock();
 
-        $views = $this->getMockBuilder('Views')
+        $views = $this->getMockBuilder('\Tripod\Mongo\Views')
             ->setMethods(array('update'))
             ->setConstructorArgs(array(
                 'tripod_php_testing',
@@ -88,12 +88,12 @@ class ApplyOperationTest extends MongoTripodTestBase
     public function testApplyTableOperation()
     {
         $this->setArgs();
-        $applyOperation = $this->getMockBuilder('ApplyOperation')
+        $applyOperation = $this->getMockBuilder('\Tripod\Mongo\ApplyOperation')
             ->setMethods(array('createImpactedSubject'))
             ->getMock();
 
         $this->setArgs();
-        $impactedSubject = new ImpactedSubject(
+        $impactedSubject = new \Tripod\Mongo\ImpactedSubject(
             array(
                 _ID_RESOURCE=>'http://example.com/resources/foo',
                 _ID_CONTEXT=>'http://talisaspire.com/'
@@ -107,7 +107,7 @@ class ApplyOperationTest extends MongoTripodTestBase
 
         $applyOperation->args = $this->args;
 
-        $subject = $this->getMockBuilder('ImpactedSubject')
+        $subject = $this->getMockBuilder('\Tripod\Mongo\ImpactedSubject')
             ->setMethods(array('getTripod'))
             ->setConstructorArgs(
                 array(
@@ -121,12 +121,12 @@ class ApplyOperationTest extends MongoTripodTestBase
                 )
             )->getMock();
 
-        $tripod = $this->getMockBuilder('Tripod')
+        $tripod = $this->getMockBuilder('\Tripod\Mongo\Tripod')
             ->setMethods(array('getComposite'))
             ->setConstructorArgs(array('CBD_testing', 'tripod_php_testing'))
             ->getMock();
 
-        $tables = $this->getMockBuilder('Tables')
+        $tables = $this->getMockBuilder('\Tripod\Mongo\Tables')
             ->setMethods(array('update'))
             ->setConstructorArgs(array(
                 'tripod_php_testing',
@@ -157,12 +157,12 @@ class ApplyOperationTest extends MongoTripodTestBase
     public function testApplySearchOperation()
     {
         $this->setArgs();
-        $applyOperation = $this->getMockBuilder('ApplyOperation')
+        $applyOperation = $this->getMockBuilder('\Tripod\Mongo\ApplyOperation')
             ->setMethods(array('createImpactedSubject'))
             ->getMock();
 
         $this->setArgs();
-        $impactedSubject = new ImpactedSubject(
+        $impactedSubject = new \Tripod\Mongo\ImpactedSubject(
             array(
                 _ID_RESOURCE=>'http://example.com/resources/foo',
                 _ID_CONTEXT=>'http://talisaspire.com/'
@@ -176,7 +176,7 @@ class ApplyOperationTest extends MongoTripodTestBase
 
         $applyOperation->args = $this->args;
 
-        $subject = $this->getMockBuilder('ImpactedSubject')
+        $subject = $this->getMockBuilder('\Tripod\Mongo\ImpactedSubject')
             ->setMethods(array('getTripod'))
             ->setConstructorArgs(
                 array(
@@ -190,12 +190,12 @@ class ApplyOperationTest extends MongoTripodTestBase
                 )
             )->getMock();
 
-        $tripod = $this->getMockBuilder('Tripod')
+        $tripod = $this->getMockBuilder('\Tripod\Mongo\Tripod')
             ->setMethods(array('getComposite'))
             ->setConstructorArgs(array('CBD_testing', 'tripod_php_testing'))
             ->getMock();
 
-        $search = $this->getMockBuilder('SearchIndexer')
+        $search = $this->getMockBuilder('\Tripod\Mongo\SearchIndexer')
             ->setMethods(array('update'))
             ->setConstructorArgs(array($tripod))
             ->getMock();
@@ -222,7 +222,7 @@ class ApplyOperationTest extends MongoTripodTestBase
 
     protected function setArgs()
     {
-        $subject = new ImpactedSubject(
+        $subject = new \Tripod\Mongo\ImpactedSubject(
             array(
                 _ID_RESOURCE=>'http://example.com/resources/foo',
                 _ID_CONTEXT=>'http://talisaspire.com/'

--- a/test/unit/mongo/ApplyOperationTest.php
+++ b/test/unit/mongo/ApplyOperationTest.php
@@ -2,6 +2,9 @@
 
 require_once 'MongoTripodTestBase.php';
 
+use \Tripod\Mongo\ApplyOperation;
+use \Tripod\Mongo\ImpactedSubject;
+
 class ApplyOperationTest extends MongoTripodTestBase
 {
     protected $args = array();
@@ -49,16 +52,16 @@ class ApplyOperationTest extends MongoTripodTestBase
                 )
             )->getMock();
 
-        $tripod = $this->getMockBuilder('MongoTripod')
+        $tripod = $this->getMockBuilder('Tripod')
             ->setMethods(array('getComposite'))
             ->setConstructorArgs(array('CBD_testing', 'tripod_php_testing'))
             ->getMock();
 
-        $views = $this->getMockBuilder('MongoTripodViews')
+        $views = $this->getMockBuilder('Views')
             ->setMethods(array('update'))
             ->setConstructorArgs(array(
                 'tripod_php_testing',
-                MongoTripodConfig::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing'),
+                \Tripod\Mongo\Config::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing'),
                 'http://talisapire.com/'
             ))->getMock();
 
@@ -118,16 +121,16 @@ class ApplyOperationTest extends MongoTripodTestBase
                 )
             )->getMock();
 
-        $tripod = $this->getMockBuilder('MongoTripod')
+        $tripod = $this->getMockBuilder('Tripod')
             ->setMethods(array('getComposite'))
             ->setConstructorArgs(array('CBD_testing', 'tripod_php_testing'))
             ->getMock();
 
-        $tables = $this->getMockBuilder('MongoTripodTables')
+        $tables = $this->getMockBuilder('Tables')
             ->setMethods(array('update'))
             ->setConstructorArgs(array(
                 'tripod_php_testing',
-                MongoTripodConfig::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing'),
+                \Tripod\Mongo\Config::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing'),
                 'http://talisapire.com/'
             ))->getMock();
 
@@ -187,12 +190,12 @@ class ApplyOperationTest extends MongoTripodTestBase
                 )
             )->getMock();
 
-        $tripod = $this->getMockBuilder('MongoTripod')
+        $tripod = $this->getMockBuilder('Tripod')
             ->setMethods(array('getComposite'))
             ->setConstructorArgs(array('CBD_testing', 'tripod_php_testing'))
             ->getMock();
 
-        $search = $this->getMockBuilder('MongoTripodSearchIndexer')
+        $search = $this->getMockBuilder('SearchIndexer')
             ->setMethods(array('update'))
             ->setConstructorArgs(array($tripod))
             ->getMock();
@@ -230,7 +233,7 @@ class ApplyOperationTest extends MongoTripodTestBase
         );
 
         $this->args = array(
-            'tripodConfig'=>MongoTripodConfig::getConfig(),
+            'tripodConfig'=>\Tripod\Mongo\Config::getConfig(),
             'subject'=>$subject->toArray()
         );
     }

--- a/test/unit/mongo/DiscoverImpactedSubjectsTest.php
+++ b/test/unit/mongo/DiscoverImpactedSubjectsTest.php
@@ -110,11 +110,11 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
             ));
 
         $discoverImpactedSubjects = $this->getMockBuilder('\Tripod\Mongo\DiscoverImpactedSubjects')
-            ->setMethods(array('getMongoTripod', 'submitJob'))
+            ->setMethods(array('getTripod', 'submitJob'))
             ->getMock();
 
         $discoverImpactedSubjects->expects($this->once())
-            ->method('getMongoTripod')
+            ->method('getTripod')
             ->will($this->returnValue($tripod));
 
         $discoverImpactedSubjects->args = $this->args;

--- a/test/unit/mongo/DiscoverImpactedSubjectsTest.php
+++ b/test/unit/mongo/DiscoverImpactedSubjectsTest.php
@@ -2,6 +2,9 @@
 
 require_once 'MongoTripodTestBase.php';
 
+use \Tripod\Mongo\DiscoverImpactedSubjects;
+use \Tripod\Mongo\ImpactedSubject;
+
 class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
 {
     protected $args = array();
@@ -69,32 +72,32 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
     {
         $this->setArgs();
 
-        $tripod = $this->getMockBuilder('MongoTripod')
+        $tripod = $this->getMockBuilder('Tripod')
             ->setMethods(array('getComposite'))
             ->setConstructorArgs(array('CBD_testing', 'tripod_php_testing'))
             ->getMock();
 
-        $views = $this->getMockBuilder('MongoTripodViews')
+        $views = $this->getMockBuilder('Views')
             ->setMethods(array('getImpactedSubjects'))
             ->setConstructorArgs(
                 array(
                     'tripod_php_testing',
-                    MongoTripodConfig::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing'),
+                    \Tripod\Mongo\Config::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing'),
                     'http://talisaspire.com/'
                 )
             )->getMock();
 
-        $tables = $this->getMockBuilder('MongoTripodTables')
+        $tables = $this->getMockBuilder('Tables')
             ->setMethods(array('getImpactedSubjects'))
             ->setConstructorArgs(
                 array(
                     'tripod_php_testing',
-                    MongoTripodConfig::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing'),
+                    \Tripod\Mongo\Config::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing'),
                     'http://talisaspire.com/'
                 )
             )->getMock();
 
-        $search = $this->getMockBuilder('MongoTripodSearchIndexer')
+        $search = $this->getMockBuilder('SearchIndexer')
             ->setMethods(array('getImpactedSubjects'))
             ->setConstructorArgs(array($tripod))
             ->getMock();
@@ -163,7 +166,7 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
             ->method('submitJob')
             ->withConsecutive(
                 array(
-                    MongoTripodConfig::getApplyQueueName(),
+                    \Tripod\Mongo\Config::getApplyQueueName(),
                     "ApplyOperation",
                     array(
                         "subject"=>$viewSubject->toArray(),
@@ -171,7 +174,7 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
                     )
                 ),
                 array(
-                    MongoTripodConfig::getApplyQueueName(),
+                    \Tripod\Mongo\Config::getApplyQueueName(),
                     "ApplyOperation",
                     array(
                         "subject"=>$tableSubject->toArray(),
@@ -186,7 +189,7 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
     protected function setArgs()
     {
         $this->args = array(
-            'tripodConfig'=>MongoTripodConfig::getConfig(),
+            'tripodConfig'=>\Tripod\Mongo\Config::getConfig(),
             'storeName'=>'tripod_php_testing',
             'podName'=>'CBD_testing',
             'changes'=>array('http://example.com/resources/foo'=>array('rdf:type','dct:title')),

--- a/test/unit/mongo/DiscoverImpactedSubjectsTest.php
+++ b/test/unit/mongo/DiscoverImpactedSubjectsTest.php
@@ -9,9 +9,9 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
     {
         $this->setArgs();
         unset($this->args['tripodConfig']);
-        $job = new \Tripod\Mongo\DiscoverImpactedSubjects();
+        $job = new \Tripod\Mongo\Jobs\DiscoverImpactedSubjects();
         $job->args = $this->args;
-        $this->setExpectedException('Exception', "Argument tripodConfig was not present in supplied job args for job Tripod\Mongo\DiscoverImpactedSubjects");
+        $this->setExpectedException('Exception', "Argument tripodConfig was not present in supplied job args for job Tripod\Mongo\Jobs\DiscoverImpactedSubjects");
         $job->perform();
     }
 
@@ -19,9 +19,9 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
     {
         $this->setArgs();
         unset($this->args['storeName']);
-        $job = new \Tripod\Mongo\DiscoverImpactedSubjects();
+        $job = new \Tripod\Mongo\Jobs\DiscoverImpactedSubjects();
         $job->args = $this->args;
-        $this->setExpectedException('Exception', "Argument storeName was not present in supplied job args for job Tripod\Mongo\DiscoverImpactedSubjects");
+        $this->setExpectedException('Exception', "Argument storeName was not present in supplied job args for job Tripod\Mongo\Jobs\DiscoverImpactedSubjects");
         $job->perform();
     }
 
@@ -29,9 +29,9 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
     {
         $this->setArgs();
         unset($this->args['podName']);
-        $job = new \Tripod\Mongo\DiscoverImpactedSubjects();
+        $job = new \Tripod\Mongo\Jobs\DiscoverImpactedSubjects();
         $job->args = $this->args;
-        $this->setExpectedException('Exception', "Argument podName was not present in supplied job args for job Tripod\Mongo\DiscoverImpactedSubjects");
+        $this->setExpectedException('Exception', "Argument podName was not present in supplied job args for job Tripod\Mongo\Jobs\DiscoverImpactedSubjects");
         $job->perform();
     }
 
@@ -39,9 +39,9 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
     {
         $this->setArgs();
         unset($this->args['changes']);
-        $job = new \Tripod\Mongo\DiscoverImpactedSubjects();
+        $job = new \Tripod\Mongo\Jobs\DiscoverImpactedSubjects();
         $job->args = $this->args;
-        $this->setExpectedException('Exception', "Argument changes was not present in supplied job args for job Tripod\Mongo\DiscoverImpactedSubjects");
+        $this->setExpectedException('Exception', "Argument changes was not present in supplied job args for job Tripod\Mongo\Jobs\DiscoverImpactedSubjects");
         $job->perform();
     }
 
@@ -49,9 +49,9 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
     {
         $this->setArgs();
         unset($this->args['operations']);
-        $job = new \Tripod\Mongo\DiscoverImpactedSubjects();
+        $job = new \Tripod\Mongo\Jobs\DiscoverImpactedSubjects();
         $job->args = $this->args;
-        $this->setExpectedException('Exception', "Argument operations was not present in supplied job args for job Tripod\Mongo\DiscoverImpactedSubjects");
+        $this->setExpectedException('Exception', "Argument operations was not present in supplied job args for job Tripod\Mongo\Jobs\DiscoverImpactedSubjects");
         $job->perform();
     }
 
@@ -59,9 +59,9 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
     {
         $this->setArgs();
         unset($this->args['contextAlias']);
-        $job = new \Tripod\Mongo\DiscoverImpactedSubjects();
+        $job = new \Tripod\Mongo\Jobs\DiscoverImpactedSubjects();
         $job->args = $this->args;
-        $this->setExpectedException('Exception', "Argument contextAlias was not present in supplied job args for job Tripod\Mongo\DiscoverImpactedSubjects");
+        $this->setExpectedException('Exception', "Argument contextAlias was not present in supplied job args for job Tripod\Mongo\Jobs\DiscoverImpactedSubjects");
         $job->perform();
     }
 
@@ -69,12 +69,12 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
     {
         $this->setArgs();
 
-        $tripod = $this->getMockBuilder('\Tripod\Mongo\Tripod')
+        $tripod = $this->getMockBuilder('\Tripod\Mongo\Driver')
             ->setMethods(array('getComposite'))
             ->setConstructorArgs(array('CBD_testing', 'tripod_php_testing'))
             ->getMock();
 
-        $views = $this->getMockBuilder('\Tripod\Mongo\Views')
+        $views = $this->getMockBuilder('\Tripod\Mongo\Composites\Views')
             ->setMethods(array('getImpactedSubjects'))
             ->setConstructorArgs(
                 array(
@@ -84,7 +84,7 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
                 )
             )->getMock();
 
-        $tables = $this->getMockBuilder('\Tripod\Mongo\Tables')
+        $tables = $this->getMockBuilder('\Tripod\Mongo\Composites\Tables')
             ->setMethods(array('getImpactedSubjects'))
             ->setConstructorArgs(
                 array(
@@ -94,7 +94,7 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
                 )
             )->getMock();
 
-        $search = $this->getMockBuilder('\Tripod\Mongo\SearchIndexer')
+        $search = $this->getMockBuilder('\Tripod\Mongo\Composites\SearchIndexer')
             ->setMethods(array('getImpactedSubjects'))
             ->setConstructorArgs(array($tripod))
             ->getMock();
@@ -109,7 +109,7 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
                 )
             ));
 
-        $discoverImpactedSubjects = $this->getMockBuilder('\Tripod\Mongo\DiscoverImpactedSubjects')
+        $discoverImpactedSubjects = $this->getMockBuilder('\Tripod\Mongo\Jobs\DiscoverImpactedSubjects')
             ->setMethods(array('getTripod', 'submitJob'))
             ->getMock();
 
@@ -164,7 +164,7 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
             ->withConsecutive(
                 array(
                     \Tripod\Mongo\Config::getApplyQueueName(),
-                    "\Tripod\Mongo\ApplyOperation",
+                    "\Tripod\Mongo\Jobs\ApplyOperation",
                     array(
                         "subject"=>$viewSubject->toArray(),
                         "tripodConfig"=>$this->args['tripodConfig']
@@ -172,7 +172,7 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
                 ),
                 array(
                     \Tripod\Mongo\Config::getApplyQueueName(),
-                    "\Tripod\Mongo\ApplyOperation",
+                    "\Tripod\Mongo\Jobs\ApplyOperation",
                     array(
                         "subject"=>$tableSubject->toArray(),
                         "tripodConfig"=>$this->args['tripodConfig']

--- a/test/unit/mongo/DiscoverImpactedSubjectsTest.php
+++ b/test/unit/mongo/DiscoverImpactedSubjectsTest.php
@@ -2,9 +2,6 @@
 
 require_once 'MongoTripodTestBase.php';
 
-use \Tripod\Mongo\DiscoverImpactedSubjects;
-use \Tripod\Mongo\ImpactedSubject;
-
 class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
 {
     protected $args = array();
@@ -12,9 +9,9 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
     {
         $this->setArgs();
         unset($this->args['tripodConfig']);
-        $job = new DiscoverImpactedSubjects();
+        $job = new \Tripod\Mongo\DiscoverImpactedSubjects();
         $job->args = $this->args;
-        $this->setExpectedException('Exception', "Argument tripodConfig was not present in supplied job args for job DiscoverImpactedSubjects");
+        $this->setExpectedException('Exception', "Argument tripodConfig was not present in supplied job args for job Tripod\Mongo\DiscoverImpactedSubjects");
         $job->perform();
     }
 
@@ -22,9 +19,9 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
     {
         $this->setArgs();
         unset($this->args['storeName']);
-        $job = new DiscoverImpactedSubjects();
+        $job = new \Tripod\Mongo\DiscoverImpactedSubjects();
         $job->args = $this->args;
-        $this->setExpectedException('Exception', "Argument storeName was not present in supplied job args for job DiscoverImpactedSubjects");
+        $this->setExpectedException('Exception', "Argument storeName was not present in supplied job args for job Tripod\Mongo\DiscoverImpactedSubjects");
         $job->perform();
     }
 
@@ -32,9 +29,9 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
     {
         $this->setArgs();
         unset($this->args['podName']);
-        $job = new DiscoverImpactedSubjects();
+        $job = new \Tripod\Mongo\DiscoverImpactedSubjects();
         $job->args = $this->args;
-        $this->setExpectedException('Exception', "Argument podName was not present in supplied job args for job DiscoverImpactedSubjects");
+        $this->setExpectedException('Exception', "Argument podName was not present in supplied job args for job Tripod\Mongo\DiscoverImpactedSubjects");
         $job->perform();
     }
 
@@ -42,9 +39,9 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
     {
         $this->setArgs();
         unset($this->args['changes']);
-        $job = new DiscoverImpactedSubjects();
+        $job = new \Tripod\Mongo\DiscoverImpactedSubjects();
         $job->args = $this->args;
-        $this->setExpectedException('Exception', "Argument changes was not present in supplied job args for job DiscoverImpactedSubjects");
+        $this->setExpectedException('Exception', "Argument changes was not present in supplied job args for job Tripod\Mongo\DiscoverImpactedSubjects");
         $job->perform();
     }
 
@@ -52,9 +49,9 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
     {
         $this->setArgs();
         unset($this->args['operations']);
-        $job = new DiscoverImpactedSubjects();
+        $job = new \Tripod\Mongo\DiscoverImpactedSubjects();
         $job->args = $this->args;
-        $this->setExpectedException('Exception', "Argument operations was not present in supplied job args for job DiscoverImpactedSubjects");
+        $this->setExpectedException('Exception', "Argument operations was not present in supplied job args for job Tripod\Mongo\DiscoverImpactedSubjects");
         $job->perform();
     }
 
@@ -62,9 +59,9 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
     {
         $this->setArgs();
         unset($this->args['contextAlias']);
-        $job = new DiscoverImpactedSubjects();
+        $job = new \Tripod\Mongo\DiscoverImpactedSubjects();
         $job->args = $this->args;
-        $this->setExpectedException('Exception', "Argument contextAlias was not present in supplied job args for job DiscoverImpactedSubjects");
+        $this->setExpectedException('Exception', "Argument contextAlias was not present in supplied job args for job Tripod\Mongo\DiscoverImpactedSubjects");
         $job->perform();
     }
 
@@ -72,12 +69,12 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
     {
         $this->setArgs();
 
-        $tripod = $this->getMockBuilder('Tripod')
+        $tripod = $this->getMockBuilder('\Tripod\Mongo\Tripod')
             ->setMethods(array('getComposite'))
             ->setConstructorArgs(array('CBD_testing', 'tripod_php_testing'))
             ->getMock();
 
-        $views = $this->getMockBuilder('Views')
+        $views = $this->getMockBuilder('\Tripod\Mongo\Views')
             ->setMethods(array('getImpactedSubjects'))
             ->setConstructorArgs(
                 array(
@@ -87,7 +84,7 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
                 )
             )->getMock();
 
-        $tables = $this->getMockBuilder('Tables')
+        $tables = $this->getMockBuilder('\Tripod\Mongo\Tables')
             ->setMethods(array('getImpactedSubjects'))
             ->setConstructorArgs(
                 array(
@@ -97,7 +94,7 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
                 )
             )->getMock();
 
-        $search = $this->getMockBuilder('SearchIndexer')
+        $search = $this->getMockBuilder('\Tripod\Mongo\SearchIndexer')
             ->setMethods(array('getImpactedSubjects'))
             ->setConstructorArgs(array($tripod))
             ->getMock();
@@ -112,7 +109,7 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
                 )
             ));
 
-        $discoverImpactedSubjects = $this->getMockBuilder('DiscoverImpactedSubjects')
+        $discoverImpactedSubjects = $this->getMockBuilder('\Tripod\Mongo\DiscoverImpactedSubjects')
             ->setMethods(array('getMongoTripod', 'submitJob'))
             ->getMock();
 
@@ -122,7 +119,7 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
 
         $discoverImpactedSubjects->args = $this->args;
 
-        $viewSubject = new ImpactedSubject(
+        $viewSubject = new \Tripod\Mongo\ImpactedSubject(
             array(
                 _ID_RESOURCE=>'http://example.com/resources/foo',
                 _ID_CONTEXT=>$this->args['contextAlias']
@@ -139,7 +136,7 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
                 array($viewSubject)
             ));
 
-        $tableSubject = new ImpactedSubject(
+        $tableSubject = new \Tripod\Mongo\ImpactedSubject(
             array(
                 _ID_RESOURCE=>'http://example.com/resources/foo2',
                 _ID_CONTEXT=>$this->args['contextAlias']
@@ -167,7 +164,7 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
             ->withConsecutive(
                 array(
                     \Tripod\Mongo\Config::getApplyQueueName(),
-                    "ApplyOperation",
+                    "\Tripod\Mongo\ApplyOperation",
                     array(
                         "subject"=>$viewSubject->toArray(),
                         "tripodConfig"=>$this->args['tripodConfig']
@@ -175,7 +172,7 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
                 ),
                 array(
                     \Tripod\Mongo\Config::getApplyQueueName(),
-                    "ApplyOperation",
+                    "\Tripod\Mongo\ApplyOperation",
                     array(
                         "subject"=>$tableSubject->toArray(),
                         "tripodConfig"=>$this->args['tripodConfig']

--- a/test/unit/mongo/MongoGraphTest.php
+++ b/test/unit/mongo/MongoGraphTest.php
@@ -2,6 +2,8 @@
 require_once 'MongoTripodTestBase.php';
 require_once 'src/mongo/MongoGraph.class.php';
 
+use \Tripod\Mongo\MongoGraph;
+
 class MongoGraphTest extends MongoTripodTestBase
 {
     protected function setUp()
@@ -17,14 +19,14 @@ class MongoGraphTest extends MongoTripodTestBase
 
     public function testUriToQNameOnUnRegisteredNS()
     {
-        $this->setExpectedException('TripodLabellerException', 'Could not label: http://someunregisteredns/');
+        $this->setExpectedException('LabellerException', 'Could not label: http://someunregisteredns/');
         $g = new MongoGraph();
         $g->uri_to_qname('http://someunregisteredns/title');
     }
 
     public function testQNameToUriOnUnRegisteredNS()
     {
-        $this->setExpectedException('TripodLabellerException', 'Could not label: someunregisteredns:title');
+        $this->setExpectedException('LabellerException', 'Could not label: someunregisteredns:title');
         $g = new MongoGraph();
         $g->qname_to_uri('someunregisteredns:title');
     }
@@ -43,7 +45,7 @@ class MongoGraphTest extends MongoTripodTestBase
 
         $expected = "<http://example.com/1> <http://purl.org/dc/terms/title> \"some literal title\" <http://talisaspire.com/> .
 <http://example.com/1> <http://purl.org/dc/terms/source> <http://www.google.com> <http://talisaspire.com/> .\n";
-        $this->assertEquals($expected, $g->to_nquads(MongoTripodConfig::getInstance()->getDefaultContextAlias()));
+        $this->assertEquals($expected, $g->to_nquads(\Tripod\Mongo\Config::getInstance()->getDefaultContextAlias()));
     }
 
     public function testToNQuadsTwoGraphsWithDifferentContext()
@@ -69,7 +71,7 @@ class MongoGraphTest extends MongoTripodTestBase
 
     public function testAddTripodArrayThrowsException()
     {
-        $this->setExpectedException('TripodException', 'Value passed to add_tripod_array is not of type array');
+        $this->setExpectedException('Exception', 'Value passed to add_tripod_array is not of type array');
         $g = new MongoGraph();
         $g->add_tripod_array(null);
     }

--- a/test/unit/mongo/MongoGraphTest.php
+++ b/test/unit/mongo/MongoGraphTest.php
@@ -19,14 +19,14 @@ class MongoGraphTest extends MongoTripodTestBase
 
     public function testUriToQNameOnUnRegisteredNS()
     {
-        $this->setExpectedException('LabellerException', 'Could not label: http://someunregisteredns/');
+        $this->setExpectedException('\Tripod\Exceptions\LabellerException', 'Could not label: http://someunregisteredns/');
         $g = new MongoGraph();
         $g->uri_to_qname('http://someunregisteredns/title');
     }
 
     public function testQNameToUriOnUnRegisteredNS()
     {
-        $this->setExpectedException('LabellerException', 'Could not label: someunregisteredns:title');
+        $this->setExpectedException('\Tripod\Exceptions\LabellerException', 'Could not label: someunregisteredns:title');
         $g = new MongoGraph();
         $g->qname_to_uri('someunregisteredns:title');
     }

--- a/test/unit/mongo/MongoGraphTest.php
+++ b/test/unit/mongo/MongoGraphTest.php
@@ -2,8 +2,9 @@
 require_once 'MongoTripodTestBase.php';
 require_once 'src/mongo/MongoGraph.class.php';
 
-use \Tripod\Mongo\MongoGraph;
-
+/**
+ * Class MongoGraphTest
+ */
 class MongoGraphTest extends MongoTripodTestBase
 {
     protected function setUp()
@@ -13,33 +14,33 @@ class MongoGraphTest extends MongoTripodTestBase
 
     public function testUriToQNameOnRegisteredNS()
     {
-        $g = new MongoGraph();
+        $g = new \Tripod\Mongo\MongoGraph();
         $this->assertEquals('dct:title',$g->uri_to_qname('http://purl.org/dc/terms/title'));
     }
 
     public function testUriToQNameOnUnRegisteredNS()
     {
         $this->setExpectedException('\Tripod\Exceptions\LabellerException', 'Could not label: http://someunregisteredns/');
-        $g = new MongoGraph();
+        $g = new \Tripod\Mongo\MongoGraph();
         $g->uri_to_qname('http://someunregisteredns/title');
     }
 
     public function testQNameToUriOnUnRegisteredNS()
     {
         $this->setExpectedException('\Tripod\Exceptions\LabellerException', 'Could not label: someunregisteredns:title');
-        $g = new MongoGraph();
+        $g = new \Tripod\Mongo\MongoGraph();
         $g->qname_to_uri('someunregisteredns:title');
     }
 
     public function testToNQuadsThrowsInvalidArgumentException() {
         $this->setExpectedException('InvalidArgumentException', 'You must specify the context when serializing to nquads');
-        $g = new MongoGraph();
+        $g = new \Tripod\Mongo\MongoGraph();
         $g->to_nquads(null);
     }
 
     public function testToNQuads()
     {
-        $g = new MongoGraph();
+        $g = new \Tripod\Mongo\MongoGraph();
         $g->add_literal_triple("http://example.com/1", $g->qname_to_uri("dct:title"),"some literal title");
         $g->add_resource_triple("http://example.com/1", $g->qname_to_uri("dct:source"),"http://www.google.com");
 
@@ -50,7 +51,7 @@ class MongoGraphTest extends MongoTripodTestBase
 
     public function testToNQuadsTwoGraphsWithDifferentContext()
     {
-        $g = new MongoGraph();
+        $g = new \Tripod\Mongo\MongoGraph();
         $g->add_literal_triple("http://example.com/1", $g->qname_to_uri("dct:title"),"some literal title");
         $g->add_resource_triple("http://example.com/1", $g->qname_to_uri("dct:source"),"http://www.google.com");
 
@@ -58,7 +59,7 @@ class MongoGraphTest extends MongoTripodTestBase
 <http://example.com/1> <http://purl.org/dc/terms/source> <http://www.google.com> <http://talisaspire.com/> .\n";
         $this->assertEquals($expected, $g->to_nquads("http://talisaspire.com/"));
 
-        $g = new MongoGraph();
+        $g = new \Tripod\Mongo\MongoGraph();
         $g->add_literal_triple("http://example.com/2", $g->qname_to_uri("dct:title"),"some literal title");
         $g->add_resource_triple("http://example.com/2", $g->qname_to_uri("dct:source"),"http://www.google.com");
 
@@ -72,7 +73,7 @@ class MongoGraphTest extends MongoTripodTestBase
     public function testAddTripodArrayThrowsException()
     {
         $this->setExpectedException('Exception', 'Value passed to add_tripod_array is not of type array');
-        $g = new MongoGraph();
+        $g = new \Tripod\Mongo\MongoGraph();
         $g->add_tripod_array(null);
     }
 
@@ -89,13 +90,13 @@ class MongoGraphTest extends MongoTripodTestBase
             "bibo:isbn13"=>array("l"=>"9211234567890")
         );
 
-        $expected = new MongoGraph();
+        $expected = new \Tripod\Mongo\MongoGraph();
         $expected->add_literal_triple("http://talisaspire.com/works/4d101f63c10a6-2", $expected->qname_to_uri("bibo:isbn13"),"9211234567890");
         $expected->add_resource_triple("http://talisaspire.com/works/4d101f63c10a6-2", $expected->qname_to_uri("dct:subject"),"http://talisaspire.com/disciplines/physics");
         $expected->add_resource_triple("http://talisaspire.com/works/4d101f63c10a6-2", $expected->qname_to_uri("rdf:type"),"http://purl.org/ontology/bibo/Book");
         $expected->add_resource_triple("http://talisaspire.com/works/4d101f63c10a6-2", $expected->qname_to_uri("rdf:type"),"http://talisaspire.com/schema#Work");
 
-        $g = new MongoGraph();
+        $g = new \Tripod\Mongo\MongoGraph();
         $g->add_tripod_array($doc);
 
         $this->assertEquals($expected, $g);
@@ -105,7 +106,7 @@ class MongoGraphTest extends MongoTripodTestBase
     {
         // view contains 4 subgraphs
         $view = json_decode(file_get_contents(dirname(__FILE__)."/data/view.json"), true);
-        $g = new MongoGraph();
+        $g = new \Tripod\Mongo\MongoGraph();
         $g->add_tripod_array($view);
 
         // graph should contain 4 subgraphs
@@ -144,7 +145,7 @@ class MongoGraphTest extends MongoTripodTestBase
         );
 
         // create a graph adding properties to it
-        $g = new MongoGraph();
+        $g = new \Tripod\Mongo\MongoGraph();
         $g->add_literal_triple("http://talisaspire.com/works/4d101f63c10a6-2", $g->qname_to_uri("bibo:isbn13"),"9211234567890");
         $g->add_resource_triple("http://talisaspire.com/works/4d101f63c10a6-2", $g->qname_to_uri("dct:subject"),"http://talisaspire.com/disciplines/physics");
         $g->add_resource_triple("http://talisaspire.com/works/4d101f63c10a6-2", $g->qname_to_uri("rdf:type"),"http://purl.org/ontology/bibo/Book");
@@ -157,7 +158,7 @@ class MongoGraphTest extends MongoTripodTestBase
 
     public function testToTripodArrayReturnsNullIfDocNotInGraph()
     {
-        $g = new MongoGraph();
+        $g = new \Tripod\Mongo\MongoGraph();
         $doc = $g->to_tripod_array("http://example.com/1", "http://example.com/");
         $this->assertNull($doc);
     }
@@ -185,7 +186,7 @@ class MongoGraphTest extends MongoTripodTestBase
         );
 
         // create a graph adding properties to it
-        $g = new MongoGraph();
+        $g = new \Tripod\Mongo\MongoGraph();
         $g->add_resource_triple("http://example.com/things/1", $g->qname_to_uri("dct:subject"),"http://talisaspire.com/disciplines/physics");
         $g->add_resource_triple("http://example.com/things/1", $g->qname_to_uri("rdf:type"),"http://purl.org/ontology/bibo/Book");
         $g->add_literal_triple( "http://example.com/things/1", $g->qname_to_uri("bibo:isbn13"),"9211234567890");
@@ -204,7 +205,7 @@ class MongoGraphTest extends MongoTripodTestBase
             _LOCKED_FOR_TRANS=>"transaction_234"
         );
 
-        $g = new MongoGraph();
+        $g = new \Tripod\Mongo\MongoGraph();
         $g->add_tripod_array($doc);
         $this->assertTrue(count($g->get_index())==0,"Graph should contain no data");
     }

--- a/test/unit/mongo/MongoSearchProviderTest.php
+++ b/test/unit/mongo/MongoSearchProviderTest.php
@@ -335,38 +335,38 @@ class MongoSearchProviderTest extends MongoTripodTestBase
 
     public function testSearchThrowsExceptionIfNoQuery()
     {
-        $this->setExpectedException("SearchException","You must specify a query");
+        $this->setExpectedException("\Tripod\Exceptions\SearchException","You must specify a query");
         $this->searchProvider->search("", "i_search_resource",  array("search_terms"), array("result"), 3, 0);
     }
 
     public function testSearchThrowsExceptionIfNoType()
     {
-        $this->setExpectedException("SearchException","You must specify the search document type to restrict the query to");
+        $this->setExpectedException("\Tripod\Exceptions\SearchException","You must specify the search document type to restrict the query to");
         $this->searchProvider->search("poetry", "",  array("search_terms"), array("result"), 3, 0);
     }
 
     public function testSearchThrowsExceptionIfSearchIndicesEmpty()
     {
-        $this->setExpectedException("SearchException","You must specify at least one index from the search document specification to query against");
+        $this->setExpectedException("\Tripod\Exceptions\SearchException","You must specify at least one index from the search document specification to query against");
         $this->searchProvider->search("poetry", "i_search_resource",  array(), array("result"), 3, 0);
     }
 
     public function testSearchThrowsExceptionIfFieldsToReturnEmpty()
     {
-        $this->setExpectedException("SearchException","You must specify at least one field from the search document specification to return");
+        $this->setExpectedException("\Tripod\Exceptions\SearchException","You must specify at least one field from the search document specification to return");
         $this->searchProvider->search("poetry", "i_search_resource",  array("search_terms"), array(), 3, 0);
     }
 
 
     public function testSearchThrowsExceptionIfLimitIsNegative()
     {
-        $this->setExpectedException("SearchException","Value for limit must be a positive number");
+        $this->setExpectedException("\Tripod\Exceptions\SearchException","Value for limit must be a positive number");
         $this->searchProvider->search("poetry", "i_search_resource",  array("search_terms"), array("result"), -3, 0);
     }
 
     public function testSearchThrowsExceptionIfOffsetIsNegative()
     {
-        $this->setExpectedException("SearchException","Value for offset must be a positive number");
+        $this->setExpectedException("\Tripod\Exceptions\SearchException","Value for offset must be a positive number");
         $this->searchProvider->search("poetry", "i_search_resource",  array("search_terms"), array("result"), 3, -1);
     }
 
@@ -501,7 +501,7 @@ class MongoSearchProviderTest extends MongoTripodTestBase
     
     public function testDeleteSearchDocumentsByTypeIdThrowsExceptionForInvalidType()
     {
-    	$mockSearchProvider = $this->getMock("MongoSearchProvider", array('getSearchDocumentSpecification'), array($this->tripod));
+    	$mockSearchProvider = $this->getMock("\Tripod\Mongo\MongoSearchProvider", array('getSearchDocumentSpecification'), array($this->tripod));
     	$mockSearchProvider->expects($this->once())
     						->method('getSearchDocumentSpecification')
     						->with('i_some_type')
@@ -519,7 +519,7 @@ class MongoSearchProviderTest extends MongoTripodTestBase
     	$this->assertEquals(12, $actualSearchDocumentCount, "Should have generated 12 search documents based on searchData.json");
 
         /** @var MongoSearchProvider|PHPUnit_Framework_MockObject_MockObject $mockSearchProvider */
-    	$mockSearchProvider = $this->getMock("MongoSearchProvider", array('getSearchDocumentSpecification'), array($this->tripod));
+    	$mockSearchProvider = $this->getMock("\Tripod\Mongo\MongoSearchProvider", array('getSearchDocumentSpecification'), array($this->tripod));
     	$mockSearchProvider->expects($this->once())
 				    	->method('getSearchDocumentSpecification')
 				    	->with('i_some_type')
@@ -546,7 +546,7 @@ class MongoSearchProviderTest extends MongoTripodTestBase
 
     	$this->assertEquals(12, $actualSearchDocumentCount, "Should have generated 12 search documents based on searchData.json");
     	 
-    	$mockSearchProvider = $this->getMock("MongoSearchProvider", array('getSearchDocumentSpecification'), array($this->tripod));
+    	$mockSearchProvider = $this->getMock("\Tripod\Mongo\MongoSearchProvider", array('getSearchDocumentSpecification'), array($this->tripod));
     	$mockSearchProvider->expects($this->once())
     					->method('getSearchDocumentSpecification')
 				    	->with('i_search_resource')
@@ -584,7 +584,7 @@ class MongoSearchProviderTest extends MongoTripodTestBase
 
     	$this->assertEquals(13, $updatedSearchDocumentCount, "Should have generated 13 search documents after adding a new document to collection");
     
-    	$mockSearchProvider = $this->getMock("MongoSearchProvider", array('getSearchDocumentSpecification'), array($this->tripod));
+    	$mockSearchProvider = $this->getMock("\Tripod\Mongo\MongoSearchProvider", array('getSearchDocumentSpecification'), array($this->tripod));
     	$mockSearchProvider->expects($this->once())
 				    	->method('getSearchDocumentSpecification')
 				    	->with('i_search_resource')

--- a/test/unit/mongo/MongoSearchProviderTest.php
+++ b/test/unit/mongo/MongoSearchProviderTest.php
@@ -1,12 +1,16 @@
 <?php
     require_once 'MongoTripodTestBase.php';
-    require_once 'src/mongo/MongoTripod.class.php';
-    require_once 'src/mongo/delegates/MongoTripodSearchIndexer.class.php';
+    require_once 'src/mongo/Tripod.class.php';
+    require_once 'src/mongo/delegates/SearchIndexer.class.php';
     require_once 'src/mongo/providers/MongoSearchProvider.class.php';
+
+use \Tripod\Mongo\Tripod;
+use \Tripod\Mongo\SearchIndexer;
+use \Tripod\Mongo\MongoSearchProvider;
 
 class MongoSearchProviderTest extends MongoTripodTestBase
 {
-    /** @var $indexer MongoTripodSearchIndexer */
+    /** @var $indexer SearchIndexer */
     private $indexer;
 
     /** @var $indexer MongoSearchProvider */
@@ -16,17 +20,17 @@ class MongoSearchProviderTest extends MongoTripodTestBase
     {
         parent::setUp();
 
-        $this->tripodTransactionLog = new MongoTransactionLog();
+        $this->tripodTransactionLog = new \Tripod\Mongo\TransactionLog();
         $this->tripodTransactionLog->purgeAllTransactions();
 
-        $this->tripod = new MongoTripod('CBD_testing', 'tripod_php_testing');
-        $this->indexer = new MongoTripodSearchIndexer($this->tripod);
+        $this->tripod = new Tripod('CBD_testing', 'tripod_php_testing');
+        $this->indexer = new SearchIndexer($this->tripod);
         $this->searchProvider = new MongoSearchProvider($this->tripod);
         $this->getTripodCollection($this->tripod)->drop();
 
         $this->loadBaseSearchDataViaTripod();
 
-        foreach(MongoTripodConfig::getInstance()->getCollectionsForSearch($this->tripod->getStoreName()) as $collection)
+        foreach(\Tripod\Mongo\Config::getInstance()->getCollectionsForSearch($this->tripod->getStoreName()) as $collection)
         {
             $collection->drop();
         }
@@ -170,7 +174,7 @@ class MongoSearchProviderTest extends MongoTripodTestBase
         );
 
         // loop through every expected document and assert that it exists, and that each property matches the value we defined above.
-        $searchCollection = MongoTripodConfig::getInstance()->getCollectionForSearchDocument($this->tripod->getStoreName(), 'i_search_resource');
+        $searchCollection = \Tripod\Mongo\Config::getInstance()->getCollectionForSearchDocument($this->tripod->getStoreName(), 'i_search_resource');
         foreach($expectedSearchDocs as $expectedSearchDoc){
             $this->assertDocumentExists($expectedSearchDoc["_id"], $searchCollection);
             $this->assertDocumentHasProperty($expectedSearchDoc["_id"], "result", $expectedSearchDoc["result"], $searchCollection);
@@ -194,7 +198,7 @@ class MongoSearchProviderTest extends MongoTripodTestBase
         $this->assertEquals(11, $actualSearchDocumentCount, "Should only be 11 search documents now that one of them has had its type changed with no corresponding search doc spec");
 
 
-        foreach(MongoTripodConfig::getInstance()->getCollectionsForSearch('tripod_php_testing') as $collection)
+        foreach(\Tripod\Mongo\Config::getInstance()->getCollectionsForSearch('tripod_php_testing') as $collection)
         {
             $this->assertNull(
                 $collection->findOne(array("_id.r"=>"http://talisaspire.com/resources/doc1")),
@@ -224,7 +228,7 @@ class MongoSearchProviderTest extends MongoTripodTestBase
 
         $this->assertEquals(12, $actualSearchDocumentCount, "Should only be 12 search documents");
 
-        foreach(MongoTripodConfig::getInstance()->getCollectionsForSearch('tripod_php_testing') as $collection)
+        foreach(\Tripod\Mongo\Config::getInstance()->getCollectionsForSearch('tripod_php_testing') as $collection)
         {
             $result = $collection->findOne(array("_id.r"=>"http://talisaspire.com/resources/doc1"));
             if($result)
@@ -260,7 +264,7 @@ class MongoSearchProviderTest extends MongoTripodTestBase
 
         $results = array();
         // We don't know where exactly these might have stored
-        foreach(MongoTripodConfig::getInstance()->getCollectionsForSearch('tripod_php_testing') as $collection)
+        foreach(\Tripod\Mongo\Config::getInstance()->getCollectionsForSearch('tripod_php_testing') as $collection)
         {
             foreach($collection->find(array("_id.r"=>"http://talisaspire.com/resources/doc1")) as $result)
             {
@@ -307,7 +311,7 @@ class MongoSearchProviderTest extends MongoTripodTestBase
 
         $results = array();
         // We don't know where exactly these might have stored
-        foreach(MongoTripodConfig::getInstance()->getCollectionsForSearch('tripod_php_testing') as $collection)
+        foreach(\Tripod\Mongo\Config::getInstance()->getCollectionsForSearch('tripod_php_testing') as $collection)
         {
             foreach($collection->find(array("_id.r"=>"http://talisaspire.com/resources/doc1")) as $result)
             {
@@ -331,38 +335,38 @@ class MongoSearchProviderTest extends MongoTripodTestBase
 
     public function testSearchThrowsExceptionIfNoQuery()
     {
-        $this->setExpectedException("TripodSearchException","You must specify a query");
+        $this->setExpectedException("SearchException","You must specify a query");
         $this->searchProvider->search("", "i_search_resource",  array("search_terms"), array("result"), 3, 0);
     }
 
     public function testSearchThrowsExceptionIfNoType()
     {
-        $this->setExpectedException("TripodSearchException","You must specify the search document type to restrict the query to");
+        $this->setExpectedException("SearchException","You must specify the search document type to restrict the query to");
         $this->searchProvider->search("poetry", "",  array("search_terms"), array("result"), 3, 0);
     }
 
     public function testSearchThrowsExceptionIfSearchIndicesEmpty()
     {
-        $this->setExpectedException("TripodSearchException","You must specify at least one index from the search document specification to query against");
+        $this->setExpectedException("SearchException","You must specify at least one index from the search document specification to query against");
         $this->searchProvider->search("poetry", "i_search_resource",  array(), array("result"), 3, 0);
     }
 
     public function testSearchThrowsExceptionIfFieldsToReturnEmpty()
     {
-        $this->setExpectedException("TripodSearchException","You must specify at least one field from the search document specification to return");
+        $this->setExpectedException("SearchException","You must specify at least one field from the search document specification to return");
         $this->searchProvider->search("poetry", "i_search_resource",  array("search_terms"), array(), 3, 0);
     }
 
 
     public function testSearchThrowsExceptionIfLimitIsNegative()
     {
-        $this->setExpectedException("TripodSearchException","Value for limit must be a positive number");
+        $this->setExpectedException("SearchException","Value for limit must be a positive number");
         $this->searchProvider->search("poetry", "i_search_resource",  array("search_terms"), array("result"), -3, 0);
     }
 
     public function testSearchThrowsExceptionIfOffsetIsNegative()
     {
-        $this->setExpectedException("TripodSearchException","Value for offset must be a positive number");
+        $this->setExpectedException("SearchException","Value for offset must be a positive number");
         $this->searchProvider->search("poetry", "i_search_resource",  array("search_terms"), array("result"), 3, -1);
     }
 
@@ -503,7 +507,7 @@ class MongoSearchProviderTest extends MongoTripodTestBase
     						->with('i_some_type')
     						->will($this->returnValue(null));
     	
-    	$this->setExpectedException("TripodException","Could not find a search specification for i_some_type");
+    	$this->setExpectedException("Exception","Could not find a search specification for i_some_type");
     	$mockSearchProvider->deleteSearchDocumentsByTypeId('i_some_type');
     }
     
@@ -524,7 +528,7 @@ class MongoSearchProviderTest extends MongoTripodTestBase
         {
     	    $mockSearchProvider->deleteSearchDocumentsByTypeId('i_some_type');
         }
-        catch(MongoTripodConfigException $e)
+        catch(\Tripod\Exceptions\ConfigException $e)
         {
             $this->assertEquals("Search document id 'i_some_type' not in configuration for store 'tripod_php_testing'", $e->getMessage());
         }
@@ -595,21 +599,21 @@ class MongoSearchProviderTest extends MongoTripodTestBase
     }
 
     /**
-     * @param MongoTripod $tripod
+     * @param Tripod $tripod
      * @param array $specs
      * @return int
      */
-    protected function getCountForSearchSpecs(MongoTripod $tripod, $specs = array())
+    protected function getCountForSearchSpecs(Tripod $tripod, $specs = array())
     {
         $count = 0;
         if(empty($specs))
         {
-            $specs = MongoTripodConfig::getInstance()->getSearchDocumentSpecifications($tripod->getStoreName(), null, true);
+            $specs = \Tripod\Mongo\Config::getInstance()->getSearchDocumentSpecifications($tripod->getStoreName(), null, true);
         }
 
         foreach($specs as $spec)
         {
-            $count += MongoTripodConfig::getInstance()->getCollectionForSearchDocument($tripod->getStoreName(), $spec)->count(array('_id.type'=>$spec));
+            $count += \Tripod\Mongo\Config::getInstance()->getCollectionForSearchDocument($tripod->getStoreName(), $spec)->count(array('_id.type'=>$spec));
         }
         return $count;
     }

--- a/test/unit/mongo/MongoSearchProviderTest.php
+++ b/test/unit/mongo/MongoSearchProviderTest.php
@@ -1,6 +1,6 @@
 <?php
     require_once 'MongoTripodTestBase.php';
-    require_once 'src/mongo/Tripod.class.php';
+    require_once 'src/mongo/Driver.class.php';
     require_once 'src/mongo/delegates/SearchIndexer.class.php';
     require_once 'src/mongo/providers/MongoSearchProvider.class.php';
 
@@ -9,7 +9,7 @@
  */
 class MongoSearchProviderTest extends MongoTripodTestBase
 {
-    /** @var $indexer \Tripod\Mongo\SearchIndexer */
+    /** @var $indexer \Tripod\Mongo\Composites\SearchIndexer */
     private $indexer;
 
     /** @var $indexer \Tripod\Mongo\MongoSearchProvider */
@@ -22,8 +22,8 @@ class MongoSearchProviderTest extends MongoTripodTestBase
         $this->tripodTransactionLog = new \Tripod\Mongo\TransactionLog();
         $this->tripodTransactionLog->purgeAllTransactions();
 
-        $this->tripod = new \Tripod\Mongo\Tripod('CBD_testing', 'tripod_php_testing');
-        $this->indexer = new \Tripod\Mongo\SearchIndexer($this->tripod);
+        $this->tripod = new \Tripod\Mongo\Driver('CBD_testing', 'tripod_php_testing');
+        $this->indexer = new \Tripod\Mongo\Composites\SearchIndexer($this->tripod);
         $this->searchProvider = new \Tripod\Mongo\MongoSearchProvider($this->tripod);
         $this->getTripodCollection($this->tripod)->drop();
 
@@ -599,11 +599,11 @@ class MongoSearchProviderTest extends MongoTripodTestBase
     }
 
     /**
-     * @param \Tripod\Mongo\Tripod $tripod
+     * @param \Tripod\Mongo\Driver $tripod
      * @param array $specs
      * @return int
      */
-    protected function getCountForSearchSpecs(\Tripod\Mongo\Tripod $tripod, $specs = array())
+    protected function getCountForSearchSpecs(\Tripod\Mongo\Driver $tripod, $specs = array())
     {
         $count = 0;
         if(empty($specs))

--- a/test/unit/mongo/MongoSearchProviderTest.php
+++ b/test/unit/mongo/MongoSearchProviderTest.php
@@ -4,16 +4,15 @@
     require_once 'src/mongo/delegates/SearchIndexer.class.php';
     require_once 'src/mongo/providers/MongoSearchProvider.class.php';
 
-use \Tripod\Mongo\Tripod;
-use \Tripod\Mongo\SearchIndexer;
-use \Tripod\Mongo\MongoSearchProvider;
-
+/**
+ * Class MongoSearchProviderTest
+ */
 class MongoSearchProviderTest extends MongoTripodTestBase
 {
-    /** @var $indexer SearchIndexer */
+    /** @var $indexer \Tripod\Mongo\SearchIndexer */
     private $indexer;
 
-    /** @var $indexer MongoSearchProvider */
+    /** @var $indexer \Tripod\Mongo\MongoSearchProvider */
     private $searchProvider;
 
     protected function setUp()
@@ -23,9 +22,9 @@ class MongoSearchProviderTest extends MongoTripodTestBase
         $this->tripodTransactionLog = new \Tripod\Mongo\TransactionLog();
         $this->tripodTransactionLog->purgeAllTransactions();
 
-        $this->tripod = new Tripod('CBD_testing', 'tripod_php_testing');
-        $this->indexer = new SearchIndexer($this->tripod);
-        $this->searchProvider = new MongoSearchProvider($this->tripod);
+        $this->tripod = new \Tripod\Mongo\Tripod('CBD_testing', 'tripod_php_testing');
+        $this->indexer = new \Tripod\Mongo\SearchIndexer($this->tripod);
+        $this->searchProvider = new \Tripod\Mongo\MongoSearchProvider($this->tripod);
         $this->getTripodCollection($this->tripod)->drop();
 
         $this->loadBaseSearchDataViaTripod();
@@ -228,6 +227,7 @@ class MongoSearchProviderTest extends MongoTripodTestBase
 
         $this->assertEquals(12, $actualSearchDocumentCount, "Should only be 12 search documents");
 
+        $result = array();
         foreach(\Tripod\Mongo\Config::getInstance()->getCollectionsForSearch('tripod_php_testing') as $collection)
         {
             $result = $collection->findOne(array("_id.r"=>"http://talisaspire.com/resources/doc1"));
@@ -518,7 +518,7 @@ class MongoSearchProviderTest extends MongoTripodTestBase
 
     	$this->assertEquals(12, $actualSearchDocumentCount, "Should have generated 12 search documents based on searchData.json");
 
-        /** @var MongoSearchProvider|PHPUnit_Framework_MockObject_MockObject $mockSearchProvider */
+        /** @var \Tripod\Mongo\MongoSearchProvider|PHPUnit_Framework_MockObject_MockObject $mockSearchProvider */
     	$mockSearchProvider = $this->getMock("\Tripod\Mongo\MongoSearchProvider", array('getSearchDocumentSpecification'), array($this->tripod));
     	$mockSearchProvider->expects($this->once())
 				    	->method('getSearchDocumentSpecification')
@@ -599,11 +599,11 @@ class MongoSearchProviderTest extends MongoTripodTestBase
     }
 
     /**
-     * @param Tripod $tripod
+     * @param \Tripod\Mongo\Tripod $tripod
      * @param array $specs
      * @return int
      */
-    protected function getCountForSearchSpecs(Tripod $tripod, $specs = array())
+    protected function getCountForSearchSpecs(\Tripod\Mongo\Tripod $tripod, $specs = array())
     {
         $count = 0;
         if(empty($specs))

--- a/test/unit/mongo/MongoTransactionLogTest.php
+++ b/test/unit/mongo/MongoTransactionLogTest.php
@@ -25,7 +25,7 @@ class MongoTransactionLogTest extends MongoTripodTestBase
         //Mongo::setPoolSize(200);
 
         // Stub ouf 'addToElastic' search to prevent writes into Elastic Search happening by default.
-        /** @var \Tripod\Mongo\Tripod|PHPUnit_Framework_MockObject_MockObject tripod */
+        /** @var \Tripod\Mongo\Tripod|PHPUnit_Framework_MockObject_MockObject $tripod */
         $this->tripod = $this->getMock('\Tripod\Mongo\Tripod', array('addToSearchIndexQueue'), array('CBD_testing','tripod_php_testing'));
         $this->tripod->expects($this->any())->method('addToSearchIndexQueue');
 

--- a/test/unit/mongo/MongoTransactionLogTest.php
+++ b/test/unit/mongo/MongoTransactionLogTest.php
@@ -407,7 +407,15 @@ class MongoTransactionLogTest extends MongoTripodTestBase
         $this->assertFalse( $g->has_triples_about('http://example.com/resources/5'), "Should not contain triples about /resources/5");
     }
 
-    // helper method
+    /**
+     * helper method
+     * @param string $id
+     * @param string $subjectOfChange
+     * @param string $startTime
+     * @param string $endTime
+     * @param int $_version
+     * @return array
+     */
     protected function buildTransactionDocument($id, $subjectOfChange, $startTime, $endTime, $_version)
     {
         $transaction_template = array(

--- a/test/unit/mongo/MongoTransactionLogTest.php
+++ b/test/unit/mongo/MongoTransactionLogTest.php
@@ -4,19 +4,18 @@ require_once 'src/mongo/Tripod.class.php';
 require_once 'src/mongo/delegates/TransactionLog.class.php';
 require_once 'src/mongo/MongoGraph.class.php';
 
-use \Tripod\Mongo\Tripod;
-use \Tripod\Mongo\TransactionLog;
-use \Tripod\Mongo\MongoGraph;
-
+/**
+ * Class MongoTransactionLogTest
+ */
 class MongoTransactionLogTest extends MongoTripodTestBase
 {
     /**
-     * @var Tripod
+     * @var \Tripod\Mongo\Tripod
      */
     protected $tripod
     ;
     /**
-     * @var TransactionLog
+     * @var \Tripod\Mongo\TransactionLog
      */
     protected $tripodTransactionLog = null;
 
@@ -26,8 +25,8 @@ class MongoTransactionLogTest extends MongoTripodTestBase
         //Mongo::setPoolSize(200);
 
         // Stub ouf 'addToElastic' search to prevent writes into Elastic Search happening by default.
-        /** @var Tripod|PHPUnit_Framework_MockObject_MockObject tripod */
-        $this->tripod = $this->getMock('Tripod', array('addToSearchIndexQueue'), array('CBD_testing','tripod_php_testing'));
+        /** @var \Tripod\Mongo\Tripod|PHPUnit_Framework_MockObject_MockObject tripod */
+        $this->tripod = $this->getMock('\Tripod\Mongo\Tripod', array('addToSearchIndexQueue'), array('CBD_testing','tripod_php_testing'));
         $this->tripod->expects($this->any())->method('addToSearchIndexQueue');
 
         $this->getTripodCollection($this->tripod)->drop();
@@ -37,7 +36,7 @@ class MongoTransactionLogTest extends MongoTripodTestBase
 
         $this->loadBaseDataViaTripod();
 
-        $this->tripodTransactionLog = new TransactionLog();
+        $this->tripodTransactionLog = new \Tripod\Mongo\TransactionLog();
         $this->tripodTransactionLog->purgeAllTransactions();
         $this->tripod->setTransactionLog($this->tripodTransactionLog);
 
@@ -48,7 +47,7 @@ class MongoTransactionLogTest extends MongoTripodTestBase
         $uri = 'http://talisaspire.com/examples/1';
 
         // store a new entity
-        $originalGraph = new MongoGraph();
+        $originalGraph = new \Tripod\Mongo\MongoGraph();
         $originalGraph->add_resource_triple($uri, $originalGraph->qname_to_uri('rdf:type'), $originalGraph->qname_to_uri("acorn:Resource"));
         $originalGraph->add_literal_triple($uri, $originalGraph->qname_to_uri('searchterms:title'), 'Physics 3rd Edition');
         $originalGraph->add_literal_triple($uri, $originalGraph->qname_to_uri('searchterms:author'), 'Joe Bloggs');
@@ -62,7 +61,7 @@ class MongoTransactionLogTest extends MongoTripodTestBase
         $this->assertDocumentVersion(array("r"=>$uri,"c"=>"http://talisaspire.com/"), 0); // the document should be at version 0
 
         // now save a change which alters one property
-        $nG = new MongoGraph();
+        $nG = new \Tripod\Mongo\MongoGraph();
         $nG->add_graph($originalGraph);
         $nG->remove_literal_triple($uri, $nG->qname_to_uri('searchterms:title'), 'Physics 3rd Edition');
         $nG->add_literal_triple($uri, $nG->qname_to_uri('searchterms:title'), 'TEST TITLE');
@@ -98,10 +97,10 @@ class MongoTransactionLogTest extends MongoTripodTestBase
     {
         $uri = 'http://example.com/resources/1';
 
-        $g = new MongoGraph();
+        $g = new \Tripod\Mongo\MongoGraph();
         $g->add_resource_triple($uri, $g->qname_to_uri("rdf:type"), $g->qname_to_uri("acorn:Resource"));
         $g->add_literal_triple($uri, $g->qname_to_uri("dct:title"), "wibble");
-        $this->tripod->saveChanges(new MongoGraph(), $g, "http://talisaspire.com/", "something new");
+        $this->tripod->saveChanges(new \Tripod\Mongo\MongoGraph(), $g, "http://talisaspire.com/", "something new");
 
         // make sure the new entity was saved correctly
         $uG = $this->tripod->describeResource($uri);
@@ -128,10 +127,10 @@ class MongoTransactionLogTest extends MongoTripodTestBase
     {
         $uri = 'http://basedata.com/b/3';
 
-        $g = new MongoGraph();
+        $g = new \Tripod\Mongo\MongoGraph();
         $g->add_resource_triple($uri, $g->qname_to_uri("rdf:type"), $g->qname_to_uri("acorn:Resource"));
         $g->add_literal_triple($uri, $g->qname_to_uri("dct:title"), "wibble");
-        $this->tripod->saveChanges(new MongoGraph(), $g, "http://basedata.com/b/DefaultGraph", "something new");
+        $this->tripod->saveChanges(new \Tripod\Mongo\MongoGraph(), $g, "http://basedata.com/b/DefaultGraph", "something new");
 
         // make sure the new entity was saved correctly
         $uG = $this->tripod->describeResource($uri,"baseData:DefaultGraph");
@@ -200,9 +199,9 @@ class MongoTransactionLogTest extends MongoTripodTestBase
         $uri = 'http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA';
 
         // Save a change to entity
-        $oG = new MongoGraph();
+        $oG = new \Tripod\Mongo\MongoGraph();
         $oG->add_literal_triple($uri, $oG->qname_to_uri('searchterms:title'), 'Physics 3rd Edition');
-        $nG = new MongoGraph();
+        $nG = new \Tripod\Mongo\MongoGraph();
         $nG->add_literal_triple($uri, $oG->qname_to_uri('searchterms:title'), 'A different title');
         $this->tripod->saveChanges($oG, $nG,"http://talisaspire.com/");
         $this->assertDocumentVersion(array("r"=>$uri,"c"=>"http://talisaspire.com/"), 1);
@@ -232,11 +231,11 @@ class MongoTransactionLogTest extends MongoTripodTestBase
         $uri_2 = 'http://talisaspire.com/works/4d101f63c10a6';
 
         // save a changes that results in a changeset with more than one subject of change
-        $oG = new MongoGraph();
+        $oG = new \Tripod\Mongo\MongoGraph();
         $oG->add_literal_triple($uri_1, $oG->qname_to_uri('searchterms:title'), 'Physics 3rd Edition');
         $oG->add_literal_triple($uri_2, $oG->qname_to_uri('searchterms:discipline'), 'physics');
         $oG->add_resource_triple($uri_2, $oG->qname_to_uri('dct:subject'), 'http://talisaspire.com/disciplines/physics');
-        $nG = new MongoGraph();
+        $nG = new \Tripod\Mongo\MongoGraph();
         $nG->add_literal_triple($uri_1, $nG->qname_to_uri('searchterms:title'), 'History of UK');
         $nG->add_literal_triple($uri_2, $nG->qname_to_uri('searchterms:discipline'), 'history');
         $nG->add_resource_triple($uri_2, $nG->qname_to_uri('dct:subject'), 'http://talisaspire.com/disciplines/history');
@@ -247,7 +246,7 @@ class MongoTransactionLogTest extends MongoTripodTestBase
         $this->assertEquals(1, $this->tripodTransactionLog->getTotalTransactionCount(), 'There should only be 1 transaction in the transaction log');
 
         // add a title to second entity:
-        $nG2  = new MongoGraph();
+        $nG2  = new \Tripod\Mongo\MongoGraph();
         $nG2->add_literal_triple($uri_2, $nG2->qname_to_uri('searchterms:title'), 'some test title');
         // this save should add a triple to just one of the documents
         $this->tripod->saveChanges(new \Tripod\ExtendedGraph(), $nG2,"http://talisaspire.com/");
@@ -256,9 +255,9 @@ class MongoTransactionLogTest extends MongoTripodTestBase
         $this->assertEquals(2, $this->tripodTransactionLog->getTotalTransactionCount(), 'There should only be 2 transactions in the transaction log');
 
         // change same entity again:
-        $nG2  = new MongoGraph();
+        $nG2  = new \Tripod\Mongo\MongoGraph();
         $nG2->add_literal_triple($uri_2, $nG2->qname_to_uri('searchterms:title'), 'some test title');
-        $nG3  = new MongoGraph();
+        $nG3  = new \Tripod\Mongo\MongoGraph();
         $nG3->add_literal_triple($uri_2, $nG2->qname_to_uri('searchterms:title'), 'a different title');
 
         // this save should change a triple on on document
@@ -269,9 +268,9 @@ class MongoTransactionLogTest extends MongoTripodTestBase
 
         // change the other entity once more so it has a second revision
         // change same entity again:
-        $nG2  = new MongoGraph();
+        $nG2  = new \Tripod\Mongo\MongoGraph();
         $nG2->add_literal_triple($uri_1, $nG2->qname_to_uri('searchterms:title'), 'History of UK');
-        $nG3  = new MongoGraph();
+        $nG3  = new \Tripod\Mongo\MongoGraph();
         $nG3->add_literal_triple($uri_1, $nG2->qname_to_uri('searchterms:title'), 'History of the United Kingdom');
 
         // this save should change a triple on the first resource
@@ -301,7 +300,7 @@ class MongoTransactionLogTest extends MongoTripodTestBase
     public function testReplayTransactions_AddingAndDeleting()
     {
         $uri = 'http://example.com/resources/1';
-        $g= new MongoGraph();
+        $g= new \Tripod\Mongo\MongoGraph();
         $g->add_literal_triple($uri, $g->qname_to_uri('searchterms:title'), 'Anything at all');
 
         // add the entity to the store
@@ -456,12 +455,12 @@ class MongoTransactionLogTest extends MongoTripodTestBase
         // STEP 1
         $uri = 'http://example.com/resources/1';
         // save a new entity, and retrieve it
-        $g = new MongoGraph();
+        $g = new \Tripod\Mongo\MongoGraph();
         $g->add_resource_triple($uri, $g->qname_to_uri("rdf:type"), $g->qname_to_uri("acorn:Resource"));
         $g->add_literal_triple($uri, $g->qname_to_uri("dct:title"), "wibble");
 
-        $mTripod = $this->getMock('Tripod', array('getDataUpdater'), array('CBD_testing', 'tripod_php_testing'));
-        $mTripodUpdate = $this->getMock('Updates', array('getUniqId'), array($mTripod));
+        $mTripod = $this->getMock('\Tripod\Mongo\Tripod', array('getDataUpdater'), array('CBD_testing', 'tripod_php_testing'));
+        $mTripodUpdate = $this->getMock('\Tripod\Mongo\Updates', array('getUniqId'), array($mTripod));
 
         $mTripodUpdate->expects($this->atLeastOnce())
             ->method('getUniqId')
@@ -471,7 +470,7 @@ class MongoTransactionLogTest extends MongoTripodTestBase
             ->will($this->returnValue($mTripodUpdate));
 
         $mTripod->setTransactionLog($this->tripodTransactionLog);
-        $mTripod->saveChanges(new MongoGraph(), $g, 'http://talisaspire.com/');
+        $mTripod->saveChanges(new \Tripod\Mongo\MongoGraph(), $g, 'http://talisaspire.com/');
 
         // assert that the transaction in the transaction log is correct
         $transactionId = 'transaction_1';
@@ -490,8 +489,8 @@ class MongoTransactionLogTest extends MongoTripodTestBase
         // STEP 2
         // update the same entity with an addition
         $mTripod = null;
-        $mTripod = $this->getMock('Tripod', array('getDataUpdater'), array('CBD_testing', 'tripod_php_testing'));
-        $mTripodUpdate = $this->getMock('Updates', array('getUniqId'), array($mTripod));
+        $mTripod = $this->getMock('\Tripod\Mongo\Tripod', array('getDataUpdater'), array('CBD_testing', 'tripod_php_testing'));
+        $mTripodUpdate = $this->getMock('\Tripod\Mongo\Updates', array('getUniqId'), array($mTripod));
 
         $mTripodUpdate->expects($this->atLeastOnce())
             ->method('getUniqId')
@@ -501,7 +500,7 @@ class MongoTransactionLogTest extends MongoTripodTestBase
             ->will($this->returnValue($mTripodUpdate));
         $mTripod->setTransactionLog($this->tripodTransactionLog);
 
-        $nG = new MongoGraph();
+        $nG = new \Tripod\Mongo\MongoGraph();
         $nG->add_graph($g);
         $nG->add_literal_triple($uri, $g->qname_to_uri("dct:title"), "another title");
         $mTripod->saveChanges($g, $nG,'http://talisaspire.com/');
@@ -536,8 +535,8 @@ class MongoTransactionLogTest extends MongoTripodTestBase
         // STEP 3
         // update the same entity with a removal
         $mTripod = null;
-        $mTripod = $this->getMock('Tripod', array('getDataUpdater'), array('CBD_testing', 'tripod_php_testing'));
-        $mTripodUpdate = $this->getMock('Updates', array('getUniqId'), array($mTripod));
+        $mTripod = $this->getMock('\Tripod\Mongo\Tripod', array('getDataUpdater'), array('CBD_testing', 'tripod_php_testing'));
+        $mTripodUpdate = $this->getMock('\Tripod\Mongo\Updates', array('getUniqId'), array($mTripod));
 
         $mTripodUpdate->expects($this->atLeastOnce())
             ->method('getUniqId')
@@ -547,7 +546,7 @@ class MongoTransactionLogTest extends MongoTripodTestBase
             ->will($this->returnValue($mTripodUpdate));
         $mTripod->setTransactionLog($this->tripodTransactionLog);
 
-        $g = new MongoGraph();
+        $g = new \Tripod\Mongo\MongoGraph();
         $g->add_graph($nG);
         $g->remove_literal_triple($uri, $g->qname_to_uri("dct:title"), "another title");
         $mTripod->saveChanges($nG, $g,'http://talisaspire.com/');
@@ -582,11 +581,11 @@ class MongoTransactionLogTest extends MongoTripodTestBase
     {
         $uri = 'http://example.com/resources/1';
         // save a new entity, and retrieve it
-        $g = new MongoGraph();
+        $g = new \Tripod\Mongo\MongoGraph();
         $g->add_resource_triple($uri, $g->qname_to_uri("rdf:type"), $g->qname_to_uri("acorn:Resource"));
         $g->add_literal_triple($uri, $g->qname_to_uri("dct:title"), "wibble");
-        $mTripod = $this->getMock('Tripod', array('getDataUpdater'), array('CBD_testing', 'tripod_php_testing'));
-        $mTripodUpdate = $this->getMock('Updates', array('getUniqId'), array($mTripod));
+        $mTripod = $this->getMock('\Tripod\Mongo\Tripod', array('getDataUpdater'), array('CBD_testing', 'tripod_php_testing'));
+        $mTripodUpdate = $this->getMock('\Tripod\Mongo\Updates', array('getUniqId'), array($mTripod));
 
         $mTripodUpdate->expects($this->atLeastOnce())
             ->method('getUniqId')
@@ -596,14 +595,14 @@ class MongoTransactionLogTest extends MongoTripodTestBase
             ->will($this->returnValue($mTripodUpdate));
 
         $mTripod->setTransactionLog($this->tripodTransactionLog);
-        $mTripod->saveChanges(new MongoGraph(), $g, 'http://talisaspire.com/');
+        $mTripod->saveChanges(new \Tripod\Mongo\MongoGraph(), $g, 'http://talisaspire.com/');
 
         // STEP 2
         // now attempt to update the entity but throw an exception in applyChangeset
         // this should cause the save to fail, and this should be reflected in the transaction log
         $mTripod = null;
-        $mTripod = $this->getMock('Tripod', array('getDataUpdater'), array('CBD_testing', 'tripod_php_testing'));
-        $mTripodUpdate = $this->getMock('Updates', array('getUniqId', 'applyChangeSet'), array($mTripod));
+        $mTripod = $this->getMock('\Tripod\Mongo\Tripod', array('getDataUpdater'), array('CBD_testing', 'tripod_php_testing'));
+        $mTripodUpdate = $this->getMock('\Tripod\Mongo\Updates', array('getUniqId', 'applyChangeSet'), array($mTripod));
 
         $mTripodUpdate->expects($this->atLeastOnce())
             ->method('getUniqId')
@@ -617,7 +616,7 @@ class MongoTransactionLogTest extends MongoTripodTestBase
             ->will($this->returnValue($mTripodUpdate));
 
         $mTripod->setTransactionLog($this->tripodTransactionLog);
-        $nG = new MongoGraph();
+        $nG = new \Tripod\Mongo\MongoGraph();
         $nG->add_graph($g);
         $nG->add_literal_triple($uri, $g->qname_to_uri("dct:title"), "another title");
 
@@ -665,18 +664,18 @@ class MongoTransactionLogTest extends MongoTripodTestBase
     public function testTransactionsLoggedCorrectlyFromMultipleTripods()
     {
         // Create two tripods onto different collection/dbname and make them use the same transaction log
-        $tripod1 = $this->getMock('Tripod', array('generateViewsAndSearchDocumentsForResources'), array('CBD_testing','tripod_php_testing'));
+        $tripod1 = $this->getMock('\Tripod\Mongo\Tripod', array('generateViewsAndSearchDocumentsForResources'), array('CBD_testing','tripod_php_testing'));
         $tripod1->expects($this->any())->method('generateViewsAndSearchDocumentsForResources');
         $this->getTripodCollection($tripod1)->drop();
         $tripod1->setTransactionLog($this->tripodTransactionLog);
 
-        $tripod2 = $this->getMock('Tripod', array('generateViewsAndSearchDocumentsForResources'), array('CBD_testing_2','tripod_php_testing'));
+        $tripod2 = $this->getMock('\Tripod\Mongo\Tripod', array('generateViewsAndSearchDocumentsForResources'), array('CBD_testing_2','tripod_php_testing'));
         $tripod2->expects($this->any())->method('generateViewsAndSearchDocumentsForResources');
         $this->getTripodCollection($tripod2)->drop();
         $tripod2->setTransactionLog($this->tripodTransactionLog);
 
         $uri = 'http://example.com/resources/1';
-        $g = new MongoGraph();
+        $g = new \Tripod\Mongo\MongoGraph();
         $g->add_literal_triple($uri, $g->qname_to_uri('searchterms:title'), "Some title");
         $g->add_literal_triple($uri, $g->qname_to_uri('searchterms:author'), "Some author");
 
@@ -692,9 +691,9 @@ class MongoTransactionLogTest extends MongoTripodTestBase
         $this->assertEquals(2, $this->tripodTransactionLog->getTotalTransactionCount());
 
         // change one of the documents
-        $oG = new MongoGraph();
+        $oG = new \Tripod\Mongo\MongoGraph();
         $oG->add_literal_triple($uri, $g->qname_to_uri('searchterms:title'), "Some title");
-        $nG = new MongoGraph();
+        $nG = new \Tripod\Mongo\MongoGraph();
         $nG->add_literal_triple($uri, $g->qname_to_uri('searchterms:title'), "Changed title");
         $tripod1->saveChanges($oG,$nG,'http://talisaspire.com/');
 
@@ -709,12 +708,12 @@ class MongoTransactionLogTest extends MongoTripodTestBase
      */
     public function testCreateNewTransactionThrowsExceptionIfInsertFails()
     {
-        $mockTransactionLog = $this->getMock('TransactionLog', array('insertTransaction'), array(), '', false, true);
+        $mockTransactionLog = $this->getMock('\Tripod\Mongo\TransactionLog', array('insertTransaction'), array(), '', false, true);
         $mockTransactionLog->expects($this->once())
             ->method('insertTransaction')
             ->will($this->returnValue(array('err'=>'something went wrong')));
 
-        /* @var $mockTransactionLog TransactionLog */
+        /* @var $mockTransactionLog \Tripod\Mongo\TransactionLog */
         try {
             $mockTransactionLog->createNewTransaction('transaction_1', array(), array(), 'mydb', 'mycollection');
             $this->fail("Exception should have been thrown by createNewTransaction");

--- a/test/unit/mongo/MongoTransactionLogTest.php
+++ b/test/unit/mongo/MongoTransactionLogTest.php
@@ -1,6 +1,6 @@
 <?php
 require_once 'MongoTripodTestBase.php';
-require_once 'src/mongo/Tripod.class.php';
+require_once 'src/mongo/Driver.class.php';
 require_once 'src/mongo/delegates/TransactionLog.class.php';
 require_once 'src/mongo/MongoGraph.class.php';
 
@@ -10,7 +10,7 @@ require_once 'src/mongo/MongoGraph.class.php';
 class MongoTransactionLogTest extends MongoTripodTestBase
 {
     /**
-     * @var \Tripod\Mongo\Tripod
+     * @var \Tripod\Mongo\Driver
      */
     protected $tripod
     ;
@@ -25,13 +25,13 @@ class MongoTransactionLogTest extends MongoTripodTestBase
         //Mongo::setPoolSize(200);
 
         // Stub ouf 'addToElastic' search to prevent writes into Elastic Search happening by default.
-        /** @var \Tripod\Mongo\Tripod|PHPUnit_Framework_MockObject_MockObject $tripod */
-        $this->tripod = $this->getMock('\Tripod\Mongo\Tripod', array('addToSearchIndexQueue'), array('CBD_testing','tripod_php_testing'));
+        /** @var \Tripod\Mongo\Driver|PHPUnit_Framework_MockObject_MockObject $tripod */
+        $this->tripod = $this->getMock('\Tripod\Mongo\Driver', array('addToSearchIndexQueue'), array('CBD_testing','tripod_php_testing'));
         $this->tripod->expects($this->any())->method('addToSearchIndexQueue');
 
         $this->getTripodCollection($this->tripod)->drop();
 
-        // Lock collection no longer available from Tripod, so drop it manually
+        // Lock collection no longer available from Driver, so drop it manually
         \Tripod\Mongo\Config::getInstance()->getCollectionForLocks($this->tripod->getStoreName())->drop();
 
         $this->loadBaseDataViaTripod();
@@ -467,7 +467,7 @@ class MongoTransactionLogTest extends MongoTripodTestBase
         $g->add_resource_triple($uri, $g->qname_to_uri("rdf:type"), $g->qname_to_uri("acorn:Resource"));
         $g->add_literal_triple($uri, $g->qname_to_uri("dct:title"), "wibble");
 
-        $mTripod = $this->getMock('\Tripod\Mongo\Tripod', array('getDataUpdater'), array('CBD_testing', 'tripod_php_testing'));
+        $mTripod = $this->getMock('\Tripod\Mongo\Driver', array('getDataUpdater'), array('CBD_testing', 'tripod_php_testing'));
         $mTripodUpdate = $this->getMock('\Tripod\Mongo\Updates', array('getUniqId'), array($mTripod));
 
         $mTripodUpdate->expects($this->atLeastOnce())
@@ -497,7 +497,7 @@ class MongoTransactionLogTest extends MongoTripodTestBase
         // STEP 2
         // update the same entity with an addition
         $mTripod = null;
-        $mTripod = $this->getMock('\Tripod\Mongo\Tripod', array('getDataUpdater'), array('CBD_testing', 'tripod_php_testing'));
+        $mTripod = $this->getMock('\Tripod\Mongo\Driver', array('getDataUpdater'), array('CBD_testing', 'tripod_php_testing'));
         $mTripodUpdate = $this->getMock('\Tripod\Mongo\Updates', array('getUniqId'), array($mTripod));
 
         $mTripodUpdate->expects($this->atLeastOnce())
@@ -543,7 +543,7 @@ class MongoTransactionLogTest extends MongoTripodTestBase
         // STEP 3
         // update the same entity with a removal
         $mTripod = null;
-        $mTripod = $this->getMock('\Tripod\Mongo\Tripod', array('getDataUpdater'), array('CBD_testing', 'tripod_php_testing'));
+        $mTripod = $this->getMock('\Tripod\Mongo\Driver', array('getDataUpdater'), array('CBD_testing', 'tripod_php_testing'));
         $mTripodUpdate = $this->getMock('\Tripod\Mongo\Updates', array('getUniqId'), array($mTripod));
 
         $mTripodUpdate->expects($this->atLeastOnce())
@@ -592,7 +592,7 @@ class MongoTransactionLogTest extends MongoTripodTestBase
         $g = new \Tripod\Mongo\MongoGraph();
         $g->add_resource_triple($uri, $g->qname_to_uri("rdf:type"), $g->qname_to_uri("acorn:Resource"));
         $g->add_literal_triple($uri, $g->qname_to_uri("dct:title"), "wibble");
-        $mTripod = $this->getMock('\Tripod\Mongo\Tripod', array('getDataUpdater'), array('CBD_testing', 'tripod_php_testing'));
+        $mTripod = $this->getMock('\Tripod\Mongo\Driver', array('getDataUpdater'), array('CBD_testing', 'tripod_php_testing'));
         $mTripodUpdate = $this->getMock('\Tripod\Mongo\Updates', array('getUniqId'), array($mTripod));
 
         $mTripodUpdate->expects($this->atLeastOnce())
@@ -609,7 +609,7 @@ class MongoTransactionLogTest extends MongoTripodTestBase
         // now attempt to update the entity but throw an exception in applyChangeset
         // this should cause the save to fail, and this should be reflected in the transaction log
         $mTripod = null;
-        $mTripod = $this->getMock('\Tripod\Mongo\Tripod', array('getDataUpdater'), array('CBD_testing', 'tripod_php_testing'));
+        $mTripod = $this->getMock('\Tripod\Mongo\Driver', array('getDataUpdater'), array('CBD_testing', 'tripod_php_testing'));
         $mTripodUpdate = $this->getMock('\Tripod\Mongo\Updates', array('getUniqId', 'applyChangeSet'), array($mTripod));
 
         $mTripodUpdate->expects($this->atLeastOnce())
@@ -672,12 +672,12 @@ class MongoTransactionLogTest extends MongoTripodTestBase
     public function testTransactionsLoggedCorrectlyFromMultipleTripods()
     {
         // Create two tripods onto different collection/dbname and make them use the same transaction log
-        $tripod1 = $this->getMock('\Tripod\Mongo\Tripod', array('generateViewsAndSearchDocumentsForResources'), array('CBD_testing','tripod_php_testing'));
+        $tripod1 = $this->getMock('\Tripod\Mongo\Driver', array('generateViewsAndSearchDocumentsForResources'), array('CBD_testing','tripod_php_testing'));
         $tripod1->expects($this->any())->method('generateViewsAndSearchDocumentsForResources');
         $this->getTripodCollection($tripod1)->drop();
         $tripod1->setTransactionLog($this->tripodTransactionLog);
 
-        $tripod2 = $this->getMock('\Tripod\Mongo\Tripod', array('generateViewsAndSearchDocumentsForResources'), array('CBD_testing_2','tripod_php_testing'));
+        $tripod2 = $this->getMock('\Tripod\Mongo\Driver', array('generateViewsAndSearchDocumentsForResources'), array('CBD_testing_2','tripod_php_testing'));
         $tripod2->expects($this->any())->method('generateViewsAndSearchDocumentsForResources');
         $this->getTripodCollection($tripod2)->drop();
         $tripod2->setTransactionLog($this->tripodTransactionLog);

--- a/test/unit/mongo/MongoTripodComputedFieldsTest.php
+++ b/test/unit/mongo/MongoTripodComputedFieldsTest.php
@@ -2,7 +2,7 @@
 
 require_once 'MongoTripodTestBase.php';
 require_once 'src/mongo/delegates/Tables.class.php';
-require_once 'src/mongo/Tripod.class.php';
+require_once 'src/mongo/Driver.class.php';
 require_once 'src/mongo/MongoGraph.class.php';
 
 class MongoTripodComputedFieldsTest extends MongoTripodTestBase
@@ -68,7 +68,7 @@ class MongoTripodComputedFieldsTest extends MongoTripodTestBase
         $newConfig['stores']['tripod_php_testing']['table_specifications'][] = $tableSpec;
         \Tripod\Mongo\Config::setConfig($newConfig);
         \Tripod\Mongo\Config::getInstance();
-        $this->tripod = new \Tripod\Mongo\Tripod('CBD_testing', 'tripod_php_testing');
+        $this->tripod = new \Tripod\Mongo\Driver('CBD_testing', 'tripod_php_testing');
         $this->loadBaseDataViaTripod();
         $this->tripod->generateTableRows('t_conditional_creators');
         $collection = \Tripod\Mongo\Config::getInstance()->getCollectionForTable('tripod_php_testing', 't_conditional_creators');
@@ -135,7 +135,7 @@ class MongoTripodComputedFieldsTest extends MongoTripodTestBase
         $newConfig['stores']['tripod_php_testing']['table_specifications'] = array($tableSpec);
         \Tripod\Mongo\Config::setConfig($newConfig);
         \Tripod\Mongo\Config::getInstance();
-        $this->tripod = new \Tripod\Mongo\Tripod('CBD_testing', 'tripod_php_testing');
+        $this->tripod = new \Tripod\Mongo\Driver('CBD_testing', 'tripod_php_testing');
         $this->loadBaseDataViaTripod();
         $this->tripod->generateTableRows('t_conditional_creators');
         $collection = \Tripod\Mongo\Config::getInstance()->getCollectionForTable('tripod_php_testing', 't_conditional_creators');
@@ -220,7 +220,7 @@ class MongoTripodComputedFieldsTest extends MongoTripodTestBase
         $newConfig['stores']['tripod_php_testing']['table_specifications'][] = $tableSpec;
         \Tripod\Mongo\Config::setConfig($newConfig);
         \Tripod\Mongo\Config::getInstance();
-        $this->tripod = new \Tripod\Mongo\Tripod('CBD_testing', 'tripod_php_testing');
+        $this->tripod = new \Tripod\Mongo\Driver('CBD_testing', 'tripod_php_testing');
         $this->loadBaseDataViaTripod();
         $this->tripod->generateTableRows('t_replace_type');
         $collection = \Tripod\Mongo\Config::getInstance()->getCollectionForTable('tripod_php_testing', 't_replace_type');
@@ -312,7 +312,7 @@ class MongoTripodComputedFieldsTest extends MongoTripodTestBase
         $newConfig['stores']['tripod_php_testing']['table_specifications'][] = $tableSpec;
         \Tripod\Mongo\Config::setConfig($newConfig);
         \Tripod\Mongo\Config::getInstance();
-        $this->tripod = new \Tripod\Mongo\Tripod('CBD_testing', 'tripod_php_testing');
+        $this->tripod = new \Tripod\Mongo\Driver('CBD_testing', 'tripod_php_testing');
         $this->loadBaseDataViaTripod();
         $this->tripod->generateTableRows('t_creator_count');
         $collection = \Tripod\Mongo\Config::getInstance()->getCollectionForTable('tripod_php_testing', 't_creator_count');
@@ -381,7 +381,7 @@ class MongoTripodComputedFieldsTest extends MongoTripodTestBase
         $newConfig['stores']['tripod_php_testing']['table_specifications'][] = $tableSpec;
         \Tripod\Mongo\Config::setConfig($newConfig);
         \Tripod\Mongo\Config::getInstance();
-        $this->tripod = new \Tripod\Mongo\Tripod('CBD_testing', 'tripod_php_testing');
+        $this->tripod = new \Tripod\Mongo\Driver('CBD_testing', 'tripod_php_testing');
         $this->loadBaseDataViaTripod();
         $this->tripod->generateTableRows('t_conditional_with_nested_arithmetic');
         $collection = \Tripod\Mongo\Config::getInstance()->getCollectionForTable('tripod_php_testing', 't_conditional_with_nested_arithmetic');
@@ -429,7 +429,7 @@ class MongoTripodComputedFieldsTest extends MongoTripodTestBase
         $newConfig['stores']['tripod_php_testing']['table_specifications'][] = $tableSpec;
         \Tripod\Mongo\Config::setConfig($newConfig);
         \Tripod\Mongo\Config::getInstance();
-        $this->tripod = new \Tripod\Mongo\Tripod('CBD_testing', 'tripod_php_testing');
+        $this->tripod = new \Tripod\Mongo\Driver('CBD_testing', 'tripod_php_testing');
         $this->loadBaseDataViaTripod();
         $this->tripod->generateTableRows('t_arithmetic_with_nested_conditional');
         $collection = \Tripod\Mongo\Config::getInstance()->getCollectionForTable('tripod_php_testing', 't_arithmetic_with_nested_conditional');

--- a/test/unit/mongo/MongoTripodComputedFieldsTest.php
+++ b/test/unit/mongo/MongoTripodComputedFieldsTest.php
@@ -1,8 +1,8 @@
 <?php
 
 require_once 'MongoTripodTestBase.php';
-require_once 'src/mongo/delegates/MongoTripodTables.class.php';
-require_once 'src/mongo/MongoTripod.class.php';
+require_once 'src/mongo/delegates/Tables.class.php';
+require_once 'src/mongo/Tripod.class.php';
 require_once 'src/mongo/MongoGraph.class.php';
 
 class MongoTripodComputedFieldsTest extends MongoTripodTestBase
@@ -12,14 +12,14 @@ class MongoTripodComputedFieldsTest extends MongoTripodTestBase
     public function setUp()
     {
         parent::setUp();
-        $this->originalConfig = MongoTripodConfig::getConfig();
-        MongoTripodConfig::setValidationLevel(MongoTripodConfig::VALIDATE_MAX);
+        $this->originalConfig = \Tripod\Mongo\Config::getConfig();
+        \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
     }
 
     public function tearDown()
     {
-        MongoTripodConfig::setConfig($this->originalConfig);
-        MongoTripodConfig::setValidationLevel(MongoTripodConfig::VALIDATE_MIN);
+        \Tripod\Mongo\Config::setConfig($this->originalConfig);
+        \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MIN);
         parent::tearDown();
     }
 
@@ -63,15 +63,15 @@ class MongoTripodComputedFieldsTest extends MongoTripodTestBase
             )
         );
 
-        $oldConfig = MongoTripodConfig::getConfig();
-        $newConfig = MongoTripodConfig::getConfig();
+        $oldConfig = \Tripod\Mongo\Config::getConfig();
+        $newConfig = \Tripod\Mongo\Config::getConfig();
         $newConfig['stores']['tripod_php_testing']['table_specifications'][] = $tableSpec;
-        MongoTripodConfig::setConfig($newConfig);
-        MongoTripodConfig::getInstance();
-        $this->tripod = new MongoTripod('CBD_testing', 'tripod_php_testing');
+        \Tripod\Mongo\Config::setConfig($newConfig);
+        \Tripod\Mongo\Config::getInstance();
+        $this->tripod = new \Tripod\Mongo\Tripod('CBD_testing', 'tripod_php_testing');
         $this->loadBaseDataViaTripod();
         $this->tripod->generateTableRows('t_conditional_creators');
-        $collection = MongoTripodConfig::getInstance()->getCollectionForTable('tripod_php_testing', 't_conditional_creators');
+        $collection = \Tripod\Mongo\Config::getInstance()->getCollectionForTable('tripod_php_testing', 't_conditional_creators');
 
         $tableDoc = $collection->findOne(array('_id.type'=>'t_conditional_creators', '_id.r'=>'baseData:foo1234'));
 
@@ -82,8 +82,8 @@ class MongoTripodComputedFieldsTest extends MongoTripodTestBase
         $this->assertEquals(1, $tableDoc['value']['creatorCount']);
         $this->assertEquals(2, $tableDoc['value']['contributorCount']);
 
-        MongoTripodConfig::setConfig($oldConfig);
-        MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::setConfig($oldConfig);
+        \Tripod\Mongo\Config::getInstance();
         $collection->drop();
     }
 
@@ -130,15 +130,15 @@ class MongoTripodComputedFieldsTest extends MongoTripodTestBase
             )
         );
 
-        $oldConfig = MongoTripodConfig::getConfig();
-        $newConfig = MongoTripodConfig::getConfig();
+        $oldConfig = \Tripod\Mongo\Config::getConfig();
+        $newConfig = \Tripod\Mongo\Config::getConfig();
         $newConfig['stores']['tripod_php_testing']['table_specifications'] = array($tableSpec);
-        MongoTripodConfig::setConfig($newConfig);
-        MongoTripodConfig::getInstance();
-        $this->tripod = new MongoTripod('CBD_testing', 'tripod_php_testing');
+        \Tripod\Mongo\Config::setConfig($newConfig);
+        \Tripod\Mongo\Config::getInstance();
+        $this->tripod = new \Tripod\Mongo\Tripod('CBD_testing', 'tripod_php_testing');
         $this->loadBaseDataViaTripod();
         $this->tripod->generateTableRows('t_conditional_creators');
-        $collection = MongoTripodConfig::getInstance()->getCollectionForTable('tripod_php_testing', 't_conditional_creators');
+        $collection = \Tripod\Mongo\Config::getInstance()->getCollectionForTable('tripod_php_testing', 't_conditional_creators');
 
         $tableDoc = $collection->findOne(array('_id.type'=>'t_conditional_creators', '_id.r'=>'baseData:foo1234'));
 
@@ -171,8 +171,8 @@ class MongoTripodComputedFieldsTest extends MongoTripodTestBase
         $this->assertArrayNotHasKey('contributorCount', $tableDoc['value']);
         $this->assertArrayNotHasKey('creatorCount', $tableDoc['value']);
 
-        MongoTripodConfig::setConfig($oldConfig);
-        MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::setConfig($oldConfig);
+        \Tripod\Mongo\Config::getInstance();
         $collection->drop();
     }
 
@@ -215,15 +215,15 @@ class MongoTripodComputedFieldsTest extends MongoTripodTestBase
             )
         );
 
-        $oldConfig = MongoTripodConfig::getConfig();
-        $newConfig = MongoTripodConfig::getConfig();
+        $oldConfig = \Tripod\Mongo\Config::getConfig();
+        $newConfig = \Tripod\Mongo\Config::getConfig();
         $newConfig['stores']['tripod_php_testing']['table_specifications'][] = $tableSpec;
-        MongoTripodConfig::setConfig($newConfig);
-        MongoTripodConfig::getInstance();
-        $this->tripod = new MongoTripod('CBD_testing', 'tripod_php_testing');
+        \Tripod\Mongo\Config::setConfig($newConfig);
+        \Tripod\Mongo\Config::getInstance();
+        $this->tripod = new \Tripod\Mongo\Tripod('CBD_testing', 'tripod_php_testing');
         $this->loadBaseDataViaTripod();
         $this->tripod->generateTableRows('t_replace_type');
-        $collection = MongoTripodConfig::getInstance()->getCollectionForTable('tripod_php_testing', 't_replace_type');
+        $collection = \Tripod\Mongo\Config::getInstance()->getCollectionForTable('tripod_php_testing', 't_replace_type');
 
         $tableDoc = $collection->findOne(array('_id.type'=>'t_replace_type', '_id.r'=>'baseData:foo1234'));
 
@@ -252,8 +252,8 @@ class MongoTripodComputedFieldsTest extends MongoTripodTestBase
         $this->assertEquals('Book Work', $tableDoc['value']['resourceType']);
         $this->assertArrayNotHasKey('rdfType', $tableDoc['value']);
 
-        MongoTripodConfig::setConfig($oldConfig);
-        MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::setConfig($oldConfig);
+        \Tripod\Mongo\Config::getInstance();
         $collection->drop();
     }
 
@@ -307,15 +307,15 @@ class MongoTripodComputedFieldsTest extends MongoTripodTestBase
             )
         );
 
-        $oldConfig = MongoTripodConfig::getConfig();
-        $newConfig = MongoTripodConfig::getConfig();
+        $oldConfig = \Tripod\Mongo\Config::getConfig();
+        $newConfig = \Tripod\Mongo\Config::getConfig();
         $newConfig['stores']['tripod_php_testing']['table_specifications'][] = $tableSpec;
-        MongoTripodConfig::setConfig($newConfig);
-        MongoTripodConfig::getInstance();
-        $this->tripod = new MongoTripod('CBD_testing', 'tripod_php_testing');
+        \Tripod\Mongo\Config::setConfig($newConfig);
+        \Tripod\Mongo\Config::getInstance();
+        $this->tripod = new \Tripod\Mongo\Tripod('CBD_testing', 'tripod_php_testing');
         $this->loadBaseDataViaTripod();
         $this->tripod->generateTableRows('t_creator_count');
-        $collection = MongoTripodConfig::getInstance()->getCollectionForTable('tripod_php_testing', 't_creator_count');
+        $collection = \Tripod\Mongo\Config::getInstance()->getCollectionForTable('tripod_php_testing', 't_creator_count');
 
         $tableDoc = $collection->findOne(array('_id.type'=>'t_creator_count', '_id.r'=>'baseData:foo1234'));
 
@@ -348,8 +348,8 @@ class MongoTripodComputedFieldsTest extends MongoTripodTestBase
         $this->assertArrayNotHasKey('contributorCount', $tableDoc['value']);
         $this->assertArrayNotHasKey('creatorCount', $tableDoc['value']);
 
-        MongoTripodConfig::setConfig($oldConfig);
-        MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::setConfig($oldConfig);
+        \Tripod\Mongo\Config::getInstance();
         $collection->drop();
     }
 
@@ -376,20 +376,20 @@ class MongoTripodComputedFieldsTest extends MongoTripodTestBase
                 )
             )
         );
-        $oldConfig = MongoTripodConfig::getConfig();
-        $newConfig = MongoTripodConfig::getConfig();
+        $oldConfig = \Tripod\Mongo\Config::getConfig();
+        $newConfig = \Tripod\Mongo\Config::getConfig();
         $newConfig['stores']['tripod_php_testing']['table_specifications'][] = $tableSpec;
-        MongoTripodConfig::setConfig($newConfig);
-        MongoTripodConfig::getInstance();
-        $this->tripod = new MongoTripod('CBD_testing', 'tripod_php_testing');
+        \Tripod\Mongo\Config::setConfig($newConfig);
+        \Tripod\Mongo\Config::getInstance();
+        $this->tripod = new \Tripod\Mongo\Tripod('CBD_testing', 'tripod_php_testing');
         $this->loadBaseDataViaTripod();
         $this->tripod->generateTableRows('t_conditional_with_nested_arithmetic');
-        $collection = MongoTripodConfig::getInstance()->getCollectionForTable('tripod_php_testing', 't_conditional_with_nested_arithmetic');
+        $collection = \Tripod\Mongo\Config::getInstance()->getCollectionForTable('tripod_php_testing', 't_conditional_with_nested_arithmetic');
         $tableDoc = $collection->findOne(array('_id.type'=>'t_conditional_with_nested_arithmetic'));
 
         $this->assertEquals('b', $tableDoc['value']['foobar']);
-        MongoTripodConfig::setConfig($oldConfig);
-        MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::setConfig($oldConfig);
+        \Tripod\Mongo\Config::getInstance();
         $collection->drop();
     }
 
@@ -424,20 +424,20 @@ class MongoTripodComputedFieldsTest extends MongoTripodTestBase
                 )
             )
         );
-        $oldConfig = MongoTripodConfig::getConfig();
-        $newConfig = MongoTripodConfig::getConfig();
+        $oldConfig = \Tripod\Mongo\Config::getConfig();
+        $newConfig = \Tripod\Mongo\Config::getConfig();
         $newConfig['stores']['tripod_php_testing']['table_specifications'][] = $tableSpec;
-        MongoTripodConfig::setConfig($newConfig);
-        MongoTripodConfig::getInstance();
-        $this->tripod = new MongoTripod('CBD_testing', 'tripod_php_testing');
+        \Tripod\Mongo\Config::setConfig($newConfig);
+        \Tripod\Mongo\Config::getInstance();
+        $this->tripod = new \Tripod\Mongo\Tripod('CBD_testing', 'tripod_php_testing');
         $this->loadBaseDataViaTripod();
         $this->tripod->generateTableRows('t_arithmetic_with_nested_conditional');
-        $collection = MongoTripodConfig::getInstance()->getCollectionForTable('tripod_php_testing', 't_arithmetic_with_nested_conditional');
+        $collection = \Tripod\Mongo\Config::getInstance()->getCollectionForTable('tripod_php_testing', 't_arithmetic_with_nested_conditional');
         $tableDoc = $collection->findOne(array('_id.type'=>'t_arithmetic_with_nested_conditional'));
 
         $this->assertEquals(300, $tableDoc['value']['foobar']);
-        MongoTripodConfig::setConfig($oldConfig);
-        MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::setConfig($oldConfig);
+        \Tripod\Mongo\Config::getInstance();
         $collection->drop();
     }
 }

--- a/test/unit/mongo/MongoTripodConfigTest.php
+++ b/test/unit/mongo/MongoTripodConfigTest.php
@@ -1133,7 +1133,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
             $this->markTestSkipped("All datasources configured for store use same configuration, nothing to test");
         }
 
-        $this->tripod = new \Tripod\Mongo\Tripod('CBD_testing', $storeName, array(OP_ASYNC=>array(OP_VIEWS=>true,OP_TABLES=>false,OP_SEARCH=>false)));
+        $this->tripod = new \Tripod\Mongo\Driver('CBD_testing', $storeName, array(OP_ASYNC=>array(OP_VIEWS=>true,OP_TABLES=>false,OP_SEARCH=>false)));
         $this->loadBaseDataViaTripod();
 
         $graph = new \Tripod\Mongo\MongoGraph();

--- a/test/unit/mongo/MongoTripodConfigTest.php
+++ b/test/unit/mongo/MongoTripodConfigTest.php
@@ -19,7 +19,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         // to test that the instance throws an exception if it is called before calling setConfig
         // i first have to destroy the instance that is created in the setUp() method of our test suite.
 
-        $this->setExpectedException('MongoTripodConfigException','Call TripodConfig::setConfig() first');
+        $this->setExpectedException('\Tripod\Exceptions\ConfigException','Call Config::setConfig() first');
         unset($this->tripodConfig);
 
         \Tripod\Mongo\Config::getInstance()->destroy();
@@ -98,7 +98,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
     public function testTConfigRepSetConnStrThrowsException()
     {
         $this->setExpectedException(
-                   'MongoTripodConfigException',
+                   '\Tripod\Exceptions\ConfigException',
                    'Connection string for \'rs1\' must include /admin database when connecting to Replica Set');
 
         $config=array();
@@ -151,7 +151,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
     public function testGetConnectionStringThrowsException()
     {
         $this->setExpectedException(
-            'MongoTripodConfigException',
+            '\Tripod\Exceptions\ConfigException',
             'Database notexists does not exist in configuration');
         $this->assertEquals("mongodb://localhost",\Tripod\Mongo\Config::getInstance()->getConnStr("notexists"));
     }
@@ -184,7 +184,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
 
     public function testGetConnectionStringThrowsExceptionForReplicaSet(){
         $this->setExpectedException(
-                   'MongoTripodConfigException',
+                   '\Tripod\Exceptions\ConfigException',
                    'Connection string for \'rs1\' must include /admin database when connecting to Replica Set');
         $config=array();
         $config["defaultContext"] = "http://talisaspire.com/";
@@ -218,7 +218,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
     public function testCompoundIndexAllArraysThrowsException()
     {
         $this->setExpectedException(
-            'MongoTripodConfigException',
+            '\Tripod\Exceptions\ConfigException',
             'Compound index IllegalCompoundIndex has more than one field with cardinality > 1 - mongo will not be able to build this index');
         $config = array();
         $config["defaultContext"] = "http://talisaspire.com/";
@@ -255,14 +255,14 @@ class MongoTripodConfigTest extends MongoTripodTestBase
     public function testSearchConfig()
     {
         $config = \Tripod\Mongo\Config::getInstance();
-        $this->assertEquals('MongoSearchProvider', $config->getSearchProviderClassName('tripod_php_testing'));
+        $this->assertEquals('\Tripod\Mongo\MongoSearchProvider', $config->getSearchProviderClassName('tripod_php_testing'));
 
         $this->assertEquals(3, count($config->getSearchDocumentSpecifications('tripod_php_testing')));
     }
 
     public function testCardinalityRuleWithNoNamespace()
     {
-        $this->setExpectedException('MongoTripodConfigException', "Cardinality 'foo:bar' does not have the namespace defined");
+        $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Cardinality 'foo:bar' does not have the namespace defined");
 
         $config = array();
         $config["defaultContext"] = "http://talisaspire.com/";
@@ -391,7 +391,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
     public function testViewSpecCountWithoutTTLThrowsException()
     {
         $this->setExpectedException(
-            'MongoTripodConfigException',
+            '\Tripod\Exceptions\ConfigException',
             'Aggregate function counts exists in spec, but no TTL defined');
         $config = array();
         $config["defaultContext"] = "http://talisaspire.com/";
@@ -432,7 +432,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
     public function testViewSpecCountNestedInJoinWithoutTTLThrowsException()
     {
         $this->setExpectedException(
-            'MongoTripodConfigException',
+            '\Tripod\Exceptions\ConfigException',
             'Aggregate function counts exists in spec, but no TTL defined');
         $config = array();
         $config["defaultContext"] = "http://talisaspire.com/";
@@ -476,7 +476,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
     public function testTableSpecNestedCountWithoutPropertyThrowsException()
     {
         $this->setExpectedException(
-            'MongoTripodConfigException',
+            '\Tripod\Exceptions\ConfigException',
             'Count spec does not contain property');
         $config = array();
         $config["defaultContext"] = "http://talisaspire.com/";
@@ -518,7 +518,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
     public function testTableSpecNested2ndLevelCountWithoutFieldNameThrowsException()
     {
         $this->setExpectedException(
-            'MongoTripodConfigException',
+            '\Tripod\Exceptions\ConfigException',
             'Count spec does not contain fieldName');
         $config = array();
         $config["defaultContext"] = "http://talisaspire.com/";
@@ -563,7 +563,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
     public function testTableSpecFieldWithoutFieldName()
     {
         $this->setExpectedException(
-            'MongoTripodConfigException',
+            '\Tripod\Exceptions\ConfigException',
             'Field spec does not contain fieldName');
         $config = array();
         $config["defaultContext"] = "http://talisaspire.com/";
@@ -602,7 +602,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
     public function testTableSpecFieldWithoutPredicates()
     {
         $this->setExpectedException(
-            'MongoTripodConfigException',
+            '\Tripod\Exceptions\ConfigException',
             'Field spec does not contain predicates');
         $config = array();
         $config["defaultContext"] = "http://talisaspire.com/";
@@ -641,7 +641,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
     public function testTableSpecCountWithoutProperty()
     {
         $this->setExpectedException(
-            'MongoTripodConfigException',
+            '\Tripod\Exceptions\ConfigException',
             'Count spec does not contain property');
         $config = array();
         $config["defaultContext"] = "http://talisaspire.com/";
@@ -680,7 +680,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
     public function testTableSpecCountWithoutFieldName()
     {
         $this->setExpectedException(
-            'MongoTripodConfigException',
+            '\Tripod\Exceptions\ConfigException',
             'Count spec does not contain fieldName');
         $config = array();
         $config["defaultContext"] = "http://talisaspire.com/";
@@ -719,7 +719,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
     public function testTableSpecCountWithoutPropertyAsAString()
     {
         $this->setExpectedException(
-            'MongoTripodConfigException',
+            '\Tripod\Exceptions\ConfigException',
             'Count spec property was not a string');
         $config = array();
         $config["defaultContext"] = "http://talisaspire.com/";
@@ -759,7 +759,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
     public function testConfigWithoutDefaultNamespaceThrowsException()
     {
         $this->setExpectedException(
-            'MongoTripodConfigException',
+            '\Tripod\Exceptions\ConfigException',
             'Mandatory config key [defaultContext] is missing from config');
         $config = array();
         $config["data_sources"] = array(
@@ -1147,10 +1147,6 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $newGraph->add_literal_triple($subject, $labeller->qname_to_uri('foaf:email'), 'anne@example.com');
         $this->tripod->saveChanges($graph, $newGraph);
 
-        // Add an item to the queue todo: why?
-//        $queue = new MongoTripodQueue();
-//        $queue->addItem(new ChangeSet(),array(),"foo","CBD_wibble",array(OP_VIEWS));
-
         // Generate views and tables
         foreach($config->getViewSpecifications($storeName) as $viewId=>$viewSpec)
         {
@@ -1275,7 +1271,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $computedFieldFunction = array('fieldName'=>'fooBar', 'value'=>array('shazzbot'=>array()));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($computedFieldFunction);
         \Tripod\Mongo\Config::setConfig($newConfig);
-        $this->setExpectedException('MongoTripodConfigException', "Computed field spec does not contain valid function");
+        $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed field spec does not contain valid function");
         \Tripod\Mongo\Config::getInstance();
     }
 
@@ -1286,7 +1282,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $computedFieldFunction = array('fieldName'=>'fooBar', 'value'=>array('conditional'=>array(),'replace'=>array()));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($computedFieldFunction);
         \Tripod\Mongo\Config::setConfig($newConfig);
-        $this->setExpectedException('MongoTripodConfigException', "Computed field spec contains more than one function");
+        $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed field spec contains more than one function");
         \Tripod\Mongo\Config::getInstance();
     }
 
@@ -1297,7 +1293,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $computedFieldFunction = array('fieldName'=>'fooBar', 'value'=>array('conditional'=>array()));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['joins']['dct:isVersionOf']['computed_fields'] = array($computedFieldFunction);
         \Tripod\Mongo\Config::setConfig($newConfig);
-        $this->setExpectedException('MongoTripodConfigException', "Table spec can only contain 'computed_fields' at the base level");
+        $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Table spec can only contain 'computed_fields' at the base level");
         \Tripod\Mongo\Config::getInstance();
     }
 
@@ -1308,7 +1304,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $conditionalFunction = array('fieldName'=>'fooBar', 'value'=>array('conditional'=>array()));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($conditionalFunction);
         \Tripod\Mongo\Config::setConfig($newConfig);
-        $this->setExpectedException('MongoTripodConfigException', "Computed conditional spec does not contain an 'if' value");
+        $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed conditional spec does not contain an 'if' value");
         \Tripod\Mongo\Config::getInstance();
     }
 
@@ -1319,7 +1315,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $conditionalFunction = array('fieldName'=>'fooBar', 'value'=>array('conditional'=>array('if'=>array())));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($conditionalFunction);
         \Tripod\Mongo\Config::setConfig($newConfig);
-        $this->setExpectedException('MongoTripodConfigException', "Computed conditional spec must contain a then or else value");
+        $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed conditional spec must contain a then or else value");
         \Tripod\Mongo\Config::getInstance();
     }
 
@@ -1330,7 +1326,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $conditionalFunction = array('fieldName'=>'fooBar', 'value'=>array('conditional'=>array('if'=>array(),'then'=>'wibble')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($conditionalFunction);
         \Tripod\Mongo\Config::setConfig($newConfig);
-        $this->setExpectedException('MongoTripodConfigException', "Computed conditional field spec 'if' value array must have 1 or 3 values");
+        $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed conditional field spec 'if' value array must have 1 or 3 values");
         \Tripod\Mongo\Config::getInstance();
     }
 
@@ -1341,7 +1337,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $conditionalFunction = array('fieldName'=>'fooBar', 'value'=>array('conditional'=>array('if'=>'foo','then'=>'wibble')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($conditionalFunction);
         \Tripod\Mongo\Config::setConfig($newConfig);
-        $this->setExpectedException('MongoTripodConfigException', "Computed conditional field spec 'if' value must be an array");
+        $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed conditional field spec 'if' value must be an array");
         \Tripod\Mongo\Config::getInstance();
     }
 
@@ -1352,7 +1348,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $conditionalFunction = array('fieldName'=>'fooBar', 'value'=>array('conditional'=>array('if'=>array('foo','*'),'then'=>'wibble')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($conditionalFunction);
         \Tripod\Mongo\Config::setConfig($newConfig);
-        $this->setExpectedException('MongoTripodConfigException', "Computed conditional field spec 'if' value array must have 1 or 3 values");
+        $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed conditional field spec 'if' value array must have 1 or 3 values");
         \Tripod\Mongo\Config::getInstance();
     }
 
@@ -1363,7 +1359,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $conditionalFunction = array('fieldName'=>'fooBar', 'value'=>array('conditional'=>array('if'=>array('a','b','c','d'),'then'=>'wibble')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($conditionalFunction);
         \Tripod\Mongo\Config::setConfig($newConfig);
-        $this->setExpectedException('MongoTripodConfigException', "Computed conditional field spec 'if' value array must have 1 or 3 values");
+        $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed conditional field spec 'if' value array must have 1 or 3 values");
         \Tripod\Mongo\Config::getInstance();
     }
 
@@ -1374,7 +1370,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $conditionalFunction = array('fieldName'=>'fooBar', 'value'=>array('conditional'=>array('if'=>array('a','*','c'),'then'=>'wibble')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($conditionalFunction);
         \Tripod\Mongo\Config::setConfig($newConfig);
-        $this->setExpectedException('MongoTripodConfigException', "Invalid conditional operator '*' in conditional spec");
+        $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Invalid conditional operator '*' in conditional spec");
         \Tripod\Mongo\Config::getInstance();
     }
 
@@ -1385,7 +1381,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $conditionalFunction = array('fieldName'=>'fooBar', 'value'=>array('conditional'=>array('if'=>array('$wibble','>=','c'),'then'=>'wibble')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($conditionalFunction);
         \Tripod\Mongo\Config::setConfig($newConfig);
-        $this->setExpectedException('MongoTripodConfigException', "Computed spec variable '\$wibble' is not defined in table spec");
+        $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed spec variable '\$wibble' is not defined in table spec");
         \Tripod\Mongo\Config::getInstance();
     }
 
@@ -1396,7 +1392,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $conditionalFunction = array('fieldName'=>'fooBar', 'value'=>array('conditional'=>array('if'=>array('a','contains','$wibble'),'then'=>'wibble')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($conditionalFunction);
         \Tripod\Mongo\Config::setConfig($newConfig);
-        $this->setExpectedException('MongoTripodConfigException', "Computed spec variable '\$wibble' is not defined in table spec");
+        $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed spec variable '\$wibble' is not defined in table spec");
         \Tripod\Mongo\Config::getInstance();
     }
 
@@ -1407,7 +1403,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $conditionalFunction = array('fieldName'=>'fooBar', 'value'=>array('conditional'=>array('if'=>array('a','<','b'),'then'=>'$wibble')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($conditionalFunction);
         \Tripod\Mongo\Config::setConfig($newConfig);
-        $this->setExpectedException('MongoTripodConfigException', "Computed spec variable '\$wibble' is not defined in table spec");
+        $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed spec variable '\$wibble' is not defined in table spec");
         \Tripod\Mongo\Config::getInstance();
     }
 
@@ -1419,7 +1415,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $conditionalFunction = array('fieldName'=>'fooBar', 'value'=>array('conditional'=>array('if'=>array('a','<','b'),'then'=>true,'else'=>'$wibble')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($conditionalFunction);
         \Tripod\Mongo\Config::setConfig($newConfig);
-        $this->setExpectedException('MongoTripodConfigException', "Computed spec variable '\$wibble' is not defined in table spec");
+        $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed spec variable '\$wibble' is not defined in table spec");
         \Tripod\Mongo\Config::getInstance();
     }
 
@@ -1430,7 +1426,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $replaceFunction = array('fieldName'=>'fooBar', 'value'=>array('replace'=>array()));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($replaceFunction);
         \Tripod\Mongo\Config::setConfig($newConfig);
-        $this->setExpectedException('MongoTripodConfigException', "Computed replace spec does not contain 'search' value");
+        $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed replace spec does not contain 'search' value");
         \Tripod\Mongo\Config::getInstance();
     }
 
@@ -1441,7 +1437,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $replaceFunction = array('fieldName'=>'fooBar', 'value'=>array('replace'=>array('search'=>'x')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($replaceFunction);
         \Tripod\Mongo\Config::setConfig($newConfig);
-        $this->setExpectedException('MongoTripodConfigException', "Computed replace spec does not contain 'replace' value");
+        $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed replace spec does not contain 'replace' value");
         \Tripod\Mongo\Config::getInstance();
     }
 
@@ -1452,7 +1448,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $replaceFunction = array('fieldName'=>'fooBar', 'value'=>array('replace'=>array('search'=>'x', 'replace'=>'y')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($replaceFunction);
         \Tripod\Mongo\Config::setConfig($newConfig);
-        $this->setExpectedException('MongoTripodConfigException', "Computed replace spec does not contain 'subject' value");
+        $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed replace spec does not contain 'subject' value");
         \Tripod\Mongo\Config::getInstance();
     }
 
@@ -1463,7 +1459,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $replaceFunction = array('fieldName'=>'fooBar', 'value'=>array('replace'=>array('search'=>'$x','replace'=>'y','subject'=>'z')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($replaceFunction);
         \Tripod\Mongo\Config::setConfig($newConfig);
-        $this->setExpectedException('MongoTripodConfigException', "Computed spec variable '\$x' is not defined in table spec");
+        $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed spec variable '\$x' is not defined in table spec");
         \Tripod\Mongo\Config::getInstance();
     }
 
@@ -1474,7 +1470,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $replaceFunction = array('fieldName'=>'fooBar', 'value'=>array('replace'=>array('search'=>array('a','b','$x'),'replace'=>'y','subject'=>'z')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($replaceFunction);
         \Tripod\Mongo\Config::setConfig($newConfig);
-        $this->setExpectedException('MongoTripodConfigException', "Computed spec variable '\$x' is not defined in table spec");
+        $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed spec variable '\$x' is not defined in table spec");
         \Tripod\Mongo\Config::getInstance();
     }
 
@@ -1485,7 +1481,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $replaceFunction = array('fieldName'=>'fooBar', 'value'=>array('replace'=>array('search'=>'x','replace'=>'$y','subject'=>'z')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($replaceFunction);
         \Tripod\Mongo\Config::setConfig($newConfig);
-        $this->setExpectedException('MongoTripodConfigException', "Computed spec variable '\$y' is not defined in table spec");
+        $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed spec variable '\$y' is not defined in table spec");
         \Tripod\Mongo\Config::getInstance();
     }
 
@@ -1496,7 +1492,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $replaceFunction = array('fieldName'=>'fooBar', 'value'=>array('replace'=>array('search'=>'x','replace'=>array('a','$y', 'c'),'subject'=>'z')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($replaceFunction);
         \Tripod\Mongo\Config::setConfig($newConfig);
-        $this->setExpectedException('MongoTripodConfigException', "Computed spec variable '\$y' is not defined in table spec");
+        $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed spec variable '\$y' is not defined in table spec");
         \Tripod\Mongo\Config::getInstance();
     }
 
@@ -1507,7 +1503,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $replaceFunction = array('fieldName'=>'fooBar', 'value'=>array('replace'=>array('search'=>'x','replace'=>'y','subject'=>'$z')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($replaceFunction);
         \Tripod\Mongo\Config::setConfig($newConfig);
-        $this->setExpectedException('MongoTripodConfigException', "Computed spec variable '\$z' is not defined in table spec");
+        $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed spec variable '\$z' is not defined in table spec");
         \Tripod\Mongo\Config::getInstance();
     }
 
@@ -1518,7 +1514,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $replaceFunction = array('fieldName'=>'fooBar', 'value'=>array('replace'=>array('search'=>'x','replace'=>'y','subject'=>array('$z','b','c'))));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($replaceFunction);
         \Tripod\Mongo\Config::setConfig($newConfig);
-        $this->setExpectedException('MongoTripodConfigException', "Computed spec variable '\$z' is not defined in table spec");
+        $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed spec variable '\$z' is not defined in table spec");
         \Tripod\Mongo\Config::getInstance();
     }
 
@@ -1529,7 +1525,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $arithmeticFunction = array('fieldName'=>'fooBar', 'value'=>array('arithmetic'=>array()));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($arithmeticFunction);
         \Tripod\Mongo\Config::setConfig($newConfig);
-        $this->setExpectedException('MongoTripodConfigException', "Computed arithmetic spec must contain 3 values");
+        $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed arithmetic spec must contain 3 values");
         \Tripod\Mongo\Config::getInstance();
     }
 
@@ -1540,7 +1536,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $arithmeticFunction = array('fieldName'=>'fooBar', 'value'=>array('arithmetic'=>array(1)));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($arithmeticFunction);
         \Tripod\Mongo\Config::setConfig($newConfig);
-        $this->setExpectedException('MongoTripodConfigException', "Computed arithmetic spec must contain 3 values");
+        $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed arithmetic spec must contain 3 values");
         \Tripod\Mongo\Config::getInstance();
     }
 
@@ -1551,7 +1547,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $arithmeticFunction = array('fieldName'=>'fooBar', 'value'=>array('arithmetic'=>array(1,'+')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($arithmeticFunction);
         \Tripod\Mongo\Config::setConfig($newConfig);
-        $this->setExpectedException('MongoTripodConfigException', "Computed arithmetic spec must contain 3 values");
+        $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed arithmetic spec must contain 3 values");
         \Tripod\Mongo\Config::getInstance();
     }
 
@@ -1562,7 +1558,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $arithmeticFunction = array('fieldName'=>'fooBar', 'value'=>array('arithmetic'=>array(1,'+',3,4)));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($arithmeticFunction);
         \Tripod\Mongo\Config::setConfig($newConfig);
-        $this->setExpectedException('MongoTripodConfigException', "Computed arithmetic spec must contain 3 values");
+        $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed arithmetic spec must contain 3 values");
         \Tripod\Mongo\Config::getInstance();
     }
 
@@ -1573,7 +1569,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $arithmeticFunction = array('fieldName'=>'fooBar', 'value'=>array('arithmetic'=>array(1,'x',3)));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($arithmeticFunction);
         \Tripod\Mongo\Config::setConfig($newConfig);
-        $this->setExpectedException('MongoTripodConfigException', "Invalid arithmetic operator 'x' in computed arithmetic spec");
+        $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Invalid arithmetic operator 'x' in computed arithmetic spec");
         \Tripod\Mongo\Config::getInstance();
     }
 
@@ -1584,7 +1580,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $arithmeticFunction = array('fieldName'=>'fooBar', 'value'=>array('arithmetic'=>array('$x','*',3)));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($arithmeticFunction);
         \Tripod\Mongo\Config::setConfig($newConfig);
-        $this->setExpectedException('MongoTripodConfigException', "Computed spec variable '\$x' is not defined in table spec");
+        $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed spec variable '\$x' is not defined in table spec");
         \Tripod\Mongo\Config::getInstance();
     }
 
@@ -1595,7 +1591,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $arithmeticFunction = array('fieldName'=>'fooBar', 'value'=>array('arithmetic'=>array(1,'*','$x')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($arithmeticFunction);
         \Tripod\Mongo\Config::setConfig($newConfig);
-        $this->setExpectedException('MongoTripodConfigException', "Computed spec variable '\$x' is not defined in table spec");
+        $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed spec variable '\$x' is not defined in table spec");
         \Tripod\Mongo\Config::getInstance();
     }
 
@@ -1606,7 +1602,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $arithmeticFunction = array('fieldName'=>'fooBar', 'value'=>array('arithmetic'=>array(array('$x','-',100),'*',3)));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($arithmeticFunction);
         \Tripod\Mongo\Config::setConfig($newConfig);
-        $this->setExpectedException('MongoTripodConfigException', "Computed spec variable '\$x' is not defined in table spec");
+        $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed spec variable '\$x' is not defined in table spec");
         \Tripod\Mongo\Config::getInstance();
     }
 
@@ -1617,7 +1613,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $arithmeticFunction = array('fieldName'=>'fooBar', 'value'=>array('arithmetic'=>array(array(101,'#',100),'*',3)));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($arithmeticFunction);
         \Tripod\Mongo\Config::setConfig($newConfig);
-        $this->setExpectedException('MongoTripodConfigException', "Invalid arithmetic operator '#' in computed arithmetic spec");
+        $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Invalid arithmetic operator '#' in computed arithmetic spec");
         \Tripod\Mongo\Config::getInstance();
     }
 

--- a/test/unit/mongo/MongoTripodConfigTest.php
+++ b/test/unit/mongo/MongoTripodConfigTest.php
@@ -1,18 +1,17 @@
 <?php
 require_once 'MongoTripodTestBase.php';
-require_once 'src/mongo/MongoTripodConfig.class.php';
-
+require_once 'src/mongo/Config.class.php';
 class MongoTripodConfigTest extends MongoTripodTestBase
 {
     /**
-     * @var MongoTripodConfig
+     * @var \Tripod\Mongo\Config
      */
     private $tripodConfig = null;
 
     protected function setUp()
     {
         parent::setup();
-        $this->tripodConfig = MongoTripodConfig::getInstance();
+        $this->tripodConfig = \Tripod\Mongo\Config::getInstance();
     }
 
     public function testGetInstanceThrowsExceptionIfSetInstanceNotCalledFirst()
@@ -20,11 +19,11 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         // to test that the instance throws an exception if it is called before calling setConfig
         // i first have to destroy the instance that is created in the setUp() method of our test suite.
 
-        $this->setExpectedException('MongoTripodConfigException','Call MongoTripodConfig::setConfig() first');
+        $this->setExpectedException('MongoTripodConfigException','Call TripodConfig::setConfig() first');
         unset($this->tripodConfig);
 
-        MongoTripodConfig::getInstance()->destroy();
-        MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::getInstance()->destroy();
+        \Tripod\Mongo\Config::getInstance();
     }
 
     public function testNamespaces()
@@ -55,8 +54,8 @@ class MongoTripodConfigTest extends MongoTripodTestBase
 
     public function testTConfig()
     {
-        $config = MongoTripodConfig::getInstance();
-        $cfg = MongoTripodConfig::getConfig();
+        $config = \Tripod\Mongo\Config::getInstance();
+        $cfg = \Tripod\Mongo\Config::getConfig();
         $tConfig = $config->getTransactionLogConfig();
         $this->assertEquals('tripod_php_testing',$tConfig['database']);
         $this->assertEquals('transaction_log',$tConfig['collection']);
@@ -91,8 +90,8 @@ class MongoTripodConfigTest extends MongoTripodTestBase
 
         );
 
-        MongoTripodConfig::setConfig($config);
-        $mtc = MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::setConfig($config);
+        $mtc = \Tripod\Mongo\Config::getInstance();
         $this->assertEquals("mongodb://tloghost:27017,tloghost:27018/admin",$mtc->getTransactionLogConnStr());
     }
 
@@ -129,8 +128,8 @@ class MongoTripodConfigTest extends MongoTripodTestBase
             "data_source"=>"rs1"
         );
 
-        MongoTripodConfig::setConfig($config);
-        $mtc = MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::setConfig($config);
+        $mtc = \Tripod\Mongo\Config::getInstance();
 
         $connStr = $mtc->getTransactionLogConnStr();
     }
@@ -146,7 +145,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
 
     public function testGetConnectionString()
     {
-        $this->assertEquals("mongodb://localhost",MongoTripodConfig::getInstance()->getConnStr("tripod_php_testing"));
+        $this->assertEquals("mongodb://localhost",\Tripod\Mongo\Config::getInstance()->getConnStr("tripod_php_testing"));
     }
 
     public function testGetConnectionStringThrowsException()
@@ -154,7 +153,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $this->setExpectedException(
             'MongoTripodConfigException',
             'Database notexists does not exist in configuration');
-        $this->assertEquals("mongodb://localhost",MongoTripodConfig::getInstance()->getConnStr("notexists"));
+        $this->assertEquals("mongodb://localhost",\Tripod\Mongo\Config::getInstance()->getConnStr("notexists"));
     }
 
     public function testGetConnectionStringForReplicaSet(){
@@ -177,8 +176,8 @@ class MongoTripodConfigTest extends MongoTripodTestBase
             )
         );
 
-        MongoTripodConfig::setConfig($config);
-        $mtc = MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::setConfig($config);
+        $mtc = \Tripod\Mongo\Config::getInstance();
 
         $this->assertEquals("mongodb://localhost:27017,localhost:27018/admin",$mtc->getConnStr("tripod_php_testing"));
     }
@@ -210,8 +209,8 @@ class MongoTripodConfigTest extends MongoTripodTestBase
             )
         );
 
-        MongoTripodConfig::setConfig($config);
-        $mtc = MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::setConfig($config);
+        $mtc = \Tripod\Mongo\Config::getInstance();
 
         $mtc->getConnStr("tripod_php_testing");
     }
@@ -249,13 +248,13 @@ class MongoTripodConfigTest extends MongoTripodTestBase
             )
         );
 
-        MongoTripodConfig::setConfig($config);
-        $mtc = MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::setConfig($config);
+        $mtc = \Tripod\Mongo\Config::getInstance();
     }
 
     public function testSearchConfig()
     {
-        $config = MongoTripodConfig::getInstance();
+        $config = \Tripod\Mongo\Config::getInstance();
         $this->assertEquals('MongoSearchProvider', $config->getSearchProviderClassName('tripod_php_testing'));
 
         $this->assertEquals(3, count($config->getSearchDocumentSpecifications('tripod_php_testing')));
@@ -286,8 +285,8 @@ class MongoTripodConfigTest extends MongoTripodTestBase
                 )
             )
         );
-        MongoTripodConfig::setConfig($config);
-        $mtc = MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::setConfig($config);
+        $mtc = \Tripod\Mongo\Config::getInstance();
     }
 
     public function testGetSearchDocumentSpecificationsByType()
@@ -332,7 +331,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
                 )
             )
         );
-        $actualSpec = MongoTripodConfig::getInstance()->getSearchDocumentSpecifications("tripod_php_testing", "resourcelist:List");
+        $actualSpec = \Tripod\Mongo\Config::getInstance()->getSearchDocumentSpecifications("tripod_php_testing", "resourcelist:List");
         $this->assertEquals($expectedSpec,$actualSpec);
     }
 
@@ -377,7 +376,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
                     )
                 )
             );
-        $actualSpec = MongoTripodConfig::getInstance()->getSearchDocumentSpecification('tripod_php_testing', "i_search_list");
+        $actualSpec = \Tripod\Mongo\Config::getInstance()->getSearchDocumentSpecification('tripod_php_testing', "i_search_list");
         $this->assertEquals($expectedSpec,$actualSpec);
     }
 
@@ -385,7 +384,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
     public function testGetSearchDocumentSpecificationsWhereNoneExists()
     {
         $expectedSpec = array();
-        $actualSpec = MongoTripodConfig::getInstance()->getSearchDocumentSpecifications("something:doesntexist");
+        $actualSpec = \Tripod\Mongo\Config::getInstance()->getSearchDocumentSpecifications("something:doesntexist");
         $this->assertEquals($expectedSpec,$actualSpec);
     }
 
@@ -426,8 +425,8 @@ class MongoTripodConfigTest extends MongoTripodTestBase
                 "joins"=>array("dct:hasVersion"=>array())
             )
         );
-        MongoTripodConfig::setConfig($config);
-        $mtc = MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::setConfig($config);
+        $mtc = \Tripod\Mongo\Config::getInstance();
     }
 
     public function testViewSpecCountNestedInJoinWithoutTTLThrowsException()
@@ -470,8 +469,8 @@ class MongoTripodConfigTest extends MongoTripodTestBase
                 )
             )
         );
-        MongoTripodConfig::setConfig($config);
-        $mtc = MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::setConfig($config);
+        $mtc = \Tripod\Mongo\Config::getInstance();
     }
 
     public function testTableSpecNestedCountWithoutPropertyThrowsException()
@@ -512,8 +511,8 @@ class MongoTripodConfigTest extends MongoTripodTestBase
                 )
             )
         );
-        MongoTripodConfig::setConfig($config);
-        $mtc = MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::setConfig($config);
+        $mtc = \Tripod\Mongo\Config::getInstance();
     }
 
     public function testTableSpecNested2ndLevelCountWithoutFieldNameThrowsException()
@@ -557,8 +556,8 @@ class MongoTripodConfigTest extends MongoTripodTestBase
                 )
             )
         );
-        MongoTripodConfig::setConfig($config);
-        $mtc = MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::setConfig($config);
+        $mtc = \Tripod\Mongo\Config::getInstance();
     }
 
     public function testTableSpecFieldWithoutFieldName()
@@ -596,8 +595,8 @@ class MongoTripodConfigTest extends MongoTripodTestBase
                 )
             )
         );
-        MongoTripodConfig::setConfig($config);
-        $mtc = MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::setConfig($config);
+        $mtc = \Tripod\Mongo\Config::getInstance();
     }
 
     public function testTableSpecFieldWithoutPredicates()
@@ -635,8 +634,8 @@ class MongoTripodConfigTest extends MongoTripodTestBase
                 )
             )
         );
-        MongoTripodConfig::setConfig($config);
-        $mtc = MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::setConfig($config);
+        $mtc = \Tripod\Mongo\Config::getInstance();
     }
 
     public function testTableSpecCountWithoutProperty()
@@ -674,8 +673,8 @@ class MongoTripodConfigTest extends MongoTripodTestBase
                 )
             )
         );
-        MongoTripodConfig::setConfig($config);
-        $mtc = MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::setConfig($config);
+        $mtc = \Tripod\Mongo\Config::getInstance();
     }
 
     public function testTableSpecCountWithoutFieldName()
@@ -713,8 +712,8 @@ class MongoTripodConfigTest extends MongoTripodTestBase
                 )
             )
         );
-        MongoTripodConfig::setConfig($config);
-        $mtc = MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::setConfig($config);
+        $mtc = \Tripod\Mongo\Config::getInstance();
     }
 
     public function testTableSpecCountWithoutPropertyAsAString()
@@ -753,8 +752,8 @@ class MongoTripodConfigTest extends MongoTripodTestBase
                 )
             )
         );
-        MongoTripodConfig::setConfig($config);
-        $mtc = MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::setConfig($config);
+        $mtc = \Tripod\Mongo\Config::getInstance();
     }
 
     public function testConfigWithoutDefaultNamespaceThrowsException()
@@ -795,17 +794,17 @@ class MongoTripodConfigTest extends MongoTripodTestBase
                 )
             )
         );
-        MongoTripodConfig::setConfig($config);
-        $mtc = MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::setConfig($config);
+        $mtc = \Tripod\Mongo\Config::getInstance();
     }
 
     /**
      * the indexesGroupedByCollection method should not only return each of the indexes that are defined explicitly in the config.json,
-     * but also include indexes that are inserted by MongoTripodConfig object because they are needed by tripod
+     * but also include indexes that are inserted by Config object because they are needed by tripod
      */
     public function testGetIndexesGroupedByCollection()
     {
-        $indexSpecs = MongoTripodConfig::getInstance()->getIndexesGroupedByCollection("tripod_php_testing");
+        $indexSpecs = \Tripod\Mongo\Config::getInstance()->getIndexesGroupedByCollection("tripod_php_testing");
 
         $this->assertArrayHasKey("CBD_testing", $indexSpecs);
         $this->assertArrayHasKey("index1", $indexSpecs["CBD_testing"]);
@@ -865,8 +864,8 @@ class MongoTripodConfigTest extends MongoTripodTestBase
                 )
             )
         );
-        MongoTripodConfig::setConfig($config);
-        $mtc = MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::setConfig($config);
+        $mtc = \Tripod\Mongo\Config::getInstance();
         $this->assertEquals("myreplicaset", $mtc->getReplicaSetName($mtc->getDefaultDataSourceForStore("tripod_php_testing")));
 
         $this->assertNull($mtc->getReplicaSetName("testing_2"));
@@ -896,10 +895,10 @@ class MongoTripodConfigTest extends MongoTripodTestBase
             )
         );
 
-        $vspec = MongoTripodConfig::getInstance()->getViewSpecification('tripod_php_testing', "v_resource_full");
+        $vspec = \Tripod\Mongo\Config::getInstance()->getViewSpecification('tripod_php_testing', "v_resource_full");
         $this->assertEquals($expectedVspec, $vspec);
 
-        $vspec = MongoTripodConfig::getInstance()->getViewSpecification('tripod_php_testing', "doesnt_exist");
+        $vspec = \Tripod\Mongo\Config::getInstance()->getViewSpecification('tripod_php_testing', "doesnt_exist");
         $this->assertNull($vspec);
     }
 
@@ -933,10 +932,10 @@ class MongoTripodConfigTest extends MongoTripodTestBase
             )
         );
 
-        $tspec = MongoTripodConfig::getInstance()->getTableSpecification("tripod_php_testing", "t_resource");
+        $tspec = \Tripod\Mongo\Config::getInstance()->getTableSpecification("tripod_php_testing", "t_resource");
         $this->assertEquals($expectedTspec, $tspec);
 
-        $tspec = MongoTripodConfig::getInstance()->getTableSpecification("tripod_php_testing", "doesnt_exist");
+        $tspec = \Tripod\Mongo\Config::getInstance()->getTableSpecification("tripod_php_testing", "doesnt_exist");
         $this->assertNull($tspec);
     }
 
@@ -961,8 +960,8 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         );
         $config["transaction_log"] = array("database"=>"transactions","collection"=>"transaction_log","data_source"=>"mongo1");
 
-        MongoTripodConfig::setConfig($config);
-        $mtc = MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::setConfig($config);
+        $mtc = \Tripod\Mongo\Config::getInstance();
         $this->assertNull($mtc->getSearchProviderClassName("tripod_php_testing"));
         $this->assertEquals(array(), $mtc->getSearchDocumentSpecifications("tripod_php_testing"));
     }
@@ -1047,8 +1046,8 @@ class MongoTripodConfigTest extends MongoTripodTestBase
 
     public function testCollectionReadPreferencesAreAppliedToDatabase()
     {
-        /** @var PHPUnit_Framework_MockObject_MockObject|MongoTripodTestConfig $mockConfig */
-        $mockConfig = $this->getMock('MongoTripodTestConfig', array('getDatabase'));
+        /** @var PHPUnit_Framework_MockObject_MockObject|TripodTestConfig $mockConfig */
+        $mockConfig = $this->getMock('TripodTestConfig', array('getDatabase'));
         $mockConfig->loadConfig(json_decode(file_get_contents(dirname(__FILE__).'/data/config.json'), true));
         $mockConfig->expects($this->exactly(2))
             ->method('getDatabase')
@@ -1074,7 +1073,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $storeName = 'tripod_php_testing';
 
         $dataSourcesForStore = array();
-        $config = MongoTripodConfig::getInstance();
+        $config = \Tripod\Mongo\Config::getInstance();
         $pods = $config->getPods($storeName);
 
         foreach($pods as $pod)
@@ -1116,7 +1115,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
 
         $diff = false;
 
-        $cfg = MongoTripodConfig::getConfig();
+        $cfg = \Tripod\Mongo\Config::getConfig();
         $defaultDataSource = $cfg["data_sources"][$config->getDefaultDataSourceForStore($storeName)];
 
         foreach($dataSourcesForStore as $source)
@@ -1134,15 +1133,15 @@ class MongoTripodConfigTest extends MongoTripodTestBase
             $this->markTestSkipped("All datasources configured for store use same configuration, nothing to test");
         }
 
-        $this->tripod = new MongoTripod('CBD_testing', $storeName, array(OP_ASYNC=>array(OP_VIEWS=>true,OP_TABLES=>false,OP_SEARCH=>false)));
+        $this->tripod = new \Tripod\Mongo\Tripod('CBD_testing', $storeName, array(OP_ASYNC=>array(OP_VIEWS=>true,OP_TABLES=>false,OP_SEARCH=>false)));
         $this->loadBaseDataViaTripod();
 
-        $graph = new MongoGraph();
+        $graph = new \Tripod\Mongo\MongoGraph();
         $subject = 'http://example.com/' . uniqid();
-        $labeller = new MongoTripodLabeller();
+        $labeller = new \Tripod\Mongo\Labeller();
         $graph->add_resource_triple($subject, RDF_TYPE, $labeller->qname_to_uri('foaf:Person'));
         $graph->add_literal_triple($subject, FOAF_NAME, "Anne Example");
-        $this->tripod->saveChanges(new ExtendedGraph(), $graph);
+        $this->tripod->saveChanges(new \Tripod\ExtendedGraph(), $graph);
 
         $newGraph = $this->tripod->describeResource($subject);
         $newGraph->add_literal_triple($subject, $labeller->qname_to_uri('foaf:email'), 'anne@example.com');
@@ -1177,9 +1176,9 @@ class MongoTripodConfigTest extends MongoTripodTestBase
 
         $collectionsForDataSource['rs2'] = array(VIEWS_COLLECTION, SEARCH_INDEX_COLLECTION, TABLE_ROWS_COLLECTION, 'CBD_testing_2', 'transaction_log');
         $specs = array();
-        $specs['views'] = MongoTripodConfig::getInstance()->getViewSpecifications($storeName);
-        $specs['search'] = MongoTripodConfig::getInstance()->getSearchDocumentSpecifications($storeName);
-        $specs['table_rows'] = MongoTripodConfig::getInstance()->getTableSpecifications($storeName);
+        $specs['views'] = \Tripod\Mongo\Config::getInstance()->getViewSpecifications($storeName);
+        $specs['search'] = \Tripod\Mongo\Config::getInstance()->getSearchDocumentSpecifications($storeName);
+        $specs['table_rows'] = \Tripod\Mongo\Config::getInstance()->getTableSpecifications($storeName);
         $specsForDataSource = array();
 
         foreach(array('views', 'search', 'table_rows') as $type)
@@ -1271,365 +1270,365 @@ class MongoTripodConfigTest extends MongoTripodTestBase
 
     public function testComputedFieldSpecValidationInvalidFunction()
     {
-        $newConfig = MongoTripodConfig::getConfig();
-        MongoTripodConfig::setValidationLevel(MongoTripodConfig::VALIDATE_MAX);
+        $newConfig = \Tripod\Mongo\Config::getConfig();
+        \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $computedFieldFunction = array('fieldName'=>'fooBar', 'value'=>array('shazzbot'=>array()));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($computedFieldFunction);
-        MongoTripodConfig::setConfig($newConfig);
+        \Tripod\Mongo\Config::setConfig($newConfig);
         $this->setExpectedException('MongoTripodConfigException', "Computed field spec does not contain valid function");
-        MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::getInstance();
     }
 
     public function testComputedFieldSpecValidationMultipleFunctions()
     {
-        $newConfig = MongoTripodConfig::getConfig();
-        MongoTripodConfig::setValidationLevel(MongoTripodConfig::VALIDATE_MAX);
+        $newConfig = \Tripod\Mongo\Config::getConfig();
+        \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $computedFieldFunction = array('fieldName'=>'fooBar', 'value'=>array('conditional'=>array(),'replace'=>array()));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($computedFieldFunction);
-        MongoTripodConfig::setConfig($newConfig);
+        \Tripod\Mongo\Config::setConfig($newConfig);
         $this->setExpectedException('MongoTripodConfigException', "Computed field spec contains more than one function");
-        MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::getInstance();
     }
 
     public function testComputedFieldSpecValidationMustBeAtBaseLevel()
     {
-        $newConfig = MongoTripodConfig::getConfig();
-        MongoTripodConfig::setValidationLevel(MongoTripodConfig::VALIDATE_MAX);
+        $newConfig = \Tripod\Mongo\Config::getConfig();
+        \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $computedFieldFunction = array('fieldName'=>'fooBar', 'value'=>array('conditional'=>array()));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['joins']['dct:isVersionOf']['computed_fields'] = array($computedFieldFunction);
-        MongoTripodConfig::setConfig($newConfig);
+        \Tripod\Mongo\Config::setConfig($newConfig);
         $this->setExpectedException('MongoTripodConfigException', "Table spec can only contain 'computed_fields' at the base level");
-        MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::getInstance();
     }
 
     public function testConditionalSpecValidationEmptyConditional()
     {
-        $newConfig = MongoTripodConfig::getConfig();
-        MongoTripodConfig::setValidationLevel(MongoTripodConfig::VALIDATE_MAX);
+        $newConfig = \Tripod\Mongo\Config::getConfig();
+        \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $conditionalFunction = array('fieldName'=>'fooBar', 'value'=>array('conditional'=>array()));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($conditionalFunction);
-        MongoTripodConfig::setConfig($newConfig);
+        \Tripod\Mongo\Config::setConfig($newConfig);
         $this->setExpectedException('MongoTripodConfigException', "Computed conditional spec does not contain an 'if' value");
-        MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::getInstance();
     }
 
     public function testConditionalSpecValidationMissingThenElse()
     {
-        $newConfig = MongoTripodConfig::getConfig();
-        MongoTripodConfig::setValidationLevel(MongoTripodConfig::VALIDATE_MAX);
+        $newConfig = \Tripod\Mongo\Config::getConfig();
+        \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $conditionalFunction = array('fieldName'=>'fooBar', 'value'=>array('conditional'=>array('if'=>array())));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($conditionalFunction);
-        MongoTripodConfig::setConfig($newConfig);
+        \Tripod\Mongo\Config::setConfig($newConfig);
         $this->setExpectedException('MongoTripodConfigException', "Computed conditional spec must contain a then or else value");
-        MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::getInstance();
     }
 
     public function testConditionalSpecValidationEmptyIf()
     {
-        $newConfig = MongoTripodConfig::getConfig();
-        MongoTripodConfig::setValidationLevel(MongoTripodConfig::VALIDATE_MAX);
+        $newConfig = \Tripod\Mongo\Config::getConfig();
+        \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $conditionalFunction = array('fieldName'=>'fooBar', 'value'=>array('conditional'=>array('if'=>array(),'then'=>'wibble')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($conditionalFunction);
-        MongoTripodConfig::setConfig($newConfig);
+        \Tripod\Mongo\Config::setConfig($newConfig);
         $this->setExpectedException('MongoTripodConfigException', "Computed conditional field spec 'if' value array must have 1 or 3 values");
-        MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::getInstance();
     }
 
     public function testConditionalSpecValidationIfNotArray()
     {
-        $newConfig = MongoTripodConfig::getConfig();
-        MongoTripodConfig::setValidationLevel(MongoTripodConfig::VALIDATE_MAX);
+        $newConfig = \Tripod\Mongo\Config::getConfig();
+        \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $conditionalFunction = array('fieldName'=>'fooBar', 'value'=>array('conditional'=>array('if'=>'foo','then'=>'wibble')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($conditionalFunction);
-        MongoTripodConfig::setConfig($newConfig);
+        \Tripod\Mongo\Config::setConfig($newConfig);
         $this->setExpectedException('MongoTripodConfigException', "Computed conditional field spec 'if' value must be an array");
-        MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::getInstance();
     }
 
     public function testConditionalSpecValidationIfHasTwoValues()
     {
-        $newConfig = MongoTripodConfig::getConfig();
-        MongoTripodConfig::setValidationLevel(MongoTripodConfig::VALIDATE_MAX);
+        $newConfig = \Tripod\Mongo\Config::getConfig();
+        \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $conditionalFunction = array('fieldName'=>'fooBar', 'value'=>array('conditional'=>array('if'=>array('foo','*'),'then'=>'wibble')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($conditionalFunction);
-        MongoTripodConfig::setConfig($newConfig);
+        \Tripod\Mongo\Config::setConfig($newConfig);
         $this->setExpectedException('MongoTripodConfigException', "Computed conditional field spec 'if' value array must have 1 or 3 values");
-        MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::getInstance();
     }
 
     public function testConditionalSpecValidationIfHasMoreThanThreeValues()
     {
-        $newConfig = MongoTripodConfig::getConfig();
-        MongoTripodConfig::setValidationLevel(MongoTripodConfig::VALIDATE_MAX);
+        $newConfig = \Tripod\Mongo\Config::getConfig();
+        \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $conditionalFunction = array('fieldName'=>'fooBar', 'value'=>array('conditional'=>array('if'=>array('a','b','c','d'),'then'=>'wibble')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($conditionalFunction);
-        MongoTripodConfig::setConfig($newConfig);
+        \Tripod\Mongo\Config::setConfig($newConfig);
         $this->setExpectedException('MongoTripodConfigException', "Computed conditional field spec 'if' value array must have 1 or 3 values");
-        MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::getInstance();
     }
 
     public function testConditionalSpecValidationIfHasInvalidConditionalOperator()
     {
-        $newConfig = MongoTripodConfig::getConfig();
-        MongoTripodConfig::setValidationLevel(MongoTripodConfig::VALIDATE_MAX);
+        $newConfig = \Tripod\Mongo\Config::getConfig();
+        \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $conditionalFunction = array('fieldName'=>'fooBar', 'value'=>array('conditional'=>array('if'=>array('a','*','c'),'then'=>'wibble')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($conditionalFunction);
-        MongoTripodConfig::setConfig($newConfig);
+        \Tripod\Mongo\Config::setConfig($newConfig);
         $this->setExpectedException('MongoTripodConfigException', "Invalid conditional operator '*' in conditional spec");
-        MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::getInstance();
     }
 
     public function testConditionalSpecValidationIfHasInvalidVariableAsLeftOperand()
     {
-        $newConfig = MongoTripodConfig::getConfig();
-        MongoTripodConfig::setValidationLevel(MongoTripodConfig::VALIDATE_MAX);
+        $newConfig = \Tripod\Mongo\Config::getConfig();
+        \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $conditionalFunction = array('fieldName'=>'fooBar', 'value'=>array('conditional'=>array('if'=>array('$wibble','>=','c'),'then'=>'wibble')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($conditionalFunction);
-        MongoTripodConfig::setConfig($newConfig);
+        \Tripod\Mongo\Config::setConfig($newConfig);
         $this->setExpectedException('MongoTripodConfigException', "Computed spec variable '\$wibble' is not defined in table spec");
-        MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::getInstance();
     }
 
     public function testConditionalSpecValidationIfHasInvalidVariableAsRightOperand()
     {
-        $newConfig = MongoTripodConfig::getConfig();
-        MongoTripodConfig::setValidationLevel(MongoTripodConfig::VALIDATE_MAX);
+        $newConfig = \Tripod\Mongo\Config::getConfig();
+        \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $conditionalFunction = array('fieldName'=>'fooBar', 'value'=>array('conditional'=>array('if'=>array('a','contains','$wibble'),'then'=>'wibble')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($conditionalFunction);
-        MongoTripodConfig::setConfig($newConfig);
+        \Tripod\Mongo\Config::setConfig($newConfig);
         $this->setExpectedException('MongoTripodConfigException', "Computed spec variable '\$wibble' is not defined in table spec");
-        MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::getInstance();
     }
 
     public function testConditionalSpecValidationThenHasInvalidVariable()
     {
-        $newConfig = MongoTripodConfig::getConfig();
-        MongoTripodConfig::setValidationLevel(MongoTripodConfig::VALIDATE_MAX);
+        $newConfig = \Tripod\Mongo\Config::getConfig();
+        \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $conditionalFunction = array('fieldName'=>'fooBar', 'value'=>array('conditional'=>array('if'=>array('a','<','b'),'then'=>'$wibble')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($conditionalFunction);
-        MongoTripodConfig::setConfig($newConfig);
+        \Tripod\Mongo\Config::setConfig($newConfig);
         $this->setExpectedException('MongoTripodConfigException', "Computed spec variable '\$wibble' is not defined in table spec");
-        MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::getInstance();
     }
 
 
     public function testConditionalSpecValidationElseHasInvalidVariable()
     {
-        $newConfig = MongoTripodConfig::getConfig();
-        MongoTripodConfig::setValidationLevel(MongoTripodConfig::VALIDATE_MAX);
+        $newConfig = \Tripod\Mongo\Config::getConfig();
+        \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $conditionalFunction = array('fieldName'=>'fooBar', 'value'=>array('conditional'=>array('if'=>array('a','<','b'),'then'=>true,'else'=>'$wibble')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($conditionalFunction);
-        MongoTripodConfig::setConfig($newConfig);
+        \Tripod\Mongo\Config::setConfig($newConfig);
         $this->setExpectedException('MongoTripodConfigException', "Computed spec variable '\$wibble' is not defined in table spec");
-        MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::getInstance();
     }
 
     public function testReplaceSpecValidationEmptyFunction()
     {
-        $newConfig = MongoTripodConfig::getConfig();
-        MongoTripodConfig::setValidationLevel(MongoTripodConfig::VALIDATE_MAX);
+        $newConfig = \Tripod\Mongo\Config::getConfig();
+        \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $replaceFunction = array('fieldName'=>'fooBar', 'value'=>array('replace'=>array()));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($replaceFunction);
-        MongoTripodConfig::setConfig($newConfig);
+        \Tripod\Mongo\Config::setConfig($newConfig);
         $this->setExpectedException('MongoTripodConfigException', "Computed replace spec does not contain 'search' value");
-        MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::getInstance();
     }
 
     public function testReplaceSpecValidationMissingReplace()
     {
-        $newConfig = MongoTripodConfig::getConfig();
-        MongoTripodConfig::setValidationLevel(MongoTripodConfig::VALIDATE_MAX);
+        $newConfig = \Tripod\Mongo\Config::getConfig();
+        \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $replaceFunction = array('fieldName'=>'fooBar', 'value'=>array('replace'=>array('search'=>'x')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($replaceFunction);
-        MongoTripodConfig::setConfig($newConfig);
+        \Tripod\Mongo\Config::setConfig($newConfig);
         $this->setExpectedException('MongoTripodConfigException', "Computed replace spec does not contain 'replace' value");
-        MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::getInstance();
     }
 
     public function testReplaceSpecValidationMissingSubject()
     {
-        $newConfig = MongoTripodConfig::getConfig();
-        MongoTripodConfig::setValidationLevel(MongoTripodConfig::VALIDATE_MAX);
+        $newConfig = \Tripod\Mongo\Config::getConfig();
+        \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $replaceFunction = array('fieldName'=>'fooBar', 'value'=>array('replace'=>array('search'=>'x', 'replace'=>'y')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($replaceFunction);
-        MongoTripodConfig::setConfig($newConfig);
+        \Tripod\Mongo\Config::setConfig($newConfig);
         $this->setExpectedException('MongoTripodConfigException', "Computed replace spec does not contain 'subject' value");
-        MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::getInstance();
     }
 
     public function testReplaceSpecValidationInvalidVariableInSearch()
     {
-        $newConfig = MongoTripodConfig::getConfig();
-        MongoTripodConfig::setValidationLevel(MongoTripodConfig::VALIDATE_MAX);
+        $newConfig = \Tripod\Mongo\Config::getConfig();
+        \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $replaceFunction = array('fieldName'=>'fooBar', 'value'=>array('replace'=>array('search'=>'$x','replace'=>'y','subject'=>'z')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($replaceFunction);
-        MongoTripodConfig::setConfig($newConfig);
+        \Tripod\Mongo\Config::setConfig($newConfig);
         $this->setExpectedException('MongoTripodConfigException', "Computed spec variable '\$x' is not defined in table spec");
-        MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::getInstance();
     }
 
     public function testReplaceSpecValidationInvalidVariableInSearchArray()
     {
-        $newConfig = MongoTripodConfig::getConfig();
-        MongoTripodConfig::setValidationLevel(MongoTripodConfig::VALIDATE_MAX);
+        $newConfig = \Tripod\Mongo\Config::getConfig();
+        \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $replaceFunction = array('fieldName'=>'fooBar', 'value'=>array('replace'=>array('search'=>array('a','b','$x'),'replace'=>'y','subject'=>'z')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($replaceFunction);
-        MongoTripodConfig::setConfig($newConfig);
+        \Tripod\Mongo\Config::setConfig($newConfig);
         $this->setExpectedException('MongoTripodConfigException', "Computed spec variable '\$x' is not defined in table spec");
-        MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::getInstance();
     }
 
     public function testReplaceSpecValidationInvalidVariableInReplace()
     {
-        $newConfig = MongoTripodConfig::getConfig();
-        MongoTripodConfig::setValidationLevel(MongoTripodConfig::VALIDATE_MAX);
+        $newConfig = \Tripod\Mongo\Config::getConfig();
+        \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $replaceFunction = array('fieldName'=>'fooBar', 'value'=>array('replace'=>array('search'=>'x','replace'=>'$y','subject'=>'z')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($replaceFunction);
-        MongoTripodConfig::setConfig($newConfig);
+        \Tripod\Mongo\Config::setConfig($newConfig);
         $this->setExpectedException('MongoTripodConfigException', "Computed spec variable '\$y' is not defined in table spec");
-        MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::getInstance();
     }
 
     public function testReplaceSpecValidationInvalidVariableInReplaceArray()
     {
-        $newConfig = MongoTripodConfig::getConfig();
-        MongoTripodConfig::setValidationLevel(MongoTripodConfig::VALIDATE_MAX);
+        $newConfig = \Tripod\Mongo\Config::getConfig();
+        \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $replaceFunction = array('fieldName'=>'fooBar', 'value'=>array('replace'=>array('search'=>'x','replace'=>array('a','$y', 'c'),'subject'=>'z')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($replaceFunction);
-        MongoTripodConfig::setConfig($newConfig);
+        \Tripod\Mongo\Config::setConfig($newConfig);
         $this->setExpectedException('MongoTripodConfigException', "Computed spec variable '\$y' is not defined in table spec");
-        MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::getInstance();
     }
 
     public function testReplaceSpecValidationInvalidVariableInSubject()
     {
-        $newConfig = MongoTripodConfig::getConfig();
-        MongoTripodConfig::setValidationLevel(MongoTripodConfig::VALIDATE_MAX);
+        $newConfig = \Tripod\Mongo\Config::getConfig();
+        \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $replaceFunction = array('fieldName'=>'fooBar', 'value'=>array('replace'=>array('search'=>'x','replace'=>'y','subject'=>'$z')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($replaceFunction);
-        MongoTripodConfig::setConfig($newConfig);
+        \Tripod\Mongo\Config::setConfig($newConfig);
         $this->setExpectedException('MongoTripodConfigException', "Computed spec variable '\$z' is not defined in table spec");
-        MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::getInstance();
     }
 
     public function testReplaceSpecValidationInvalidVariableInSubjectArray()
     {
-        $newConfig = MongoTripodConfig::getConfig();
-        MongoTripodConfig::setValidationLevel(MongoTripodConfig::VALIDATE_MAX);
+        $newConfig = \Tripod\Mongo\Config::getConfig();
+        \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $replaceFunction = array('fieldName'=>'fooBar', 'value'=>array('replace'=>array('search'=>'x','replace'=>'y','subject'=>array('$z','b','c'))));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($replaceFunction);
-        MongoTripodConfig::setConfig($newConfig);
+        \Tripod\Mongo\Config::setConfig($newConfig);
         $this->setExpectedException('MongoTripodConfigException', "Computed spec variable '\$z' is not defined in table spec");
-        MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::getInstance();
     }
 
     public function testArithmeticSpecValidationEmptyFunction()
     {
-        $newConfig = MongoTripodConfig::getConfig();
-        MongoTripodConfig::setValidationLevel(MongoTripodConfig::VALIDATE_MAX);
+        $newConfig = \Tripod\Mongo\Config::getConfig();
+        \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $arithmeticFunction = array('fieldName'=>'fooBar', 'value'=>array('arithmetic'=>array()));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($arithmeticFunction);
-        MongoTripodConfig::setConfig($newConfig);
+        \Tripod\Mongo\Config::setConfig($newConfig);
         $this->setExpectedException('MongoTripodConfigException', "Computed arithmetic spec must contain 3 values");
-        MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::getInstance();
     }
 
     public function testArithmeticSpecValidationOneValue()
     {
-        $newConfig = MongoTripodConfig::getConfig();
-        MongoTripodConfig::setValidationLevel(MongoTripodConfig::VALIDATE_MAX);
+        $newConfig = \Tripod\Mongo\Config::getConfig();
+        \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $arithmeticFunction = array('fieldName'=>'fooBar', 'value'=>array('arithmetic'=>array(1)));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($arithmeticFunction);
-        MongoTripodConfig::setConfig($newConfig);
+        \Tripod\Mongo\Config::setConfig($newConfig);
         $this->setExpectedException('MongoTripodConfigException', "Computed arithmetic spec must contain 3 values");
-        MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::getInstance();
     }
 
     public function testArithmeticSpecValidationTwoValues()
     {
-        $newConfig = MongoTripodConfig::getConfig();
-        MongoTripodConfig::setValidationLevel(MongoTripodConfig::VALIDATE_MAX);
+        $newConfig = \Tripod\Mongo\Config::getConfig();
+        \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $arithmeticFunction = array('fieldName'=>'fooBar', 'value'=>array('arithmetic'=>array(1,'+')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($arithmeticFunction);
-        MongoTripodConfig::setConfig($newConfig);
+        \Tripod\Mongo\Config::setConfig($newConfig);
         $this->setExpectedException('MongoTripodConfigException', "Computed arithmetic spec must contain 3 values");
-        MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::getInstance();
     }
 
     public function testArithmeticSpecValidationFourValues()
     {
-        $newConfig = MongoTripodConfig::getConfig();
-        MongoTripodConfig::setValidationLevel(MongoTripodConfig::VALIDATE_MAX);
+        $newConfig = \Tripod\Mongo\Config::getConfig();
+        \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $arithmeticFunction = array('fieldName'=>'fooBar', 'value'=>array('arithmetic'=>array(1,'+',3,4)));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($arithmeticFunction);
-        MongoTripodConfig::setConfig($newConfig);
+        \Tripod\Mongo\Config::setConfig($newConfig);
         $this->setExpectedException('MongoTripodConfigException', "Computed arithmetic spec must contain 3 values");
-        MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::getInstance();
     }
 
     public function testArithmeticSpecValidationInvalidArithmeticOperator()
     {
-        $newConfig = MongoTripodConfig::getConfig();
-        MongoTripodConfig::setValidationLevel(MongoTripodConfig::VALIDATE_MAX);
+        $newConfig = \Tripod\Mongo\Config::getConfig();
+        \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $arithmeticFunction = array('fieldName'=>'fooBar', 'value'=>array('arithmetic'=>array(1,'x',3)));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($arithmeticFunction);
-        MongoTripodConfig::setConfig($newConfig);
+        \Tripod\Mongo\Config::setConfig($newConfig);
         $this->setExpectedException('MongoTripodConfigException', "Invalid arithmetic operator 'x' in computed arithmetic spec");
-        MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::getInstance();
     }
 
     public function testArithmeticSpecValidationInvalidVariableLeftOperand()
     {
-        $newConfig = MongoTripodConfig::getConfig();
-        MongoTripodConfig::setValidationLevel(MongoTripodConfig::VALIDATE_MAX);
+        $newConfig = \Tripod\Mongo\Config::getConfig();
+        \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $arithmeticFunction = array('fieldName'=>'fooBar', 'value'=>array('arithmetic'=>array('$x','*',3)));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($arithmeticFunction);
-        MongoTripodConfig::setConfig($newConfig);
+        \Tripod\Mongo\Config::setConfig($newConfig);
         $this->setExpectedException('MongoTripodConfigException', "Computed spec variable '\$x' is not defined in table spec");
-        MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::getInstance();
     }
 
     public function testArithmeticSpecValidationInvalidVariableRightOperand()
     {
-        $newConfig = MongoTripodConfig::getConfig();
-        MongoTripodConfig::setValidationLevel(MongoTripodConfig::VALIDATE_MAX);
+        $newConfig = \Tripod\Mongo\Config::getConfig();
+        \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $arithmeticFunction = array('fieldName'=>'fooBar', 'value'=>array('arithmetic'=>array(1,'*','$x')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($arithmeticFunction);
-        MongoTripodConfig::setConfig($newConfig);
+        \Tripod\Mongo\Config::setConfig($newConfig);
         $this->setExpectedException('MongoTripodConfigException', "Computed spec variable '\$x' is not defined in table spec");
-        MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::getInstance();
     }
 
     public function testArithmeticSpecValidationInvalidNestedVariable()
     {
-        $newConfig = MongoTripodConfig::getConfig();
-        MongoTripodConfig::setValidationLevel(MongoTripodConfig::VALIDATE_MAX);
+        $newConfig = \Tripod\Mongo\Config::getConfig();
+        \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $arithmeticFunction = array('fieldName'=>'fooBar', 'value'=>array('arithmetic'=>array(array('$x','-',100),'*',3)));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($arithmeticFunction);
-        MongoTripodConfig::setConfig($newConfig);
+        \Tripod\Mongo\Config::setConfig($newConfig);
         $this->setExpectedException('MongoTripodConfigException', "Computed spec variable '\$x' is not defined in table spec");
-        MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::getInstance();
     }
 
     public function testArithmeticSpecValidationInvalidNestedOperator()
     {
-        $newConfig = MongoTripodConfig::getConfig();
-        MongoTripodConfig::setValidationLevel(MongoTripodConfig::VALIDATE_MAX);
+        $newConfig = \Tripod\Mongo\Config::getConfig();
+        \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $arithmeticFunction = array('fieldName'=>'fooBar', 'value'=>array('arithmetic'=>array(array(101,'#',100),'*',3)));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($arithmeticFunction);
-        MongoTripodConfig::setConfig($newConfig);
+        \Tripod\Mongo\Config::setConfig($newConfig);
         $this->setExpectedException('MongoTripodConfigException', "Invalid arithmetic operator '#' in computed arithmetic spec");
-        MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::getInstance();
     }
 
     public function testGetResqueServer()
     {
-        MongoTripodConfig::setValidationLevel(MongoTripodConfig::VALIDATE_MAX);
+        \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
 
         if(!getenv(MONGO_TRIPOD_RESQUE_SERVER))
         {
             putenv(MONGO_TRIPOD_RESQUE_SERVER . "=localhost:6379");
         }
-        $this->assertEquals(getenv(MONGO_TRIPOD_RESQUE_SERVER), MongoTripodConfig::getResqueServer());
+        $this->assertEquals(getenv(MONGO_TRIPOD_RESQUE_SERVER), \Tripod\Mongo\Config::getResqueServer());
     }
 }

--- a/test/unit/mongo/MongoTripodDocumentStructureTest.php
+++ b/test/unit/mongo/MongoTripodDocumentStructureTest.php
@@ -1,6 +1,6 @@
 <?php
 require_once 'MongoTripodTestBase.php';
-require_once 'src/mongo/Tripod.class.php';
+require_once 'src/mongo/Driver.class.php';
 
 /**
  * Class MongoTripodDocumentStructureTest
@@ -8,7 +8,7 @@ require_once 'src/mongo/Tripod.class.php';
 class MongoTripodDocumentStructureTest extends MongoTripodTestBase
 {
     /**
-     * @var \Tripod\Mongo\Tripod|PHPUnit_Framework_MockObject_MockObject
+     * @var \Tripod\Mongo\Driver|PHPUnit_Framework_MockObject_MockObject
      */
     protected $tripod = null;
     /**
@@ -25,7 +25,7 @@ class MongoTripodDocumentStructureTest extends MongoTripodTestBase
         $this->tripodTransactionLog->purgeAllTransactions();
 
         // Stub ouf 'addToElastic' search to prevent writes into Elastic Search happening by default.
-        $this->tripod = $this->getMock('\Tripod\Mongo\Tripod', array('addToSearchIndexQueue'), array('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/')));
+        $this->tripod = $this->getMock('\Tripod\Mongo\Driver', array('addToSearchIndexQueue'), array('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/')));
         $this->tripod->expects($this->any())->method('addToSearchIndexQueue');
 
         $this->getTripodCollection($this->tripod)->drop();
@@ -125,7 +125,7 @@ class MongoTripodDocumentStructureTest extends MongoTripodTestBase
      */
     public function testOnlyDocumentUpdatedTimestampIsAddedToDocumentThatDidntHaveTimestampsToBeginWith()
     {
-        // add the initial document, but not through Tripod!
+        // add the initial document, but not through Driver!
         $_id = array("r"=>"http://talisaspire.com/resources/testDocument2","c"=>"http://talisaspire.com/");
         $document = array(
             '_id' => $_id,

--- a/test/unit/mongo/MongoTripodDocumentStructureTest.php
+++ b/test/unit/mongo/MongoTripodDocumentStructureTest.php
@@ -1,15 +1,19 @@
 <?php
 require_once 'MongoTripodTestBase.php';
-require_once 'src/mongo/MongoTripod.class.php';
+require_once 'src/mongo/Tripod.class.php';
+
+use \Tripod\Mongo\Tripod;
+use \Tripod\Mongo\TransactionLog;
+use \Tripod\Mongo\MongoGraph;
 
 class MongoTripodDocumentStructureTest extends MongoTripodTestBase
 {
     /**
-     * @var MongoTripod|PHPUnit_Framework_MockObject_MockObject
+     * @var \Tripod\Mongo\Tripod|PHPUnit_Framework_MockObject_MockObject
      */
     protected $tripod = null;
     /**
-     * @var MongoTransactionLog
+     * @var TransactionLog
      */
     protected $tripodTransactionLog = null;
 
@@ -18,11 +22,11 @@ class MongoTripodDocumentStructureTest extends MongoTripodTestBase
         parent::setup();
         //Mongo::setPoolSize(200);
 
-        $this->tripodTransactionLog = new MongoTransactionLog();
+        $this->tripodTransactionLog = new TransactionLog();
         $this->tripodTransactionLog->purgeAllTransactions();
 
         // Stub ouf 'addToElastic' search to prevent writes into Elastic Search happening by default.
-        $this->tripod = $this->getMock('MongoTripod', array('addToSearchIndexQueue'), array('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/')));
+        $this->tripod = $this->getMock('Tripod', array('addToSearchIndexQueue'), array('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/')));
         $this->tripod->expects($this->any())->method('addToSearchIndexQueue');
 
         $this->getTripodCollection($this->tripod)->drop();

--- a/test/unit/mongo/MongoTripodDocumentStructureTest.php
+++ b/test/unit/mongo/MongoTripodDocumentStructureTest.php
@@ -2,10 +2,9 @@
 require_once 'MongoTripodTestBase.php';
 require_once 'src/mongo/Tripod.class.php';
 
-use \Tripod\Mongo\Tripod;
-use \Tripod\Mongo\TransactionLog;
-use \Tripod\Mongo\MongoGraph;
-
+/**
+ * Class MongoTripodDocumentStructureTest
+ */
 class MongoTripodDocumentStructureTest extends MongoTripodTestBase
 {
     /**
@@ -13,7 +12,7 @@ class MongoTripodDocumentStructureTest extends MongoTripodTestBase
      */
     protected $tripod = null;
     /**
-     * @var TransactionLog
+     * @var \Tripod\Mongo\TransactionLog
      */
     protected $tripodTransactionLog = null;
 
@@ -22,11 +21,11 @@ class MongoTripodDocumentStructureTest extends MongoTripodTestBase
         parent::setup();
         //Mongo::setPoolSize(200);
 
-        $this->tripodTransactionLog = new TransactionLog();
+        $this->tripodTransactionLog = new \Tripod\Mongo\TransactionLog();
         $this->tripodTransactionLog->purgeAllTransactions();
 
         // Stub ouf 'addToElastic' search to prevent writes into Elastic Search happening by default.
-        $this->tripod = $this->getMock('Tripod', array('addToSearchIndexQueue'), array('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/')));
+        $this->tripod = $this->getMock('\Tripod\Mongo\Tripod', array('addToSearchIndexQueue'), array('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/')));
         $this->tripod->expects($this->any())->method('addToSearchIndexQueue');
 
         $this->getTripodCollection($this->tripod)->drop();
@@ -39,9 +38,9 @@ class MongoTripodDocumentStructureTest extends MongoTripodTestBase
     {
         $id = array("r"=>"http://talisaspire.com/resources/testDocument", "c"=>"http://talisaspire.com/");
 
-        $graph = new MongoGraph();
+        $graph = new \Tripod\Mongo\MongoGraph();
         $graph->add_literal_triple($id['r'], $graph->qname_to_uri('searchterms:title'), 'TEST TITLE');
-        $this->tripod->saveChanges(new MongoGraph(), $graph);
+        $this->tripod->saveChanges(new \Tripod\Mongo\MongoGraph(), $graph);
 
         $this->assertDocumentExists($id);
         $this->assertDocumentHasProperty($id, _VERSION, 0);
@@ -54,9 +53,9 @@ class MongoTripodDocumentStructureTest extends MongoTripodTestBase
         // create an initial document
         $id = array("r"=>"http://talisaspire.com/resources/testDocument", "c"=>"http://talisaspire.com/");
 
-        $graph = new MongoGraph();
+        $graph = new \Tripod\Mongo\MongoGraph();
         $graph->add_literal_triple($id['r'], $graph->qname_to_uri('searchterms:title'), 'TEST TITLE');
-        $this->tripod->saveChanges(new MongoGraph(), $graph);
+        $this->tripod->saveChanges(new \Tripod\Mongo\MongoGraph(), $graph);
         // assert that it is at version 0
         $this->assertDocumentExists($id);
         $this->assertDocumentHasProperty($id, _VERSION, 0);
@@ -69,7 +68,7 @@ class MongoTripodDocumentStructureTest extends MongoTripodTestBase
         sleep(1); // have to sleep to make sure ->sec will be greater between writes.
 
         // change document through tripod
-        $newGraph = new MongoGraph();
+        $newGraph = new \Tripod\Mongo\MongoGraph();
         $newGraph->add_literal_triple($id['r'], $graph->qname_to_uri('searchterms:title'), 'CHANGED TITLE');
         $this->tripod->saveChanges($graph, $newGraph);
 
@@ -87,7 +86,7 @@ class MongoTripodDocumentStructureTest extends MongoTripodTestBase
         sleep(1);
 
         // update again
-        $finalGraph = new MongoGraph();
+        $finalGraph = new \Tripod\Mongo\MongoGraph();
         $finalGraph->add_literal_triple($id['r'], $graph->qname_to_uri('searchterms:title'), 'CHANGED TITLE AGAIN');
         $this->tripod->saveChanges($newGraph, $finalGraph);
 
@@ -105,7 +104,7 @@ class MongoTripodDocumentStructureTest extends MongoTripodTestBase
 
         // now delete through tripod, only the _ID, _VERSION, _UPDATED_TS and _CREATED_TS properties should exist on the document
         // updated ts will have changed the created should not have
-        $this->tripod->saveChanges($finalGraph, new MongoGraph());
+        $this->tripod->saveChanges($finalGraph, new \Tripod\Mongo\MongoGraph());
 
         $this->assertDocumentExists($id);
         $deleted_document = $this->getDocument($id);
@@ -144,9 +143,9 @@ class MongoTripodDocumentStructureTest extends MongoTripodTestBase
         $this->assertDocumentDoesNotHaveProperty($_id, _CREATED_TS);
 
         // change the document through tripod, for this im just doing a new addition
-        $graph = new MongoGraph();
+        $graph = new \Tripod\Mongo\MongoGraph();
         $graph->add_literal_triple($_id["r"], $graph->qname_to_uri('searchterms:title'), 'a new property');
-        $this->tripod->saveChanges(new MongoGraph(), $graph);
+        $this->tripod->saveChanges(new \Tripod\Mongo\MongoGraph(), $graph);
 
         // Now assert, document should contain the additiona triple we added, an updated _version.
         // Should now also contain an _UPDATED_TS but not a _CREATED_TS

--- a/test/unit/mongo/MongoTripodDriverTest.php
+++ b/test/unit/mongo/MongoTripodDriverTest.php
@@ -1,14 +1,14 @@
 <?php
 require_once 'MongoTripodTestBase.php';
-require_once 'src/mongo/Tripod.class.php';
+require_once 'src/mongo/Driver.class.php';
 
 /**
- * Class MongoTripodTest
+ * Class MongoTripodDriverTest
  */
-class MongoTripodTest extends MongoTripodTestBase
+class MongoTripodDriverTest extends MongoTripodTestBase
 {
     /**
-     * @var \Tripod\Mongo\Tripod | PHPUnit_Framework_MockObject_MockObject
+     * @var \Tripod\Mongo\Driver | PHPUnit_Framework_MockObject_MockObject
      */
     protected $tripod = null;
     /**
@@ -25,7 +25,7 @@ class MongoTripodTest extends MongoTripodTestBase
 
         // Stub ouf 'addToElastic' search to prevent writes into Elastic Search happening by default.
         $this->tripod = $this->getMock(
-            '\Tripod\Mongo\Tripod',
+            '\Tripod\Mongo\Driver',
             array('addToSearchIndexQueue'),
             array(
                 'CBD_testing',
@@ -351,7 +351,7 @@ class MongoTripodTest extends MongoTripodTestBase
         $doc = array("_id"=>$uri, "rdf:type"=>array(array('value'=>$g->qname_to_uri("acorn:Resource"), 'type'=>'uri')));
 
         $mockTripod = $this->getMock(
-            '\Tripod\Mongo\Tripod',
+            '\Tripod\Mongo\Driver',
             array('getDataUpdater'),
             array(
                 'CBD_testing',
@@ -399,7 +399,7 @@ class MongoTripodTest extends MongoTripodTestBase
         $doc = array("_id"=>$uri, "_version"=>3,"rdf:type"=>array(array('value'=>$g->qname_to_uri("acorn:Resource"), 'type'=>'uri')));
 
         $mockTripod = $this->getMock(
-            '\Tripod\Mongo\Tripod',
+            '\Tripod\Mongo\Driver',
             array('getDataUpdater'),
             array(
                 'CBD_testing',
@@ -555,9 +555,9 @@ class MongoTripodTest extends MongoTripodTestBase
 
     public function testSetReadPreferenceWhenSavingChanges(){
         $subjectOne = "http://talisaspire.com/works/checkReadPreferencesWrite";
-        /** @var $tripodMock \Tripod\Mongo\Tripod **/
+        /** @var $tripodMock \Tripod\Mongo\Driver **/
         $tripodMock = $this->getMock(
-            '\Tripod\Mongo\Tripod', 
+            '\Tripod\Mongo\Driver', 
             array('getDataUpdater'), 
             array(
                 'CBD_testing',
@@ -595,9 +595,9 @@ class MongoTripodTest extends MongoTripodTestBase
      */
     public function testReadPreferencesAreRestoredWhenErrorSavingChanges(){
         $subjectOne = "http://talisaspire.com/works/checkReadPreferencesAreRestoredOnError";
-        /** @var $tripodMock \Tripod\Mongo\Tripod|PHPUnit_Framework_MockObject_MockObject **/
+        /** @var $tripodMock \Tripod\Mongo\Driver|PHPUnit_Framework_MockObject_MockObject **/
         $tripodMock = $this->getMock(
-            '\Tripod\Mongo\Tripod', 
+            '\Tripod\Mongo\Driver', 
             array('getDataUpdater'), 
             array(
                 'CBD_testing',
@@ -837,7 +837,7 @@ class MongoTripodTest extends MongoTripodTestBase
         // Override the config defined in base test class as we need specific config here.
         \Tripod\Mongo\Config::setConfig($config);
 
-        $tripod = new \Tripod\Mongo\Tripod('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/'));
+        $tripod = new \Tripod\Mongo\Driver('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/'));
 
         $oldGraph = new \Tripod\ExtendedGraph();
         $newGraph = new \Tripod\ExtendedGraph();
@@ -857,9 +857,9 @@ class MongoTripodTest extends MongoTripodTestBase
         $oG->add_resource_triple($uri_2, $oG->qname_to_uri("rdf:type"), $oG->qname_to_uri("acorn:Resource"));
 
         // just updates, all three operations async
-        /** @var \Tripod\Mongo\Tripod|PHPUnit_Framework_MockObject_MockObject $mockTripod */
+        /** @var \Tripod\Mongo\Driver|PHPUnit_Framework_MockObject_MockObject $mockTripod */
         $mockTripod = $this->getMock(
-            '\Tripod\Mongo\Tripod',
+            '\Tripod\Mongo\Driver',
             array(
                 'getDataUpdater',
                 'getComposite'
@@ -917,7 +917,7 @@ class MongoTripodTest extends MongoTripodTestBase
             ->method('getComposite');
         $mockTripodUpdates->expects($this->once())
             ->method('submitJob')
-            ->with(\Tripod\Mongo\Config::getDiscoverQueueName(),"\Tripod\Mongo\DiscoverImpactedSubjects", $jobData);
+            ->with(\Tripod\Mongo\Config::getDiscoverQueueName(),"\Tripod\Mongo\Jobs\DiscoverImpactedSubjects", $jobData);
 
         $mockTripodUpdates->expects($this->once())
             ->method('storeChanges')
@@ -939,7 +939,7 @@ class MongoTripodTest extends MongoTripodTestBase
         $oG->add_resource_triple($uri_2, $oG->qname_to_uri("rdf:type"), $oG->qname_to_uri("acorn:Resource"));
 //        // just deletes, search only
         $mockTripod = $this->getMock(
-            '\Tripod\Mongo\Tripod',
+            '\Tripod\Mongo\Driver',
             array('getDataUpdater','getComposite'),
             array(
                 'CBD_testing',
@@ -970,7 +970,7 @@ class MongoTripodTest extends MongoTripodTestBase
         );
 
         $mockViews = $this->getMock(
-            '\Tripod\Mongo\Views',
+            '\Tripod\Mongo\Composites\Views',
             array('getImpactedSubjects', 'update'),
             array(
                 'tripod_php_testing',
@@ -980,7 +980,7 @@ class MongoTripodTest extends MongoTripodTestBase
         );
 
         $mockTables = $this->getMock(
-            '\Tripod\Mongo\Tables',
+            '\Tripod\Mongo\Composites\Tables',
             array('getImpactedSubjects', 'update'),
             array(
                 'tripod_php_testing',
@@ -1080,7 +1080,7 @@ class MongoTripodTest extends MongoTripodTestBase
 
         $mockTripodUpdates->expects($this->once())
             ->method('submitJob')
-            ->with(\Tripod\Mongo\Config::getDiscoverQueueName(),"\Tripod\Mongo\DiscoverImpactedSubjects", $jobData);
+            ->with(\Tripod\Mongo\Config::getDiscoverQueueName(),"\Tripod\Mongo\Jobs\DiscoverImpactedSubjects", $jobData);
 
         $mockTripodUpdates->expects($this->once())
             ->method('storeChanges')
@@ -1117,9 +1117,9 @@ class MongoTripodTest extends MongoTripodTestBase
         $nG->add_literal_triple($uri_1, $nG->qname_to_uri("searchterms:title"), "wibble");
         $nG->remove_resource_triple($uri_2, $oG->qname_to_uri("rdf:type"), "http://foo/bar#Class2");
 
-        /** @var \Tripod\Mongo\Tripod|PHPUnit_Framework_MockObject_MockObject $mockTripod */
+        /** @var \Tripod\Mongo\Driver|PHPUnit_Framework_MockObject_MockObject $mockTripod */
         $mockTripod = $this->getMock(
-            '\Tripod\Mongo\Tripod',
+            '\Tripod\Mongo\Driver',
             array(
                 'getComposite',
                 'getDataUpdater'
@@ -1151,7 +1151,7 @@ class MongoTripodTest extends MongoTripodTestBase
         );
 
         $mockViews = $this->getMock(
-            '\Tripod\Mongo\Views',
+            '\Tripod\Mongo\Composites\Views',
             array('getImpactedSubjects', 'update'),
             array(
                 'tripod_php_testing',
@@ -1205,7 +1205,7 @@ class MongoTripodTest extends MongoTripodTestBase
 
         $mockTripodUpdates->expects($this->once())
             ->method('submitJob')
-            ->with(\Tripod\Mongo\Config::getDiscoverQueueName(),"\Tripod\Mongo\DiscoverImpactedSubjects", $jobData);
+            ->with(\Tripod\Mongo\Config::getDiscoverQueueName(),"\Tripod\Mongo\Jobs\DiscoverImpactedSubjects", $jobData);
 
         $mockTripodUpdates->expects($this->once())
             ->method('storeChanges')
@@ -1236,7 +1236,7 @@ class MongoTripodTest extends MongoTripodTestBase
             '\Tripod\Exceptions\ConfigException',
             'Collection name \'SOME_COLLECTION\' not in configuration');
 
-        $tripod = new \Tripod\Mongo\Tripod("SOME_COLLECTION","tripod_php_testing");
+        $tripod = new \Tripod\Mongo\Driver("SOME_COLLECTION","tripod_php_testing");
         $tripod->saveChanges(new \Tripod\ExtendedGraph(), new \Tripod\ExtendedGraph(), 'http://talisaspire.com/');
     }
 
@@ -1605,7 +1605,7 @@ class MongoTripodTest extends MongoTripodTestBase
             ->will($this->throwException(new Exception('Some unexpected error occurred.')));
 
         /* @var $tripod PHPUnit_Framework_MockObject_MockObject */
-        $tripod = $this->getMock('\Tripod\Mongo\Tripod', array('getDataUpdater'), array('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/')));
+        $tripod = $this->getMock('\Tripod\Mongo\Driver', array('getDataUpdater'), array('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/')));
         $tripodUpdate = $this->getMock('\Tripod\Mongo\Updates', array('getAuditManualRollbacksCollection'), array($tripod));
 
         $tripodUpdate
@@ -1642,7 +1642,7 @@ class MongoTripodTest extends MongoTripodTestBase
             ->with(array("_id" => $mongoDocumentId), array('$set' => array("status" => AUDIT_STATUS_ERROR, _UPDATED_TS => $mongoDate, 'error' => 'Some unexpected error occurred.')));
 
         /* @var $tripod PHPUnit_Framework_MockObject_MockObject */
-        $tripod = $this->getMock('\Tripod\Mongo\Tripod', array('getDataUpdater'), array('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/')));
+        $tripod = $this->getMock('\Tripod\Mongo\Driver', array('getDataUpdater'), array('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/')));
         $tripodUpdate = $this->getMock('\Tripod\Mongo\Updates',
             array('unlockAllDocuments', 'generateIdForNewMongoDocument', 'getMongoDate', 'getAuditManualRollbacksCollection'),
             array($tripod));
@@ -1700,8 +1700,8 @@ class MongoTripodTest extends MongoTripodTestBase
             ->method('update')
             ->with(array("_id" => $mongoDocumentId), array('$set' => array("status" => AUDIT_STATUS_COMPLETED, _UPDATED_TS => $mongoDate)));
 
-        /* @var \Tripod\Mongo\Tripod PHPUnit_Framework_MockObject_MockObject */
-        $tripod = $this->getMock('\Tripod\Mongo\Tripod', array('getDataUpdater'), array('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/')));
+        /* @var \Tripod\Mongo\Driver PHPUnit_Framework_MockObject_MockObject */
+        $tripod = $this->getMock('\Tripod\Mongo\Driver', array('getDataUpdater'), array('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/')));
         $tripodUpdate = $this->getMock('\Tripod\Mongo\Updates',
             array('unlockAllDocuments', 'generateIdForNewMongoDocument', 'getMongoDate', 'getAuditManualRollbacksCollection'),
             array($tripod));

--- a/test/unit/mongo/MongoTripodNQuadSerializerTest.php
+++ b/test/unit/mongo/MongoTripodNQuadSerializerTest.php
@@ -1,7 +1,10 @@
 <?php
 require_once 'MongoTripodTestBase.php';
 require_once 'src/mongo/MongoGraph.class.php';
-require_once 'src/mongo/serializers/MongoTripodNQuadSerializer.class.php';
+require_once 'src/mongo/serializers/NQuadSerializer.class.php';
+
+use \Tripod\Mongo\MongoGraph;
+use \Tripod\Mongo\NQuadSerializer;
 
 class MongoTripodNQuadSerializerTest extends MongoTripodTestBase
 {
@@ -19,8 +22,8 @@ class MongoTripodNQuadSerializerTest extends MongoTripodTestBase
         $expected = "<http://example.com/1> <http://purl.org/dc/terms/title> \"some literal title\" <http://talisaspire.com/> .
 <http://example.com/1> <http://purl.org/dc/terms/source> <http://www.google.com> <http://talisaspire.com/> .\n";
 
-        $serializer = new MongoTripodNQuadSerializer();
-        $actual = $serializer->getSerializedIndex($g->_index, MongoTripodConfig::getInstance()->getDefaultContextAlias());
+        $serializer = new NQuadSerializer();
+        $actual = $serializer->getSerializedIndex($g->_index, \Tripod\Mongo\Config::getInstance()->getDefaultContextAlias());
 
         $this->assertEquals($expected, $actual);
     }
@@ -133,8 +136,8 @@ class MongoTripodNQuadSerializerTest extends MongoTripodTestBase
 <http://basedata.com/b/bar1234> <http://purl.org/dc/terms/title> \"Another document title\" <http://talisaspire.com/> .
 ";
         
-        $serializer = new MongoTripodNQuadSerializer();
-        $actual = $serializer->getSerializedIndex($g->_index, MongoTripodConfig::getInstance()->getDefaultContextAlias());
+        $serializer = new NQuadSerializer();
+        $actual = $serializer->getSerializedIndex($g->_index, \Tripod\Mongo\Config::getInstance()->getDefaultContextAlias());
 
         $this->assertEquals($expected, $actual);
     }

--- a/test/unit/mongo/MongoTripodQueueOperationsTest.php
+++ b/test/unit/mongo/MongoTripodQueueOperationsTest.php
@@ -10,7 +10,6 @@ require_once 'src/mongo/Tripod.class.php';
  * Tripod Queue, and for each of those items added to the queue the correct operations are listed; furthermore in some cases that when operations are performed
  * the results are as we would expect. For that reason this suite is more than just a series of unit tests, feels more like a set of integration tests since we
  * are testing a chained flow of events.
- * todo: refactor this whole lot due to resque
  */
 class MongoTripodQueueOperations extends MongoTripodTestBase
 {
@@ -49,7 +48,7 @@ class MongoTripodQueueOperations extends MongoTripodTestBase
                 )
             )->getMock();
 
-        $tripodUpdates = $this->getMockBuilder('Updates')
+        $tripodUpdates = $this->getMockBuilder('\Tripod\Mongo\Updates')
             ->setMethods(array('processSyncOperations','submitJob'))
             ->setConstructorArgs(array(
                 $tripod,
@@ -81,7 +80,7 @@ class MongoTripodQueueOperations extends MongoTripodTestBase
 
         $tripodUpdates->expects($this->once())
             ->method('submitJob')
-            ->with(\Tripod\Mongo\Config::getDiscoverQueueName(),"DiscoverImpactedSubjects",$data);
+            ->with(\Tripod\Mongo\Config::getDiscoverQueueName(),"\Tripod\Mongo\DiscoverImpactedSubjects",$data);
 
 
         $g1 = $tripod->describeResource("http://talisaspire.com/resources/doc1");
@@ -101,7 +100,7 @@ class MongoTripodQueueOperations extends MongoTripodTestBase
     public function testSingleItemWithViewsOpIsAddedToQueueForChangeToSingleSubject()
     {
         // create a tripod instance that will send all operations to the queue
-        $tripod = $this->getMockBuilder('Tripod')
+        $tripod = $this->getMockBuilder('\Tripod\Mongo\Tripod')
             ->setMethods(array('getDataUpdater', 'getComposite'))
             ->setConstructorArgs(
                 array(
@@ -114,7 +113,7 @@ class MongoTripodQueueOperations extends MongoTripodTestBase
                 )
             )->getMock();
 
-        $tripodUpdates = $this->getMockBuilder('Updates')
+        $tripodUpdates = $this->getMockBuilder('\Tripod\Mongo\Updates')
             ->setMethods(array('processSyncOperations','submitJob'))
             ->setConstructorArgs(array(
                 $tripod,
@@ -149,7 +148,7 @@ class MongoTripodQueueOperations extends MongoTripodTestBase
 
         $tripodUpdates->expects($this->once())
             ->method('submitJob')
-            ->with(\Tripod\Mongo\Config::getDiscoverQueueName(),"DiscoverImpactedSubjects",$data);
+            ->with(\Tripod\Mongo\Config::getDiscoverQueueName(),"\Tripod\Mongo\DiscoverImpactedSubjects",$data);
 
 
         $g1 = $tripod->describeResource("http://talisaspire.com/resources/doc1");
@@ -166,7 +165,7 @@ class MongoTripodQueueOperations extends MongoTripodTestBase
     public function testNoItemIsAddedToQueueForChangeToSingleSubjectWithNoAsyncOps()
     {
         // create a tripod instance that will send all operations to the queue
-        $tripod = $this->getMockBuilder('Tripod')
+        $tripod = $this->getMockBuilder('\Tripod\Mongo\Tripod')
             ->setMethods(array('getDataUpdater', 'getComposite'))
             ->setConstructorArgs(
                 array(
@@ -179,7 +178,7 @@ class MongoTripodQueueOperations extends MongoTripodTestBase
                 )
             )->getMock();
 
-        $tripodUpdates = $this->getMockBuilder('Updates')
+        $tripodUpdates = $this->getMockBuilder('\Tripod\Mongo\Updates')
             ->setMethods(array('processSyncOperations','submitJob'))
             ->setConstructorArgs(array(
                 $tripod,
@@ -273,7 +272,7 @@ class MongoTripodQueueOperations extends MongoTripodTestBase
 
         $tripodUpdates->expects($this->once())
             ->method('submitJob')
-            ->with(\Tripod\Mongo\Config::getDiscoverQueueName(),"DiscoverImpactedSubjects",$data);
+            ->with(\Tripod\Mongo\Config::getDiscoverQueueName(),"\Tripod\Mongo\DiscoverImpactedSubjects",$data);
 
         $g1 = $tripod->describeResources(array(
             "http://talisaspire.com/resources/doc1",

--- a/test/unit/mongo/MongoTripodQueueOperationsTest.php
+++ b/test/unit/mongo/MongoTripodQueueOperationsTest.php
@@ -1,6 +1,6 @@
 <?php
 require_once 'MongoTripodTestBase.php';
-require_once 'src/mongo/Tripod.class.php';
+require_once 'src/mongo/Driver.class.php';
 
 /**
  * Class MongoTripodQueueOperationsTest
@@ -14,14 +14,14 @@ require_once 'src/mongo/Tripod.class.php';
 class MongoTripodQueueOperations extends MongoTripodTestBase
 {
     /**
-     * @var \Tripod\Mongo\Tripod
+     * @var \Tripod\Mongo\Driver
      */
     protected $tripod = null;
 
     protected function setUp()
     {
         parent::setup();
-        $this->tripod = new \Tripod\Mongo\Tripod(
+        $this->tripod = new \Tripod\Mongo\Driver(
             'CBD_testing',
             'tripod_php_testing'
         );
@@ -35,7 +35,7 @@ class MongoTripodQueueOperations extends MongoTripodTestBase
     public function testSingleItemIsAddedToQueueForChangeToSingleSubject()
     {
         // create a tripod instance that will send all operations to the queue
-        $tripod = $this->getMockBuilder('\Tripod\Mongo\Tripod')
+        $tripod = $this->getMockBuilder('\Tripod\Mongo\Driver')
             ->setMethods(array('getDataUpdater', 'getComposite'))
             ->setConstructorArgs(
                 array(
@@ -80,7 +80,7 @@ class MongoTripodQueueOperations extends MongoTripodTestBase
 
         $tripodUpdates->expects($this->once())
             ->method('submitJob')
-            ->with(\Tripod\Mongo\Config::getDiscoverQueueName(),"\Tripod\Mongo\DiscoverImpactedSubjects",$data);
+            ->with(\Tripod\Mongo\Config::getDiscoverQueueName(),"\Tripod\Mongo\Jobs\DiscoverImpactedSubjects",$data);
 
 
         $g1 = $tripod->describeResource("http://talisaspire.com/resources/doc1");
@@ -100,7 +100,7 @@ class MongoTripodQueueOperations extends MongoTripodTestBase
     public function testSingleItemWithViewsOpIsAddedToQueueForChangeToSingleSubject()
     {
         // create a tripod instance that will send all operations to the queue
-        $tripod = $this->getMockBuilder('\Tripod\Mongo\Tripod')
+        $tripod = $this->getMockBuilder('\Tripod\Mongo\Driver')
             ->setMethods(array('getDataUpdater', 'getComposite'))
             ->setConstructorArgs(
                 array(
@@ -148,7 +148,7 @@ class MongoTripodQueueOperations extends MongoTripodTestBase
 
         $tripodUpdates->expects($this->once())
             ->method('submitJob')
-            ->with(\Tripod\Mongo\Config::getDiscoverQueueName(),"\Tripod\Mongo\DiscoverImpactedSubjects",$data);
+            ->with(\Tripod\Mongo\Config::getDiscoverQueueName(),"\Tripod\Mongo\Jobs\DiscoverImpactedSubjects",$data);
 
 
         $g1 = $tripod->describeResource("http://talisaspire.com/resources/doc1");
@@ -165,7 +165,7 @@ class MongoTripodQueueOperations extends MongoTripodTestBase
     public function testNoItemIsAddedToQueueForChangeToSingleSubjectWithNoAsyncOps()
     {
         // create a tripod instance that will send all operations to the queue
-        $tripod = $this->getMockBuilder('\Tripod\Mongo\Tripod')
+        $tripod = $this->getMockBuilder('\Tripod\Mongo\Driver')
             ->setMethods(array('getDataUpdater', 'getComposite'))
             ->setConstructorArgs(
                 array(
@@ -225,7 +225,7 @@ class MongoTripodQueueOperations extends MongoTripodTestBase
      */
     public function testSingleJobSubmittedToQueueForChangeToSeveralSubjects()
     {
-        $tripod = $this->getMockBuilder('\Tripod\Mongo\Tripod')
+        $tripod = $this->getMockBuilder('\Tripod\Mongo\Driver')
             ->setMethods(array('getDataUpdater', 'getComposite'))
             ->setConstructorArgs(
                 array(
@@ -272,7 +272,7 @@ class MongoTripodQueueOperations extends MongoTripodTestBase
 
         $tripodUpdates->expects($this->once())
             ->method('submitJob')
-            ->with(\Tripod\Mongo\Config::getDiscoverQueueName(),"\Tripod\Mongo\DiscoverImpactedSubjects",$data);
+            ->with(\Tripod\Mongo\Config::getDiscoverQueueName(),"\Tripod\Mongo\Jobs\DiscoverImpactedSubjects",$data);
 
         $g1 = $tripod->describeResources(array(
             "http://talisaspire.com/resources/doc1",

--- a/test/unit/mongo/MongoTripodQueueOperationsTest.php
+++ b/test/unit/mongo/MongoTripodQueueOperationsTest.php
@@ -1,6 +1,6 @@
 <?php
 require_once 'MongoTripodTestBase.php';
-require_once 'src/mongo/MongoTripod.class.php';
+require_once 'src/mongo/Tripod.class.php';
 
 /**
  * Class MongoTripodQueueOperationsTest
@@ -15,14 +15,14 @@ require_once 'src/mongo/MongoTripod.class.php';
 class MongoTripodQueueOperations extends MongoTripodTestBase
 {
     /**
-     * @var MongoTripod
+     * @var \Tripod\Mongo\Tripod
      */
     protected $tripod = null;
 
     protected function setUp()
     {
         parent::setup();
-        $this->tripod = new MongoTripod(
+        $this->tripod = new \Tripod\Mongo\Tripod(
             'CBD_testing',
             'tripod_php_testing'
         );
@@ -36,7 +36,7 @@ class MongoTripodQueueOperations extends MongoTripodTestBase
     public function testSingleItemIsAddedToQueueForChangeToSingleSubject()
     {
         // create a tripod instance that will send all operations to the queue
-        $tripod = $this->getMockBuilder('MongoTripod')
+        $tripod = $this->getMockBuilder('\Tripod\Mongo\Tripod')
             ->setMethods(array('getDataUpdater', 'getComposite'))
             ->setConstructorArgs(
                 array(
@@ -49,7 +49,7 @@ class MongoTripodQueueOperations extends MongoTripodTestBase
                 )
             )->getMock();
 
-        $tripodUpdates = $this->getMockBuilder('MongoTripodUpdates')
+        $tripodUpdates = $this->getMockBuilder('Updates')
             ->setMethods(array('processSyncOperations','submitJob'))
             ->setConstructorArgs(array(
                 $tripod,
@@ -73,7 +73,7 @@ class MongoTripodQueueOperations extends MongoTripodTestBase
         $data = array(
             "changes" => $subjectsAndPredicatesOfChange,
             "operations" => array(OP_VIEWS, OP_TABLES, OP_SEARCH),
-            "tripodConfig" => MongoTripodConfig::getConfig(),
+            "tripodConfig" => \Tripod\Mongo\Config::getConfig(),
             "storeName" => 'tripod_php_testing',
             "podName" => 'CBD_testing',
             "contextAlias" => 'http://talisaspire.com/'
@@ -81,7 +81,7 @@ class MongoTripodQueueOperations extends MongoTripodTestBase
 
         $tripodUpdates->expects($this->once())
             ->method('submitJob')
-            ->with(MongoTripodConfig::getDiscoverQueueName(),"DiscoverImpactedSubjects",$data);
+            ->with(\Tripod\Mongo\Config::getDiscoverQueueName(),"DiscoverImpactedSubjects",$data);
 
 
         $g1 = $tripod->describeResource("http://talisaspire.com/resources/doc1");
@@ -101,7 +101,7 @@ class MongoTripodQueueOperations extends MongoTripodTestBase
     public function testSingleItemWithViewsOpIsAddedToQueueForChangeToSingleSubject()
     {
         // create a tripod instance that will send all operations to the queue
-        $tripod = $this->getMockBuilder('MongoTripod')
+        $tripod = $this->getMockBuilder('Tripod')
             ->setMethods(array('getDataUpdater', 'getComposite'))
             ->setConstructorArgs(
                 array(
@@ -114,7 +114,7 @@ class MongoTripodQueueOperations extends MongoTripodTestBase
                 )
             )->getMock();
 
-        $tripodUpdates = $this->getMockBuilder('MongoTripodUpdates')
+        $tripodUpdates = $this->getMockBuilder('Updates')
             ->setMethods(array('processSyncOperations','submitJob'))
             ->setConstructorArgs(array(
                 $tripod,
@@ -141,7 +141,7 @@ class MongoTripodQueueOperations extends MongoTripodTestBase
         $data = array(
             "changes" => $subjectsAndPredicatesOfChange,
             "operations" => array(OP_VIEWS),
-            "tripodConfig" => MongoTripodConfig::getConfig(),
+            "tripodConfig" => \Tripod\Mongo\Config::getConfig(),
             "storeName" => 'tripod_php_testing',
             "podName" => 'CBD_testing',
             "contextAlias" => 'http://talisaspire.com/'
@@ -149,7 +149,7 @@ class MongoTripodQueueOperations extends MongoTripodTestBase
 
         $tripodUpdates->expects($this->once())
             ->method('submitJob')
-            ->with(MongoTripodConfig::getDiscoverQueueName(),"DiscoverImpactedSubjects",$data);
+            ->with(\Tripod\Mongo\Config::getDiscoverQueueName(),"DiscoverImpactedSubjects",$data);
 
 
         $g1 = $tripod->describeResource("http://talisaspire.com/resources/doc1");
@@ -166,7 +166,7 @@ class MongoTripodQueueOperations extends MongoTripodTestBase
     public function testNoItemIsAddedToQueueForChangeToSingleSubjectWithNoAsyncOps()
     {
         // create a tripod instance that will send all operations to the queue
-        $tripod = $this->getMockBuilder('MongoTripod')
+        $tripod = $this->getMockBuilder('Tripod')
             ->setMethods(array('getDataUpdater', 'getComposite'))
             ->setConstructorArgs(
                 array(
@@ -179,7 +179,7 @@ class MongoTripodQueueOperations extends MongoTripodTestBase
                 )
             )->getMock();
 
-        $tripodUpdates = $this->getMockBuilder('MongoTripodUpdates')
+        $tripodUpdates = $this->getMockBuilder('Updates')
             ->setMethods(array('processSyncOperations','submitJob'))
             ->setConstructorArgs(array(
                 $tripod,
@@ -226,7 +226,7 @@ class MongoTripodQueueOperations extends MongoTripodTestBase
      */
     public function testSingleJobSubmittedToQueueForChangeToSeveralSubjects()
     {
-        $tripod = $this->getMockBuilder('MongoTripod')
+        $tripod = $this->getMockBuilder('\Tripod\Mongo\Tripod')
             ->setMethods(array('getDataUpdater', 'getComposite'))
             ->setConstructorArgs(
                 array(
@@ -239,7 +239,7 @@ class MongoTripodQueueOperations extends MongoTripodTestBase
                 )
             )->getMock();
 
-        $tripodUpdates = $this->getMockBuilder('MongoTripodUpdates')
+        $tripodUpdates = $this->getMockBuilder('\Tripod\Mongo\Updates')
             ->setMethods(array('processSyncOperations','submitJob'))
             ->setConstructorArgs(array(
                 $tripod,
@@ -265,7 +265,7 @@ class MongoTripodQueueOperations extends MongoTripodTestBase
         $data = array(
             "changes" => $subjectsAndPredicatesOfChange,
             "operations" => array(OP_VIEWS, OP_TABLES, OP_SEARCH),
-            "tripodConfig" => MongoTripodConfig::getConfig(),
+            "tripodConfig" => \Tripod\Mongo\Config::getConfig(),
             "storeName" => 'tripod_php_testing',
             "podName" => 'CBD_testing',
             "contextAlias" => 'http://talisaspire.com/'
@@ -273,7 +273,7 @@ class MongoTripodQueueOperations extends MongoTripodTestBase
 
         $tripodUpdates->expects($this->once())
             ->method('submitJob')
-            ->with(MongoTripodConfig::getDiscoverQueueName(),"DiscoverImpactedSubjects",$data);
+            ->with(\Tripod\Mongo\Config::getDiscoverQueueName(),"DiscoverImpactedSubjects",$data);
 
         $g1 = $tripod->describeResources(array(
             "http://talisaspire.com/resources/doc1",

--- a/test/unit/mongo/MongoTripodSearchDocumentsTest.php
+++ b/test/unit/mongo/MongoTripodSearchDocumentsTest.php
@@ -24,7 +24,11 @@ class MongoTripodSearchDocumentsTest extends MongoTripodTestBase
         }
 	}
 
-    protected function getMongoTripodSearchDocuments(\Tripod\Mongo\Tripod $tripod)
+    /**
+     * @param \Tripod\Mongo\Tripod $tripod
+     * @return SearchDocuments
+     */
+    protected function getSearchDocuments(\Tripod\Mongo\Tripod $tripod)
     {
         return new \Tripod\Mongo\SearchDocuments(
             $tripod->getStoreName(),
@@ -36,14 +40,14 @@ class MongoTripodSearchDocumentsTest extends MongoTripodTestBase
 	public function testGenerateSearchDocumentBasedOnSpecIdThrowsExceptionWithEmptyResource()
 	{
 		$this->setExpectedException("Exception","Resource must be specified");		
-		$searchDocuments = $this->getMongoTripodSearchDocuments($this->tripod);
+		$searchDocuments = $this->getSearchDocuments($this->tripod);
 		$searchDocuments->generateSearchDocumentBasedOnSpecId('i_search_resource', null, 'http://talisaspire.com/');
 	}
 	
 	public function testGenerateSearchDocumentBasedOnSpecIdThrowsExceptionWithEmptyContext()
 	{
 		$this->setExpectedException("Exception","Context must be specified");
-        $searchDocuments = $this->getMongoTripodSearchDocuments($this->tripod);
+        $searchDocuments = $this->getSearchDocuments($this->tripod);
 		$searchDocuments->generateSearchDocumentBasedOnSpecId('i_search_resource', 'http://talisaspire.com/resource/1', null);
 	}
 	
@@ -64,14 +68,14 @@ class MongoTripodSearchDocumentsTest extends MongoTripodTestBase
 	
 	public function testGenerateSearchDocumentBasedOnSpecIdReturnNullIfNoMatchForResourceFound()
 	{
-        $searchDocuments = $this->getMongoTripodSearchDocuments($this->tripod);
+        $searchDocuments = $this->getSearchDocuments($this->tripod);
         $generatedDocuments = $searchDocuments->generateSearchDocumentBasedOnSpecId('i_search_resource', 'http://talisaspire.com/resource/1', 'http://talisaspire.com/');
 		$this->assertNull($generatedDocuments);
 	}
 	
 	public function testGenerateSearchDocumentBasedOnSpecId()
 	{
-        $searchDocuments = $this->getMongoTripodSearchDocuments($this->tripod);
+        $searchDocuments = $this->getSearchDocuments($this->tripod);
 		$generatedDocuments = $searchDocuments->generateSearchDocumentBasedOnSpecId('i_search_resource', 'http://talisaspire.com/resources/doc1', 'http://talisaspire.com/');	
 		$this->assertEquals('http://talisaspire.com/resources/doc1' , $generatedDocuments['_id']['r']);
 	}

--- a/test/unit/mongo/MongoTripodSearchDocumentsTest.php
+++ b/test/unit/mongo/MongoTripodSearchDocumentsTest.php
@@ -405,7 +405,7 @@ class MongoTripodSearchDocumentsTest extends MongoTripodTestBase
 
         $subjectsAndPredicatesOfChange = array($uriAlias=>array('rdf:type', 'dct:title'));
 
-        /** @var \Tripod\Mongo\Tripod|PHPUnit_Framework_MockObject_MockObject $mockTripod */
+        /** @var PHPUnit_Framework_MockObject_MockObject|\Tripod\Mongo\Tripod $mockTripod */
         $mockTripod = $this->getMock(
             '\Tripod\Mongo\Tripod',
             array(

--- a/test/unit/mongo/MongoTripodSearchDocumentsTest.php
+++ b/test/unit/mongo/MongoTripodSearchDocumentsTest.php
@@ -14,8 +14,8 @@ class MongoTripodSearchDocumentsTest extends MongoTripodTestBase
 	protected function setUp()
 	{
 		parent::setUp();
-	
-		$this->tripod = new \Tripod\Mongo\Tripod('CBD_testing', 'tripod_php_testing');
+
+		$this->tripod = new \Tripod\Mongo\Driver('CBD_testing', 'tripod_php_testing');
 		$this->getTripodCollection($this->tripod)->drop();
         $this->loadBaseSearchDataViaTripod();
         foreach(\Tripod\Mongo\Config::getInstance()->getCollectionsForSearch($this->tripod->getStoreName()) as $collection)
@@ -25,10 +25,10 @@ class MongoTripodSearchDocumentsTest extends MongoTripodTestBase
 	}
 
     /**
-     * @param \Tripod\Mongo\Tripod $tripod
+     * @param \Tripod\Mongo\Driver $tripod
      * @return SearchDocuments
      */
-    protected function getSearchDocuments(\Tripod\Mongo\Tripod $tripod)
+    protected function getSearchDocuments(\Tripod\Mongo\Driver $tripod)
     {
         return new \Tripod\Mongo\SearchDocuments(
             $tripod->getStoreName(),
@@ -36,21 +36,21 @@ class MongoTripodSearchDocumentsTest extends MongoTripodTestBase
             'http://talisaspire.com/'
         );
     }
-	
+
 	public function testGenerateSearchDocumentBasedOnSpecIdThrowsExceptionWithEmptyResource()
 	{
-		$this->setExpectedException("Exception","Resource must be specified");		
+		$this->setExpectedException("Exception","Resource must be specified");
 		$searchDocuments = $this->getSearchDocuments($this->tripod);
 		$searchDocuments->generateSearchDocumentBasedOnSpecId('i_search_resource', null, 'http://talisaspire.com/');
 	}
-	
+
 	public function testGenerateSearchDocumentBasedOnSpecIdThrowsExceptionWithEmptyContext()
 	{
 		$this->setExpectedException("Exception","Context must be specified");
         $searchDocuments = $this->getSearchDocuments($this->tripod);
 		$searchDocuments->generateSearchDocumentBasedOnSpecId('i_search_resource', 'http://talisaspire.com/resource/1', null);
 	}
-	
+
 	public function testGenerateSearchDocumentBasedOnSpecIdReturnNullForInvalidSearchSpecId()
 	{
 		$mockSearchDocuments = $this->getMock(
@@ -58,30 +58,30 @@ class MongoTripodSearchDocumentsTest extends MongoTripodTestBase
             array('getSearchDocumentSpecification'),
             array($this->tripod->getStoreName(), $this->getTripodCollection($this->tripod), 'http://talisaspire.com/')
         );
-		
+
 		$mockSearchDocuments->expects($this->once())
 							->method('getSearchDocumentSpecification')
 							->will($this->returnValue(null));
 		$generatedDocuments = $mockSearchDocuments->generateSearchDocumentBasedOnSpecId('i_search_something', 'http://talisaspire.com/resource/1', 'http://talisaspire.com/');
 		$this->assertNull($generatedDocuments);
 	}
-	
+
 	public function testGenerateSearchDocumentBasedOnSpecIdReturnNullIfNoMatchForResourceFound()
 	{
         $searchDocuments = $this->getSearchDocuments($this->tripod);
         $generatedDocuments = $searchDocuments->generateSearchDocumentBasedOnSpecId('i_search_resource', 'http://talisaspire.com/resource/1', 'http://talisaspire.com/');
 		$this->assertNull($generatedDocuments);
 	}
-	
+
 	public function testGenerateSearchDocumentBasedOnSpecId()
 	{
         $searchDocuments = $this->getSearchDocuments($this->tripod);
-		$generatedDocuments = $searchDocuments->generateSearchDocumentBasedOnSpecId('i_search_resource', 'http://talisaspire.com/resources/doc1', 'http://talisaspire.com/');	
+		$generatedDocuments = $searchDocuments->generateSearchDocumentBasedOnSpecId('i_search_resource', 'http://talisaspire.com/resources/doc1', 'http://talisaspire.com/');
 		$this->assertEquals('http://talisaspire.com/resources/doc1' , $generatedDocuments['_id']['r']);
 	}
-	
-	
-	
+
+
+
 	public function testGenerateSearchDocumentBasedOnSpecIdWithFieldNamePredicatesHavingNoValueInCollection()
 	{
 		$searchSpecs = json_decode('{"_id":"i_search_resource","type":["bibo:Book"],"from":"CBD_testing","filter":[{"condition":{"dct:title.l":{"$exists":true}}}],"indices":[{"fieldName":"search_terms","predicates":["dct:title","dct:subject"]},{"fieldName":"other_terms","predicates":["rdf:type"]}],"fields":[{"fieldName":"result.title","predicates":["dct:title"],"limit":1},{"fieldName":"result.link","value":"link"},{"fieldName":"rdftype","predicates":["rdf:type"],"limit":1}],"joins":{"dct:creator":{"indices":[{"fieldName":"search_terms","predicates":["foaf:name"]}],"fields":[{"fieldName":"result.author","predicates":["foaf:name"],"limit":1}, {"fieldName":"result.role","predicates":["siocAccess:Role"], "limit":1}] } }}', true);
@@ -95,7 +95,7 @@ class MongoTripodSearchDocumentsTest extends MongoTripodTestBase
 		$mockSearchDocuments->expects($this->once())
 							->method('getSearchDocumentSpecification')
 							->will($this->returnValue($searchSpecs));
-		
+
 		$generatedDocuments = $mockSearchDocuments->generateSearchDocumentBasedOnSpecId('i_search_resource', 'http://talisaspire.com/resources/doc1', 'http://talisaspire.com/');
 		$this->assertNotNull($generatedDocuments);
 		$this->assertEquals('http://talisaspire.com/resources/doc1' , $generatedDocuments['_id']['r']);
@@ -113,8 +113,8 @@ class MongoTripodSearchDocumentsTest extends MongoTripodTestBase
 
         $this->tripod->getSearchIndexer()->generateAndIndexSearchDocuments($uri, $this->defaultContext, $this->defaultPodName);
 
-        /** @var \Tripod\Mongo\SearchIndexer|PHPUnit_Framework_MockObject_MockObject $searchIndexer */
-        $searchIndexer = $this->getMock('\Tripod\Mongo\SearchIndexer',
+        /** @var \Tripod\Mongo\Composites\SearchIndexer|PHPUnit_Framework_MockObject_MockObject $searchIndexer */
+        $searchIndexer = $this->getMock('\Tripod\Mongo\Composites\SearchIndexer',
             array('getSearchDocumentGenerator'),
             array($this->tripod)
         );
@@ -190,8 +190,8 @@ class MongoTripodSearchDocumentsTest extends MongoTripodTestBase
             $labeller->uri_to_alias($uri)=>array('foaf:name')
         );
 
-        /** @var \Tripod\Mongo\SearchIndexer|PHPUnit_Framework_MockObject_MockObject $searchIndexer */
-        $searchIndexer = $this->getMock('\Tripod\Mongo\SearchIndexer',
+        /** @var \Tripod\Mongo\Composites\SearchIndexer|PHPUnit_Framework_MockObject_MockObject $searchIndexer */
+        $searchIndexer = $this->getMock('\Tripod\Mongo\Composites\SearchIndexer',
             array('getSearchDocumentGenerator'),
             array($this->tripod)
         );
@@ -254,9 +254,9 @@ class MongoTripodSearchDocumentsTest extends MongoTripodTestBase
             )
         );
 
-        /** @var \Tripod\Mongo\Tripod|PHPUnit_Framework_MockObject_MockObject $mockTripod */
+        /** @var \Tripod\Mongo\Driver|PHPUnit_Framework_MockObject_MockObject $mockTripod */
         $mockTripod = $this->getMock(
-            '\Tripod\Mongo\Tripod',
+            '\Tripod\Mongo\Driver',
             array(
                 'getDataUpdater'
             ),
@@ -311,9 +311,9 @@ class MongoTripodSearchDocumentsTest extends MongoTripodTestBase
                 $this->defaultContext
             );
 
-        /** @var \Tripod\Mongo\SearchIndexer|PHPUnit_Framework_MockObject_MockObject $searchIndexer */
+        /** @var \Tripod\Mongo\Composites\SearchIndexer|PHPUnit_Framework_MockObject_MockObject $searchIndexer */
         $searchIndexer = $this->getMock(
-            '\Tripod\Mongo\SearchIndexer',
+            '\Tripod\Mongo\Composites\SearchIndexer',
             array('getSearchDocumentGenerator'),
             array($this->tripod)
         );
@@ -368,7 +368,7 @@ class MongoTripodSearchDocumentsTest extends MongoTripodTestBase
         $labeller = new Tripod\Mongo\Labeller();
         $uriAlias = $labeller->uri_to_alias($uri);
 
-        $searchIndexer = new \Tripod\Mongo\SearchIndexer($this->tripod);
+        $searchIndexer = new \Tripod\Mongo\Composites\SearchIndexer($this->tripod);
 
         $subjectsAndPredicatesOfChange = array($uriAlias =>array('dct:subject'));
 
@@ -405,9 +405,9 @@ class MongoTripodSearchDocumentsTest extends MongoTripodTestBase
 
         $subjectsAndPredicatesOfChange = array($uriAlias=>array('rdf:type', 'dct:title'));
 
-        /** @var PHPUnit_Framework_MockObject_MockObject|\Tripod\Mongo\Tripod $mockTripod */
+        /** @var PHPUnit_Framework_MockObject_MockObject|\Tripod\Mongo\Driver $mockTripod */
         $mockTripod = $this->getMock(
-            '\Tripod\Mongo\Tripod',
+            '\Tripod\Mongo\Driver',
             array(
                 'getDataUpdater'
             ),
@@ -548,7 +548,7 @@ class MongoTripodSearchDocumentsTest extends MongoTripodTestBase
         );
 
         // Save the graphs and ensure that table rows are generated
-        $tripod = new \Tripod\Mongo\Tripod(
+        $tripod = new \Tripod\Mongo\Driver(
             $this->defaultPodName,
             $this->defaultStoreName,
             array(
@@ -592,8 +592,8 @@ class MongoTripodSearchDocumentsTest extends MongoTripodTestBase
         );
         $this->assertEquals(2, $collection->count($impactQuery));
 
-        /** @var \Tripod\Mongo\Tripod|PHPUnit_Framework_MockObject_MockObject $mockTripod */
-        $mockTripod = $this->getMockBuilder('\Tripod\Mongo\Tripod')
+        /** @var \Tripod\Mongo\Driver|PHPUnit_Framework_MockObject_MockObject $mockTripod */
+        $mockTripod = $this->getMockBuilder('\Tripod\Mongo\Driver')
             ->setMethods(array('getDataUpdater'))
             ->setConstructorArgs(
                 array(
@@ -649,7 +649,7 @@ class MongoTripodSearchDocumentsTest extends MongoTripodTestBase
         $this->assertTrue($deletedGraph->is_empty());
 
         // Manually walk through the tables operation
-        /** @var \Tripod\Mongo\SearchIndexer $search */
+        /** @var \Tripod\Mongo\Composites\SearchIndexer $search */
         $search = $mockTripod->getComposite(OP_SEARCH);
 
         $expectedImpactedSubjects = array(

--- a/test/unit/mongo/MongoTripodSearchDocumentsTest.php
+++ b/test/unit/mongo/MongoTripodSearchDocumentsTest.php
@@ -26,7 +26,7 @@ class MongoTripodSearchDocumentsTest extends MongoTripodTestBase
 
     protected function getMongoTripodSearchDocuments(\Tripod\Mongo\Tripod $tripod)
     {
-        return new SearchDocuments(
+        return new \Tripod\Mongo\SearchDocuments(
             $tripod->getStoreName(),
             $this->getTripodCollection($tripod),
             'http://talisaspire.com/'
@@ -49,9 +49,11 @@ class MongoTripodSearchDocumentsTest extends MongoTripodTestBase
 	
 	public function testGenerateSearchDocumentBasedOnSpecIdReturnNullForInvalidSearchSpecId()
 	{
-		$mockSearchDocuments = $this->getMock('SearchDocuments',
-											array('getSearchDocumentSpecification'), 
-											array($this->tripod->getStoreName(), $this->getTripodCollection($this->tripod), 'http://talisaspire.com/'));
+		$mockSearchDocuments = $this->getMock(
+            '\Tripod\Mongo\SearchDocuments',
+            array('getSearchDocumentSpecification'),
+            array($this->tripod->getStoreName(), $this->getTripodCollection($this->tripod), 'http://talisaspire.com/')
+        );
 		
 		$mockSearchDocuments->expects($this->once())
 							->method('getSearchDocumentSpecification')
@@ -79,9 +81,13 @@ class MongoTripodSearchDocumentsTest extends MongoTripodTestBase
 	public function testGenerateSearchDocumentBasedOnSpecIdWithFieldNamePredicatesHavingNoValueInCollection()
 	{
 		$searchSpecs = json_decode('{"_id":"i_search_resource","type":["bibo:Book"],"from":"CBD_testing","filter":[{"condition":{"dct:title.l":{"$exists":true}}}],"indices":[{"fieldName":"search_terms","predicates":["dct:title","dct:subject"]},{"fieldName":"other_terms","predicates":["rdf:type"]}],"fields":[{"fieldName":"result.title","predicates":["dct:title"],"limit":1},{"fieldName":"result.link","value":"link"},{"fieldName":"rdftype","predicates":["rdf:type"],"limit":1}],"joins":{"dct:creator":{"indices":[{"fieldName":"search_terms","predicates":["foaf:name"]}],"fields":[{"fieldName":"result.author","predicates":["foaf:name"],"limit":1}, {"fieldName":"result.role","predicates":["siocAccess:Role"], "limit":1}] } }}', true);
-		$mockSearchDocuments = $this->getMock('SearchDocuments',
-				array('getSearchDocumentSpecification'),
-				array($this->tripod->getStoreName(), $this->getTripodCollection($this->tripod), 'http://talisaspire.com/'));
+
+        $mockSearchDocuments = $this->getMock(
+            '\Tripod\Mongo\SearchDocuments',
+            array('getSearchDocumentSpecification'),
+            array($this->tripod->getStoreName(), $this->getTripodCollection($this->tripod), 'http://talisaspire.com/')
+        );
+
 		$mockSearchDocuments->expects($this->once())
 							->method('getSearchDocumentSpecification')
 							->will($this->returnValue($searchSpecs));
@@ -104,12 +110,12 @@ class MongoTripodSearchDocumentsTest extends MongoTripodTestBase
         $this->tripod->getSearchIndexer()->generateAndIndexSearchDocuments($uri, $this->defaultContext, $this->defaultPodName);
 
         /** @var \Tripod\Mongo\SearchIndexer|PHPUnit_Framework_MockObject_MockObject $searchIndexer */
-        $searchIndexer = $this->getMock('SearchIndexer',
+        $searchIndexer = $this->getMock('\Tripod\Mongo\SearchIndexer',
             array('getSearchDocumentGenerator'),
             array($this->tripod)
         );
 
-        $searchDocuments = $this->getMockBuilder('SearchDocuments')
+        $searchDocuments = $this->getMockBuilder('\Tripod\Mongo\SearchDocuments')
             ->setMethods(array('generateSearchDocumentBasedOnSpecId'))
             ->setConstructorArgs(
                 array(
@@ -181,12 +187,12 @@ class MongoTripodSearchDocumentsTest extends MongoTripodTestBase
         );
 
         /** @var \Tripod\Mongo\SearchIndexer|PHPUnit_Framework_MockObject_MockObject $searchIndexer */
-        $searchIndexer = $this->getMock('SearchIndexer',
+        $searchIndexer = $this->getMock('\Tripod\Mongo\SearchIndexer',
             array('getSearchDocumentGenerator'),
             array($this->tripod)
         );
 
-        $searchDocuments = $this->getMockBuilder('SearchDocuments')
+        $searchDocuments = $this->getMockBuilder('\Tripod\Mongo\SearchDocuments')
             ->setMethods(array('generateSearchDocumentBasedOnSpecId'))
             ->setConstructorArgs(
                 array(
@@ -246,7 +252,7 @@ class MongoTripodSearchDocumentsTest extends MongoTripodTestBase
 
         /** @var \Tripod\Mongo\Tripod|PHPUnit_Framework_MockObject_MockObject $mockTripod */
         $mockTripod = $this->getMock(
-            'Tripod',
+            '\Tripod\Mongo\Tripod',
             array(
                 'getDataUpdater'
             ),
@@ -266,7 +272,7 @@ class MongoTripodSearchDocumentsTest extends MongoTripodTestBase
 
         /** @var \Tripod\Mongo\Updates|PHPUnit_Framework_MockObject_MockObject $mockTripodUpdates */
         $mockTripodUpdates = $this->getMock(
-            'Updates',
+            '\Tripod\Mongo\Updates',
             array(
                 'processSyncOperations',
                 'queueAsyncOperations'
@@ -302,12 +308,13 @@ class MongoTripodSearchDocumentsTest extends MongoTripodTestBase
             );
 
         /** @var \Tripod\Mongo\SearchIndexer|PHPUnit_Framework_MockObject_MockObject $searchIndexer */
-        $searchIndexer = $this->getMock('SearchIndexer',
+        $searchIndexer = $this->getMock(
+            '\Tripod\Mongo\SearchIndexer',
             array('getSearchDocumentGenerator'),
             array($this->tripod)
         );
 
-        $searchDocuments = $this->getMockBuilder('SearchDocuments')
+        $searchDocuments = $this->getMockBuilder('\Tripod\Mongo\SearchDocuments')
             ->setMethods(array('generateSearchDocumentBasedOnSpecId'))
             ->setConstructorArgs(
                 array(
@@ -396,7 +403,7 @@ class MongoTripodSearchDocumentsTest extends MongoTripodTestBase
 
         /** @var \Tripod\Mongo\Tripod|PHPUnit_Framework_MockObject_MockObject $mockTripod */
         $mockTripod = $this->getMock(
-            'Tripod',
+            '\Tripod\Mongo\Tripod',
             array(
                 'getDataUpdater'
             ),
@@ -416,7 +423,7 @@ class MongoTripodSearchDocumentsTest extends MongoTripodTestBase
 
         /** @var \Tripod\Mongo\Updates|PHPUnit_Framework_MockObject_MockObject $mockTripodUpdates */
         $mockTripodUpdates = $this->getMock(
-            'Updates',
+            '\Tripod\Mongo\Updates',
             array(
                 'processSyncOperations',
                 'queueAsyncOperations'
@@ -582,7 +589,7 @@ class MongoTripodSearchDocumentsTest extends MongoTripodTestBase
         $this->assertEquals(2, $collection->count($impactQuery));
 
         /** @var \Tripod\Mongo\Tripod|PHPUnit_Framework_MockObject_MockObject $mockTripod */
-        $mockTripod = $this->getMockBuilder('Tripod')
+        $mockTripod = $this->getMockBuilder('\Tripod\Mongo\Tripod')
             ->setMethods(array('getDataUpdater'))
             ->setConstructorArgs(
                 array(
@@ -599,7 +606,7 @@ class MongoTripodSearchDocumentsTest extends MongoTripodTestBase
                 )
             )->getMock();
 
-        $mockTripodUpdates = $this->getMockBuilder('Updates')
+        $mockTripodUpdates = $this->getMockBuilder('\Tripod\Mongo\Updates')
             ->setConstructorArgs(
                 array(
                     $mockTripod,

--- a/test/unit/mongo/MongoTripodSearchIndexerTest.php
+++ b/test/unit/mongo/MongoTripodSearchIndexerTest.php
@@ -1,6 +1,6 @@
 <?php
 require_once 'MongoTripodTestBase.php';
-require_once 'src/mongo/MongoTripod.class.php';
+require_once 'src/mongo/Tripod.class.php';
 require_once 'src/mongo/MongoGraph.class.php';
 
 
@@ -10,8 +10,8 @@ class MongoTripodSearchIndexerTest extends MongoTripodTestBase {
     {
         parent::setUp();
 
-        $this->tripod = new MongoTripod("CBD_testing", "tripod_php_testing", array("async"=>array(OP_VIEWS=>true, OP_TABLES=>true, OP_SEARCH=>false)));
-        foreach(MongoTripodConfig::getInstance()->getCollectionsForSearch($this->tripod->getStoreName()) as $collection)
+        $this->tripod = new \Tripod\Mongo\Tripod("CBD_testing", "tripod_php_testing", array("async"=>array(OP_VIEWS=>true, OP_TABLES=>true, OP_SEARCH=>false)));
+        foreach(\Tripod\Mongo\Config::getInstance()->getCollectionsForSearch($this->tripod->getStoreName()) as $collection)
         {
             $collection->drop();
         }
@@ -23,7 +23,7 @@ class MongoTripodSearchIndexerTest extends MongoTripodTestBase {
     {
         // First make a change that affects a search document
         $tripod = $this->getMock(
-            'MongoTripod',
+            '\Tripod\Mongo\Tripod',
             array('getSearchIndexer', 'getDataUpdater'),
             array(
                 'CBD_testing',
@@ -40,7 +40,7 @@ class MongoTripodSearchIndexerTest extends MongoTripodTestBase {
         );
 
         $tripodUpdate = $this->getMock(
-            'MongoTripodUpdates',
+            '\Tripod\Mongo\Updates',
             array('storeChanges'),
             array(
                 $tripod,
@@ -55,7 +55,7 @@ class MongoTripodSearchIndexerTest extends MongoTripodTestBase {
             )
         );
 
-        $labeller = new MongoTripodLabeller();
+        $labeller = new \Tripod\Mongo\Labeller();
         $subjectsAndPredicatesOfChange = array(
             $labeller->uri_to_alias("http://talisaspire.com/authors/1")=>array("foaf:name")
         );
@@ -68,7 +68,7 @@ class MongoTripodSearchIndexerTest extends MongoTripodTestBase {
             ->method('getDataUpdater')
             ->will($this->returnValue($tripodUpdate));
 
-        $searchIndexer = $this->getMock('MongoTripodSearchIndexer',
+        $searchIndexer = $this->getMock('SearchIndexer',
             array('getSearchProvider'),
             array($tripod)
         );
@@ -106,7 +106,7 @@ class MongoTripodSearchIndexerTest extends MongoTripodTestBase {
 
         // Now make a change that affects a different search document - Create new document
         $tripod = $this->getMock(
-            'MongoTripod',
+            'Tripod',
             array('getSearchIndexer'),
             array(
                 'CBD_testing',
@@ -122,7 +122,7 @@ class MongoTripodSearchIndexerTest extends MongoTripodTestBase {
             )
         );
 
-        $searchIndexer = $this->getMock('MongoTripodSearchIndexer',
+        $searchIndexer = $this->getMock('SearchIndexer',
             array('getSearchProvider'),
             array($tripod)
         );
@@ -152,11 +152,11 @@ class MongoTripodSearchIndexerTest extends MongoTripodTestBase {
             ->method('getSearchIndexer')
             ->will($this->returnValue($searchIndexer));
 
-        $list = new ExtendedGraph();
+        $list = new \Tripod\ExtendedGraph();
         $list->add_resource_triple("http://talisaspire.com/lists/1234", RDF_TYPE, "http://purl.org/vocab/resourcelist/schema#List");
         $list->add_literal_triple("http://talisaspire.com/lists/1234", "http://rdfs.org/sioc/spec/name", "Testing list");
 
-        $tripod->saveChanges(new ExtendedGraph(), $list);
+        $tripod->saveChanges(new \Tripod\ExtendedGraph(), $list);
 
         // Regen our search docs for real since this step was overridden in the stub
         $this->tripod->getSearchIndexer()->generateAndIndexSearchDocuments(
@@ -167,7 +167,7 @@ class MongoTripodSearchIndexerTest extends MongoTripodTestBase {
 
         // Now make a change to the last document
         $tripod = $this->getMock(
-            'MongoTripod',
+            '\Tripod\Mongo\Tripod',
             array('getSearchIndexer'),
             array(
                 'CBD_testing',
@@ -183,7 +183,7 @@ class MongoTripodSearchIndexerTest extends MongoTripodTestBase {
             )
         );
 
-        $searchIndexer = $this->getMock('MongoTripodSearchIndexer',
+        $searchIndexer = $this->getMock('SearchIndexer',
             array('getSearchProvider'),
             array($tripod)
         );
@@ -234,7 +234,7 @@ class MongoTripodSearchIndexerTest extends MongoTripodTestBase {
 
         // Now make a change that shouldn't affect any search docs
         $tripod = $this->getMock(
-            'MongoTripod',
+            'Tripod',
             array('getSearchIndexer', 'getDataUpdater'),
             array(
                 'CBD_testing',
@@ -251,7 +251,7 @@ class MongoTripodSearchIndexerTest extends MongoTripodTestBase {
         );
 
         $tripodUpdate = $this->getMock(
-            'MongoTripodUpdates',
+            'Updates',
             array('storeChanges'),
             array(
                 $tripod,
@@ -273,7 +273,7 @@ class MongoTripodSearchIndexerTest extends MongoTripodTestBase {
             ->method('getDataUpdater')
             ->will($this->returnValue($tripodUpdate));
 
-        $searchIndexer = $this->getMock('MongoTripodSearchIndexer',
+        $searchIndexer = $this->getMock('SearchIndexer',
             array('getSearchProvider', 'update'),
             array($tripod)
         );
@@ -314,7 +314,7 @@ class MongoTripodSearchIndexerTest extends MongoTripodTestBase {
      */
     public function testSavingMultipleNewEntitiesResultsInOneImpactedSubject()
     {
-        $tripod = $this->getMockBuilder('MongoTripod')
+        $tripod = $this->getMockBuilder('Tripod')
             ->setMethods(array('getDataUpdater'))
             ->setConstructorArgs(
                 array(
@@ -331,7 +331,7 @@ class MongoTripodSearchIndexerTest extends MongoTripodTestBase {
                 )
             )->getMock();
 
-        $tripodUpdates = $this->getMockBuilder('MongoTripodUpdates')
+        $tripodUpdates = $this->getMockBuilder('Updates')
             ->setMethods(array('submitJob'))
             ->setConstructorArgs(
                 array(
@@ -352,7 +352,7 @@ class MongoTripodSearchIndexerTest extends MongoTripodTestBase {
             ->will($this->returnValue($tripodUpdates));
 
         // first lets add a book, which should trigger a search doc, view and table gen for a single item
-        $g = new MongoGraph();
+        $g = new \Tripod\Mongo\MongoGraph();
         $newSubjectUri1 = "http://talisaspire.com/resources/newdoc1";
         $newSubjectUri2 = "http://talisaspire.com/resources/newdoc2";
         $newSubjectUri3 = "http://talisaspire.com/resources/newdoc3";
@@ -380,13 +380,13 @@ class MongoTripodSearchIndexerTest extends MongoTripodTestBase {
             $newSubjectUri2=>array('rdf:type','dct:creator','dct:title','dct:subject'),
             $newSubjectUri3=>array('rdf:type','dct:creator','dct:title','dct:subject')
         );
-        $tripod->saveChanges(new MongoGraph(), $g);
+        $tripod->saveChanges(new \Tripod\Mongo\MongoGraph(), $g);
 
         /** @var MongoTripodTables $tables */
         $search = $tripod->getComposite(OP_SEARCH);
 
         $expectedImpactedSubjects = array(
-            new ImpactedSubject(
+            new \Tripod\Mongo\ImpactedSubject(
                 array(
                     _ID_RESOURCE=>$newSubjectUri2,
                     _ID_CONTEXT=>'http://talisaspire.com/'

--- a/test/unit/mongo/MongoTripodSearchIndexerTest.php
+++ b/test/unit/mongo/MongoTripodSearchIndexerTest.php
@@ -1,6 +1,6 @@
 <?php
 require_once 'MongoTripodTestBase.php';
-require_once 'src/mongo/Tripod.class.php';
+require_once 'src/mongo/Driver.class.php';
 require_once 'src/mongo/MongoGraph.class.php';
 
 /**
@@ -12,7 +12,7 @@ class MongoTripodSearchIndexerTest extends MongoTripodTestBase {
     {
         parent::setUp();
 
-        $this->tripod = new \Tripod\Mongo\Tripod("CBD_testing", "tripod_php_testing", array("async"=>array(OP_VIEWS=>true, OP_TABLES=>true, OP_SEARCH=>false)));
+        $this->tripod = new \Tripod\Mongo\Driver("CBD_testing", "tripod_php_testing", array("async"=>array(OP_VIEWS=>true, OP_TABLES=>true, OP_SEARCH=>false)));
         foreach(\Tripod\Mongo\Config::getInstance()->getCollectionsForSearch($this->tripod->getStoreName()) as $collection)
         {
             $collection->drop();
@@ -25,7 +25,7 @@ class MongoTripodSearchIndexerTest extends MongoTripodTestBase {
     {
         // First make a change that affects a search document
         $tripod = $this->getMock(
-            '\Tripod\Mongo\Tripod',
+            '\Tripod\Mongo\Driver',
             array('getSearchIndexer', 'getDataUpdater'),
             array(
                 'CBD_testing',
@@ -70,7 +70,7 @@ class MongoTripodSearchIndexerTest extends MongoTripodTestBase {
             ->method('getDataUpdater')
             ->will($this->returnValue($tripodUpdate));
 
-        $searchIndexer = $this->getMock('\Tripod\Mongo\SearchIndexer',
+        $searchIndexer = $this->getMock('\Tripod\Mongo\Composites\SearchIndexer',
             array('getSearchProvider'),
             array($tripod)
         );
@@ -108,7 +108,7 @@ class MongoTripodSearchIndexerTest extends MongoTripodTestBase {
 
         // Now make a change that affects a different search document - Create new document
         $tripod = $this->getMock(
-            '\Tripod\Mongo\Tripod',
+            '\Tripod\Mongo\Driver',
             array('getSearchIndexer'),
             array(
                 'CBD_testing',
@@ -124,7 +124,7 @@ class MongoTripodSearchIndexerTest extends MongoTripodTestBase {
             )
         );
 
-        $searchIndexer = $this->getMock('\Tripod\Mongo\SearchIndexer',
+        $searchIndexer = $this->getMock('\Tripod\Mongo\Composites\SearchIndexer',
             array('getSearchProvider'),
             array($tripod)
         );
@@ -169,7 +169,7 @@ class MongoTripodSearchIndexerTest extends MongoTripodTestBase {
 
         // Now make a change to the last document
         $tripod = $this->getMock(
-            '\Tripod\Mongo\Tripod',
+            '\Tripod\Mongo\Driver',
             array('getSearchIndexer'),
             array(
                 'CBD_testing',
@@ -185,7 +185,7 @@ class MongoTripodSearchIndexerTest extends MongoTripodTestBase {
             )
         );
 
-        $searchIndexer = $this->getMock('\Tripod\Mongo\SearchIndexer',
+        $searchIndexer = $this->getMock('\Tripod\Mongo\Composites\SearchIndexer',
             array('getSearchProvider'),
             array($tripod)
         );
@@ -236,7 +236,7 @@ class MongoTripodSearchIndexerTest extends MongoTripodTestBase {
 
         // Now make a change that shouldn't affect any search docs
         $tripod = $this->getMock(
-            '\Tripod\Mongo\Tripod',
+            '\Tripod\Mongo\Driver',
             array('getSearchIndexer', 'getDataUpdater'),
             array(
                 'CBD_testing',
@@ -275,7 +275,7 @@ class MongoTripodSearchIndexerTest extends MongoTripodTestBase {
             ->method('getDataUpdater')
             ->will($this->returnValue($tripodUpdate));
 
-        $searchIndexer = $this->getMock('\Tripod\Mongo\SearchIndexer',
+        $searchIndexer = $this->getMock('\Tripod\Mongo\Composites\SearchIndexer',
             array('getSearchProvider', 'update'),
             array($tripod)
         );
@@ -316,7 +316,7 @@ class MongoTripodSearchIndexerTest extends MongoTripodTestBase {
      */
     public function testSavingMultipleNewEntitiesResultsInOneImpactedSubject()
     {
-        $tripod = $this->getMockBuilder('\Tripod\Mongo\Tripod')
+        $tripod = $this->getMockBuilder('\Tripod\Mongo\Driver')
             ->setMethods(array('getDataUpdater'))
             ->setConstructorArgs(
                 array(

--- a/test/unit/mongo/MongoTripodSearchIndexerTest.php
+++ b/test/unit/mongo/MongoTripodSearchIndexerTest.php
@@ -3,7 +3,9 @@ require_once 'MongoTripodTestBase.php';
 require_once 'src/mongo/Tripod.class.php';
 require_once 'src/mongo/MongoGraph.class.php';
 
-
+/**
+ * Class MongoTripodSearchIndexerTest
+ */
 class MongoTripodSearchIndexerTest extends MongoTripodTestBase {
 
     protected function setUp()
@@ -68,12 +70,12 @@ class MongoTripodSearchIndexerTest extends MongoTripodTestBase {
             ->method('getDataUpdater')
             ->will($this->returnValue($tripodUpdate));
 
-        $searchIndexer = $this->getMock('SearchIndexer',
+        $searchIndexer = $this->getMock('\Tripod\Mongo\SearchIndexer',
             array('getSearchProvider'),
             array($tripod)
         );
 
-        $searchProvider = $this->getMock('MongoSearchProvider',
+        $searchProvider = $this->getMock('\Tripod\Mongo\MongoSearchProvider',
             array('deleteDocument','indexDocument'),
             array($tripod)
         );
@@ -106,7 +108,7 @@ class MongoTripodSearchIndexerTest extends MongoTripodTestBase {
 
         // Now make a change that affects a different search document - Create new document
         $tripod = $this->getMock(
-            'Tripod',
+            '\Tripod\Mongo\Tripod',
             array('getSearchIndexer'),
             array(
                 'CBD_testing',
@@ -122,12 +124,12 @@ class MongoTripodSearchIndexerTest extends MongoTripodTestBase {
             )
         );
 
-        $searchIndexer = $this->getMock('SearchIndexer',
+        $searchIndexer = $this->getMock('\Tripod\Mongo\SearchIndexer',
             array('getSearchProvider'),
             array($tripod)
         );
 
-        $searchProvider = $this->getMock('MongoSearchProvider',
+        $searchProvider = $this->getMock('\Tripod\Mongo\MongoSearchProvider',
             array('deleteDocument','indexDocument'),
             array($tripod)
         );
@@ -183,12 +185,12 @@ class MongoTripodSearchIndexerTest extends MongoTripodTestBase {
             )
         );
 
-        $searchIndexer = $this->getMock('SearchIndexer',
+        $searchIndexer = $this->getMock('\Tripod\Mongo\SearchIndexer',
             array('getSearchProvider'),
             array($tripod)
         );
 
-        $searchProvider = $this->getMock('MongoSearchProvider',
+        $searchProvider = $this->getMock('\Tripod\Mongo\MongoSearchProvider',
             array('deleteDocument','indexDocument'),
             array($tripod)
         );
@@ -234,7 +236,7 @@ class MongoTripodSearchIndexerTest extends MongoTripodTestBase {
 
         // Now make a change that shouldn't affect any search docs
         $tripod = $this->getMock(
-            'Tripod',
+            '\Tripod\Mongo\Tripod',
             array('getSearchIndexer', 'getDataUpdater'),
             array(
                 'CBD_testing',
@@ -251,7 +253,7 @@ class MongoTripodSearchIndexerTest extends MongoTripodTestBase {
         );
 
         $tripodUpdate = $this->getMock(
-            'Updates',
+            '\Tripod\Mongo\Updates',
             array('storeChanges'),
             array(
                 $tripod,
@@ -273,12 +275,12 @@ class MongoTripodSearchIndexerTest extends MongoTripodTestBase {
             ->method('getDataUpdater')
             ->will($this->returnValue($tripodUpdate));
 
-        $searchIndexer = $this->getMock('SearchIndexer',
+        $searchIndexer = $this->getMock('\Tripod\Mongo\SearchIndexer',
             array('getSearchProvider', 'update'),
             array($tripod)
         );
 
-        $searchProvider = $this->getMock('MongoSearchProvider',
+        $searchProvider = $this->getMock('\Tripod\Mongo\MongoSearchProvider',
             array('deleteDocument','indexDocument'),
             array($tripod)
         );
@@ -314,7 +316,7 @@ class MongoTripodSearchIndexerTest extends MongoTripodTestBase {
      */
     public function testSavingMultipleNewEntitiesResultsInOneImpactedSubject()
     {
-        $tripod = $this->getMockBuilder('Tripod')
+        $tripod = $this->getMockBuilder('\Tripod\Mongo\Tripod')
             ->setMethods(array('getDataUpdater'))
             ->setConstructorArgs(
                 array(
@@ -331,7 +333,7 @@ class MongoTripodSearchIndexerTest extends MongoTripodTestBase {
                 )
             )->getMock();
 
-        $tripodUpdates = $this->getMockBuilder('Updates')
+        $tripodUpdates = $this->getMockBuilder('\Tripod\Mongo\Updates')
             ->setMethods(array('submitJob'))
             ->setConstructorArgs(
                 array(
@@ -382,7 +384,7 @@ class MongoTripodSearchIndexerTest extends MongoTripodTestBase {
         );
         $tripod->saveChanges(new \Tripod\Mongo\MongoGraph(), $g);
 
-        /** @var MongoTripodTables $tables */
+        /** @var \Tripod\Mongo\Tables $tables */
         $search = $tripod->getComposite(OP_SEARCH);
 
         $expectedImpactedSubjects = array(

--- a/test/unit/mongo/MongoTripodTablesTest.php
+++ b/test/unit/mongo/MongoTripodTablesTest.php
@@ -898,8 +898,6 @@ class MongoTripodTablesTest extends MongoTripodTestBase
 
         $impactedSubjects = $table->getImpactedSubjects($subjectsAndPredicatesOfChange, $this->defaultContext);
 
-        $this->assertEquals($expectedImpactedSubject, $impactedSubjects[0]);
-
         $impactedSubject = $impactedSubjects[0];
 
         $this->assertEquals($expectedImpactedSubject->getResourceId(), $impactedSubject->getResourceId());

--- a/test/unit/mongo/MongoTripodTablesTest.php
+++ b/test/unit/mongo/MongoTripodTablesTest.php
@@ -4,7 +4,9 @@ require_once 'src/mongo/delegates/Tables.class.php';
 require_once 'src/mongo/Tripod.class.php';
 require_once 'src/mongo/MongoGraph.class.php';
 
-
+/**
+ * Class MongoTripodTablesTest
+ */
 class MongoTripodTablesTest extends MongoTripodTestBase
 {
     /**
@@ -270,6 +272,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
 
     public function testUpdateWillDeleteItem()
     {
+        /** @var \Tripod\Mongo\Tables|PHPUnit_Framework_MockObject_MockObject $mockTables */
         $mockTables = $this->getMock('\Tripod\Mongo\Tables', array('deleteTableRowsForResource','generateTableRowsForType'), $this->tablesConstParams);
         $mockTables->expects($this->once())->method('deleteTableRowsForResource')->with("http://foo","context");
         $mockTables->expects($this->never())->method('generateTableRowsForType');
@@ -279,6 +282,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
 
     public function testUpdateWillGenerateRows()
     {
+        /** @var \Tripod\Mongo\Tables|PHPUnit_Framework_MockObject_MockObject $mockTables */
         $mockTables = $this->getMock('\Tripod\Mongo\Tables', array('deleteRowsForResource','generateTableRowsForResource'), $this->tablesConstParams);
         $mockTables->expects($this->once())->method('generateTableRowsForResource')->with("http://foo","context");
         $mockTables->expects($this->never())->method('deleteTableRowsForResource');
@@ -844,6 +848,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
             $labeller->uri_to_alias($uri)=>array("dct:title")
         );
 
+        /** @var \Tripod\Mongo\Tables|PHPUnit_Framework_MockObject_MockObject $mockTables */
         $tables = $this->getMock('\Tripod\Mongo\Tables',
             array('generateTableRows'),
             array(
@@ -1336,6 +1341,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
 
         $this->assertEquals(1, $tableRows['head']['count']);
 
+        /** @var \Tripod\Mongo\Tripod|PHPUnit_Framework_MockObject_MockObject $mockTripod */
         $mockTripod = $this->getMockBuilder('\Tripod\Mongo\Tripod')
             ->setMethods(array('getDataUpdater'))
             ->setConstructorArgs(
@@ -1353,6 +1359,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
                 )
             )->getMock();
 
+        /** @var \Tripod\Mongo\Updates|PHPUnit_Framework_MockObject_MockObject $mockUpdates */
         $mockTripodUpdates = $this->getMockBuilder('\Tripod\Mongo\Updates')
             ->setConstructorArgs(
                 array(
@@ -1456,6 +1463,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
      */
     public function testSavingMultipleNewEntitiesResultsInOneImpactedSubject()
     {
+        /** @var \Tripod\Mongo\Tripod|PHPUnit_Framework_MockObject_MockObject $tripod */
         $tripod = $this->getMockBuilder('\Tripod\Mongo\Tripod')
             ->setMethods(array('getDataUpdater'))
             ->setConstructorArgs(
@@ -1473,6 +1481,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
                 )
             )->getMock();
 
+        /** @var \Tripod\Mongo\Updates|PHPUnit_Framework_MockObject_MockObject $tripodUpdates */
         $tripodUpdates = $this->getMockBuilder('\Tripod\Mongo\Updates')
             ->setMethods(array('submitJob'))
             ->setConstructorArgs(

--- a/test/unit/mongo/MongoTripodTablesTest.php
+++ b/test/unit/mongo/MongoTripodTablesTest.php
@@ -8,16 +8,16 @@ require_once 'src/mongo/MongoGraph.class.php';
 class MongoTripodTablesTest extends MongoTripodTestBase
 {
     /**
-     * @var MongoTripod
+     * @var \Tripod\Mongo\Tripod
      */
     protected $tripod = null;
     /**
-     * @var TransactionLog
+     * @var \Tripod\Mongo\TransactionLog
      */
     protected $tripodTransationLog = null;
 
     /**
-     * @var Tables
+     * @var \Tripod\Mongo\Tables
      */
     protected $tripodTables = null;
 
@@ -227,7 +227,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
             }
         }
 
-        $this->assertNotNull($result,"Cound not find table row for $subject");
+        $this->assertNotNull($result,"Could not find table row for $subject");
         // check out the columns
         $this->assertArrayHasKey('type',$result,"Result does not contain type");
         $this->assertArrayHasKey('source_count',$result,"Result does not contain source_count");
@@ -270,20 +270,20 @@ class MongoTripodTablesTest extends MongoTripodTestBase
 
     public function testUpdateWillDeleteItem()
     {
-        $mockTables = $this->getMock('Tables', array('deleteTableRowsForResource','generateTableRowsForType'), $this->tablesConstParams);
+        $mockTables = $this->getMock('\Tripod\Mongo\Tables', array('deleteTableRowsForResource','generateTableRowsForType'), $this->tablesConstParams);
         $mockTables->expects($this->once())->method('deleteTableRowsForResource')->with("http://foo","context");
         $mockTables->expects($this->never())->method('generateTableRowsForType');
 
-        $mockTables->update(new ImpactedSubject(array("r"=>"http://foo","c"=>"context"),OP_TABLES,"foo","bar",array("t_table"),true));
+        $mockTables->update(new \Tripod\Mongo\ImpactedSubject(array("r"=>"http://foo","c"=>"context"),OP_TABLES,"foo","bar",array("t_table"),true));
     }
 
     public function testUpdateWillGenerateRows()
     {
-        $mockTables = $this->getMock('Tables', array('deleteRowsForResource','generateTableRowsForResource'), $this->tablesConstParams);
+        $mockTables = $this->getMock('\Tripod\Mongo\Tables', array('deleteRowsForResource','generateTableRowsForResource'), $this->tablesConstParams);
         $mockTables->expects($this->once())->method('generateTableRowsForResource')->with("http://foo","context");
         $mockTables->expects($this->never())->method('deleteTableRowsForResource');
 
-        $mockTables->update(new ImpactedSubject(array("r"=>"http://foo","c"=>"context"),OP_TABLES,"foo","bar",array("t_table"),false));
+        $mockTables->update(new \Tripod\Mongo\ImpactedSubject(array("r"=>"http://foo","c"=>"context"),OP_TABLES,"foo","bar",array("t_table"),false));
     }
 
     public function testGenerateTableRows()
@@ -346,7 +346,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
 
     public function testGenerateTableRowsForResourceUnnamespaced()
     {
-        $this->tripodTables->update(new ImpactedSubject(array("r"=>"http://basedata.com/b/2","c"=>"http://basedata.com/b/DefaultGraph"),OP_TABLES,$this->tripodTables->getStoreName(),$this->tripodTables->getPodName(),array("t_work2"),false));
+        $this->tripodTables->update(new \Tripod\Mongo\ImpactedSubject(array("r"=>"http://basedata.com/b/2","c"=>"http://basedata.com/b/DefaultGraph"),OP_TABLES,$this->tripodTables->getStoreName(),$this->tripodTables->getPodName(),array("t_work2"),false));
 
         $rows = $this->tripodTables->getTableRows("t_work2");
 
@@ -354,7 +354,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
     }
     public function testGenerateTableRowsForResourceNamespaced()
     {
-        $this->tripodTables->update(new ImpactedSubject(array("r"=>"baseData:2","c"=>"baseData:DefaultGraph"),OP_TABLES,$this->tripodTables->getStoreName(),$this->tripodTables->getPodName(),array("t_work2"),false));
+        $this->tripodTables->update(new \Tripod\Mongo\ImpactedSubject(array("r"=>"baseData:2","c"=>"baseData:DefaultGraph"),OP_TABLES,$this->tripodTables->getStoreName(),$this->tripodTables->getPodName(),array("t_work2"),false));
 
         $rows = $this->tripodTables->getTableRows("t_work2");
 
@@ -362,7 +362,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
     }
     public function testGenerateTableRowsForResourceContextNamespaced()
     {
-        $this->tripodTables->update(new ImpactedSubject(array("r"=>"http://basedata.com/b/2","c"=>"baseData:DefaultGraph"),OP_TABLES,$this->tripodTables->getStoreName(),$this->tripodTables->getPodName(),array("t_work2"),false));
+        $this->tripodTables->update(new \Tripod\Mongo\ImpactedSubject(array("r"=>"http://basedata.com/b/2","c"=>"baseData:DefaultGraph"),OP_TABLES,$this->tripodTables->getStoreName(),$this->tripodTables->getPodName(),array("t_work2"),false));
 
         $rows = $this->tripodTables->getTableRows("t_work2");
 
@@ -370,7 +370,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
     }
     public function testGenerateTableRowsForResourceResourceNamespaced()
     {
-        $this->tripodTables->update(new ImpactedSubject(array("r"=>"baseData:2","c"=>"http://basedata.com/b/DefaultGraph"),OP_TABLES,$this->tripodTables->getStoreName(),$this->tripodTables->getPodName(),array("t_work2"),false));
+        $this->tripodTables->update(new \Tripod\Mongo\ImpactedSubject(array("r"=>"baseData:2","c"=>"http://basedata.com/b/DefaultGraph"),OP_TABLES,$this->tripodTables->getStoreName(),$this->tripodTables->getPodName(),array("t_work2"),false));
 
         $rows = $this->tripodTables->getTableRows("t_work2");
 
@@ -379,9 +379,9 @@ class MongoTripodTablesTest extends MongoTripodTestBase
 
     public function testGenerateTableRowsForResourcesOfTypeWithNamespace()
     {
-        /* @var MongoTripodTables|PHPUnit_Framework_MockObject_MockObject $mockTripodTables  */
+        /* @var \Tripod\Mongo\Tables|PHPUnit_Framework_MockObject_MockObject $mockTripodTables  */
         $mockTripodTables = $this->getMock(
-            'Tables',
+            '\Tripod\Mongo\Tables',
             array('generateTableRows'),
             array($this->tripod->getStoreName(),$this->getTripodCollection($this->tripod),'http://talisaspire.com/')
         );
@@ -390,9 +390,9 @@ class MongoTripodTablesTest extends MongoTripodTestBase
         // check where referred to as acorn:Work2 in spec...
         $mockTripodTables->generateTableRowsForType("http://talisaspire.com/schema#Work2");
 
-        /* @var MongoTripodTables|PHPUnit_Framework_MockObject_MockObject $mockTripodTables */
+        /* @var \Tripod\Mongo\Tables|PHPUnit_Framework_MockObject_MockObject $mockTripodTables */
         $mockTripodTables = $this->getMock(
-            'Tables',
+            '\Tripod\Mongo\Tables',
             array('generateTableRows'),
             array($this->tripod->getStoreName(),$this->getTripodCollection($this->tripod),'http://talisaspire.com/')
         );
@@ -460,7 +460,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
         foreach($tableSpecifications['fields'] as $field)
         {
             // If there is invalid config, an exception will be thrown
-            $this->assertNull($tripodConfig->checkModifierFunctions($field['predicates'], MongoTripodTables::$predicateModifiers), 'Invalid tablespec config');
+            $tripodConfig->checkModifierFunctions($field['predicates'], \Tripod\Mongo\Tables::$predicateModifiers);
         }
 
     }
@@ -473,7 +473,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
     public function testGenerateTableRowsForUsersWithModifiersInvalidConfigBadGlue()
     {
         $this->setExpectedException(
-            'MongoTripodConfigException',
+            '\Tripod\Exceptions\ConfigException',
             "Invalid modifier: 'glue2' in key 'join'"
         );
 
@@ -494,7 +494,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
         \Tripod\Mongo\Config::setConfig($this->generateMongoTripodTestConfig());
         $tripodConfig = \Tripod\Mongo\Config::getInstance();
 
-        $tripodConfig->checkModifierFunctions($tableSpecifications['predicates'], MongoTripodTables::$predicateModifiers);
+        $tripodConfig->checkModifierFunctions($tableSpecifications['predicates'], \Tripod\Mongo\Tables::$predicateModifiers);
     }
 
     /**
@@ -685,10 +685,10 @@ class MongoTripodTablesTest extends MongoTripodTestBase
         // Confirm this user does not exist
         $this->assertFalse($this->tripod->describeResource($uri)->has_triples_about($uri));
 
-        $g = new MongoGraph();
+        $g = new \Tripod\Mongo\MongoGraph();
         $g->add_resource_triple($uri, $g->qname_to_uri("rdf:type"), $g->qname_to_uri("foaf:Person"));
         $g->add_literal_triple($uri, $g->qname_to_uri("foaf:name"), "A. Nonymous");
-        $this->tripod->saveChanges(new MongoGraph(), $g,"http://talisaspire.com/", "This resource didn't exist at join time");
+        $this->tripod->saveChanges(new \Tripod\Mongo\MongoGraph(), $g,"http://talisaspire.com/", "This resource didn't exist at join time");
 
         $userGraph = $this->tripod->describeResource($uri);
 
@@ -773,7 +773,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
     {
         $table = "t_nothing_to_see_here";
         $this->setExpectedException(
-            'MongoTripodConfigException',
+            '\Tripod\Exceptions\ConfigException',
             'Table id \'t_nothing_to_see_here\' not in configuration'
         );
         $results = $this->tripodTables->distinct($table, "value.foo");
@@ -821,9 +821,9 @@ class MongoTripodTablesTest extends MongoTripodTestBase
         
         $uri = "http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA-2";
 
-        /** @var PHPUnit_Framework_MockObject_MockObject|MongoTripod $tripod */
+        /** @var PHPUnit_Framework_MockObject_MockObject|\Tripod\Mongo\Tripod $tripod */
         $tripod = $this->getMock(
-            'Tripod',
+            '\Tripod\Mongo\Tripod',
             array('getComposite'),
             array(
                 $this->defaultPodName,
@@ -839,12 +839,12 @@ class MongoTripodTablesTest extends MongoTripodTestBase
             )
         );
 
-        $labeller = new MongoTripodLabeller();
+        $labeller = new \Tripod\Mongo\Labeller();
         $subjectsAndPredicatesOfChange = array(
             $labeller->uri_to_alias($uri)=>array("dct:title")
         );
 
-        $tables = $this->getMock('Tables',
+        $tables = $this->getMock('\Tripod\Mongo\Tables',
             array('generateTableRows'),
             array(
                 $tripod->getStoreName(),
@@ -876,11 +876,11 @@ class MongoTripodTablesTest extends MongoTripodTestBase
 
         // Walk through the processSyncOperations process manually for tables
 
-        /** @var MongoTripodTables $table */
+        /** @var \Tripod\Mongo\Tables $table */
         $table = $tripod->getComposite(OP_TABLES);
-        $this->assertInstanceOf('Tables', $table);
+        $this->assertInstanceOf('\Tripod\Mongo\Tables', $table);
 
-        $expectedImpactedSubject = new ImpactedSubject(
+        $expectedImpactedSubject = new \Tripod\Mongo\ImpactedSubject(
             array(
                 _ID_RESOURCE=>$labeller->uri_to_alias($uri),
                 _ID_CONTEXT=>$this->defaultContext
@@ -888,13 +888,26 @@ class MongoTripodTablesTest extends MongoTripodTestBase
             OP_TABLES,
             $this->defaultStoreName,
             $this->defaultPodName,
-            // Order of these doesn't matter - if the test fails, reverse the order and try again
             array("t_distinct","t_join_source_count_regex")
         );
 
         $impactedSubjects = $table->getImpactedSubjects($subjectsAndPredicatesOfChange, $this->defaultContext);
 
-        $this->assertEquals($expectedImpactedSubject, $impactedSubjects[0]);
+
+        $impactedSubject = $impactedSubjects[0];
+
+        $this->assertEquals($expectedImpactedSubject->getResourceId(), $impactedSubject->getResourceId());
+        $this->assertEquals($expectedImpactedSubject->getOperation(), $impactedSubject->getOperation());
+        $this->assertEquals($expectedImpactedSubject->getStoreName(), $impactedSubject->getStoreName());
+        $this->assertEquals($expectedImpactedSubject->getPodName(), $impactedSubject->getPodName());
+
+        // Order of these doesn't matter - so sort the spec types for matching
+        $expectedSpecTypes = $expectedImpactedSubject->getSpecTypes();
+        sort($expectedSpecTypes);
+        $specTypes = $impactedSubject->getSpecTypes();
+        sort($specTypes);
+
+        $this->assertEquals($expectedSpecTypes, $specTypes);
 
         foreach($impactedSubjects as $subject)
         {
@@ -924,14 +937,14 @@ class MongoTripodTablesTest extends MongoTripodTestBase
         
         $uri = "http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA-2";
 
-        $labeller = new MongoTripodLabeller();
+        $labeller = new \Tripod\Mongo\Labeller();
         $subjectsAndPredicatesOfChange = array(
             $labeller->uri_to_alias($uri)=>array("dct:description")
         );
 
         // Walk through the processSyncOperations process manually for tables
 
-        $table = new MongoTripodTables(
+        $table = new \Tripod\Mongo\Tables(
             $this->defaultStoreName,
             \Tripod\Mongo\Config::getInstance()->getCollectionForCBD($this->defaultStoreName, $this->defaultPodName),
             $this->defaultContext
@@ -946,9 +959,9 @@ class MongoTripodTablesTest extends MongoTripodTestBase
     public function testUpdateOfResourceInImpactIndexTriggersRegenerationTableRows()
     {
         
-        /** @var MongoTripodTables|PHPUnit_Framework_MockObject_MockObject $mockTables */
+        /** @var \Tripod\Mongo\Tables|PHPUnit_Framework_MockObject_MockObject $mockTables */
         $mockTables = $this->getMock(
-            'Tables',
+            '\Tripod\Mongo\Tables',
             array('generateTableRows'),
             $this->tablesConstParams
         );
@@ -969,7 +982,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
                 $this->defaultContext
             );
 
-        $labeller = new MongoTripodLabeller();
+        $labeller = new \Tripod\Mongo\Labeller();
         // generate table rows
         $this->tripodTables->generateTableRows("t_resource");
 
@@ -980,7 +993,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
         );
 
         $expectedImpactedSubjects = array(
-            new ImpactedSubject(
+            new \Tripod\Mongo\ImpactedSubject(
                 array(
                     _ID_RESOURCE=>"http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA",
                     _ID_CONTEXT=>$this->defaultContext
@@ -990,7 +1003,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
                 $this->defaultPodName,
                 array('t_resource')
             ),
-            new ImpactedSubject(
+            new \Tripod\Mongo\ImpactedSubject(
                 array(
                     _ID_RESOURCE=>"http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA-2",
                     _ID_CONTEXT=>$this->defaultContext
@@ -1018,7 +1031,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
         $uri = 'http://example.com/resources/' . uniqid();
         
 
-        $labeller = new MongoTripodLabeller();
+        $labeller = new \Tripod\Mongo\Labeller();
         $graph = new \Tripod\ExtendedGraph();
         // This should trigger a table row regeneration, even though issn isn't in the tablespec
         $graph->add_resource_triple($uri, RDF_TYPE, $labeller->qname_to_uri('acorn:Resource'));
@@ -1030,9 +1043,9 @@ class MongoTripodTablesTest extends MongoTripodTestBase
             )
         );
 
-        /** @var MongoTripod|PHPUnit_Framework_MockObject_MockObject $mockTripod */
+        /** @var \Tripod\Mongo\Tripod|PHPUnit_Framework_MockObject_MockObject $mockTripod */
         $mockTripod = $this->getMock(
-            'Tripod',
+            '\Tripod\Mongo\Tripod',
             array(
                 'getDataUpdater'
             ),
@@ -1050,9 +1063,9 @@ class MongoTripodTablesTest extends MongoTripodTestBase
             )
         );
 
-        /** @var TripodUpdates|PHPUnit_Framework_MockObject_MockObject $mockTripodUpdates */
+        /** @var \Tripod\Mongo\Updates|PHPUnit_Framework_MockObject_MockObject $mockTripodUpdates */
         $mockTripodUpdates = $this->getMock(
-            'Updates',
+            '\Tripod\Mongo\Updates',
             array(
                 'processSyncOperations',
                 'queueAsyncOperations'
@@ -1087,9 +1100,9 @@ class MongoTripodTablesTest extends MongoTripodTestBase
                 $this->defaultContext
             );
 
-        /** @var MongoTripodTables|PHPUnit_Framework_MockObject_MockObject $mockTables */
+        /** @var \Tripod\Mongo\Tables|PHPUnit_Framework_MockObject_MockObject $mockTables */
         $mockTables = $this->getMock(
-            'Tables',
+            '\Tripod\Mongo\Tables',
             array('generateTableRowsForType'),
             array(
                 $this->defaultStoreName,
@@ -1108,7 +1121,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
             );
 
         $expectedImpactedSubjects = array(
-            new ImpactedSubject(
+            new \Tripod\Mongo\ImpactedSubject(
                 array(
                     _ID_RESOURCE=>$labeller->uri_to_alias($uri),
                     _ID_CONTEXT=>$this->defaultContext
@@ -1134,10 +1147,10 @@ class MongoTripodTablesTest extends MongoTripodTestBase
     public function testUpdateToResourceWithMatchingRdfTypeShouldOnlyRegenerateIfRdfTypeIsPartOfUpdate()
     {
         $uri = "http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA";
-        $labeller = new MongoTripodLabeller();
+        $labeller = new \Tripod\Mongo\Labeller();
         $uriAlias = $labeller->uri_to_alias($uri);
 
-        $tables = new MongoTripodTables(
+        $tables = new \Tripod\Mongo\Tables(
             $this->defaultStoreName,
             \Tripod\Mongo\Config::getInstance()->getCollectionForCBD($this->defaultStoreName, $this->defaultPodName),
             $this->defaultContext
@@ -1150,7 +1163,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
         $subjectsAndPredicatesOfChange = array($uriAlias =>array('dct:subject', 'rdf:type'));
 
         $expectedImpactedSubjects = array(
-            new ImpactedSubject(
+            new \Tripod\Mongo\ImpactedSubject(
                 array(
                     _ID_RESOURCE=>$uriAlias,
                     _ID_CONTEXT=>$this->defaultContext
@@ -1169,7 +1182,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
     public function testNewResourceThatDoesNotMatchAnythingCreatesNoImpactedSubjects()
     {
         $uri = 'http://example.com/resources/' . uniqid();
-        $labeller = new MongoTripodLabeller();
+        $labeller = new \Tripod\Mongo\Labeller();
         $uriAlias = $labeller->uri_to_alias($uri);
 
         $graph = new \Tripod\ExtendedGraph();
@@ -1178,9 +1191,9 @@ class MongoTripodTablesTest extends MongoTripodTestBase
 
         $subjectsAndPredicatesOfChange = array($uriAlias=>array('rdf:type', 'dct:title'));
 
-        /** @var MongoTripod|PHPUnit_Framework_MockObject_MockObject $mockTripod */
+        /** @var \Tripod\Mongo\Tripod|PHPUnit_Framework_MockObject_MockObject $mockTripod */
         $mockTripod = $this->getMock(
-            'Tripod',
+            '\Tripod\Mongo\Tripod',
             array(
                 'getDataUpdater'
             ),
@@ -1198,9 +1211,9 @@ class MongoTripodTablesTest extends MongoTripodTestBase
             )
         );
 
-        /** @var TripodUpdates|PHPUnit_Framework_MockObject_MockObject $mockTripodUpdates */
+        /** @var \Tripod\Mongo\Updates|PHPUnit_Framework_MockObject_MockObject $mockTripodUpdates */
         $mockTripodUpdates = $this->getMock(
-            'Updates',
+            '\Tripod\Mongo\Updates',
             array(
                 'processSyncOperations',
                 'queueAsyncOperations'
@@ -1245,7 +1258,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
     public function testDeleteResourceCreatesImpactedSubjects()
     {
         $uri = 'http://example.com/users/' . uniqid();
-        $labeller = new MongoTripodLabeller();
+        $labeller = new \Tripod\Mongo\Labeller();
         $uriAlias = $labeller->uri_to_alias($uri);
 
         $graph = new \Tripod\ExtendedGraph();
@@ -1286,7 +1299,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
         );
 
         // Save the graphs and ensure that table rows are generated
-        $tripod = new MongoTripod(
+        $tripod = new \Tripod\Mongo\Tripod(
             $this->defaultPodName,
             $this->defaultStoreName,
             array(
@@ -1323,7 +1336,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
 
         $this->assertEquals(1, $tableRows['head']['count']);
 
-        $mockTripod = $this->getMockBuilder('Tripod')
+        $mockTripod = $this->getMockBuilder('\Tripod\Mongo\Tripod')
             ->setMethods(array('getDataUpdater'))
             ->setConstructorArgs(
                 array(
@@ -1340,7 +1353,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
                 )
             )->getMock();
 
-        $mockTripodUpdates = $this->getMockBuilder('Updates')
+        $mockTripodUpdates = $this->getMockBuilder('\Tripod\Mongo\Updates')
             ->setConstructorArgs(
                 array(
                     $mockTripod,
@@ -1382,11 +1395,11 @@ class MongoTripodTablesTest extends MongoTripodTestBase
         $this->assertTrue($deletedGraph->is_empty());
 
         // Manually walk through the tables operation
-        /** @var MongoTripodTables $tables */
+        /** @var \Tripod\Mongo\Tables $tables */
         $tables = $mockTripod->getComposite(OP_TABLES);
 
         $expectedImpactedSubjects = array(
-            new ImpactedSubject(
+            new \Tripod\Mongo\ImpactedSubject(
                 array(
                     _ID_RESOURCE=>$uriAlias,
                     _ID_CONTEXT=>$this->defaultContext
@@ -1396,7 +1409,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
                 $this->defaultPodName,
                 array('t_users')
             ),
-            new ImpactedSubject(
+            new \Tripod\Mongo\ImpactedSubject(
                 array(
                     _ID_RESOURCE=>$uriAlias2,
                     _ID_CONTEXT=>$this->defaultContext
@@ -1443,7 +1456,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
      */
     public function testSavingMultipleNewEntitiesResultsInOneImpactedSubject()
     {
-        $tripod = $this->getMockBuilder('Tripod')
+        $tripod = $this->getMockBuilder('\Tripod\Mongo\Tripod')
             ->setMethods(array('getDataUpdater'))
             ->setConstructorArgs(
                 array(
@@ -1460,7 +1473,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
                 )
             )->getMock();
 
-        $tripodUpdates = $this->getMockBuilder('Updates')
+        $tripodUpdates = $this->getMockBuilder('\Tripod\Mongo\Updates')
             ->setMethods(array('submitJob'))
             ->setConstructorArgs(
                 array(
@@ -1481,7 +1494,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
             ->will($this->returnValue($tripodUpdates));
 
         // first lets add a book, which should trigger a search doc, view and table gen for a single item
-        $g = new MongoGraph();
+        $g = new \Tripod\Mongo\MongoGraph();
         $newSubjectUri1 = "http://talisaspire.com/resources/newdoc1";
         $newSubjectUri2 = "http://talisaspire.com/resources/newdoc2";
         $newSubjectUri3 = "http://talisaspire.com/resources/newdoc3";
@@ -1509,13 +1522,13 @@ class MongoTripodTablesTest extends MongoTripodTestBase
             $newSubjectUri2=>array('rdf:type','dct:creator','dct:title','dct:subject'),
             $newSubjectUri3=>array('rdf:type','dct:creator','dct:title','dct:subject')
         );
-        $tripod->saveChanges(new MongoGraph(), $g);
+        $tripod->saveChanges(new \Tripod\Mongo\MongoGraph(), $g);
 
-        /** @var MongoTripodTables $tables */
+        /** @var \Tripod\Mongo\Tables $tables */
         $tables = $tripod->getComposite(OP_TABLES);
 
         $expectedImpactedSubjects = array(
-            new ImpactedSubject(
+            new \Tripod\Mongo\ImpactedSubject(
                 array(
                     _ID_RESOURCE=>$newSubjectUri2,
                     _ID_CONTEXT=>'http://talisaspire.com/'

--- a/test/unit/mongo/MongoTripodTablesTest.php
+++ b/test/unit/mongo/MongoTripodTablesTest.php
@@ -1,7 +1,7 @@
 <?php
 require_once 'MongoTripodTestBase.php';
-require_once 'src/mongo/delegates/MongoTripodTables.class.php';
-require_once 'src/mongo/MongoTripod.class.php';
+require_once 'src/mongo/delegates/Tables.class.php';
+require_once 'src/mongo/Tripod.class.php';
 require_once 'src/mongo/MongoGraph.class.php';
 
 
@@ -12,12 +12,12 @@ class MongoTripodTablesTest extends MongoTripodTestBase
      */
     protected $tripod = null;
     /**
-     * @var MongoTransactionLog
+     * @var TransactionLog
      */
     protected $tripodTransationLog = null;
 
     /**
-     * @var MongoTripodTables
+     * @var Tables
      */
     protected $tripodTables = null;
 
@@ -35,10 +35,10 @@ class MongoTripodTablesTest extends MongoTripodTestBase
         parent::setup();
         //Mongo::setPoolSize(200);
 
-        $this->tripodTransactionLog = new MongoTransactionLog();
+        $this->tripodTransactionLog = new \Tripod\Mongo\TransactionLog();
         $this->tripodTransactionLog->purgeAllTransactions();
 
-        $this->tripod = new MongoTripod($this->defaultPodName, $this->defaultStoreName, array("async"=>array(OP_VIEWS=>false, OP_TABLES=>false, OP_SEARCH=>false)));
+        $this->tripod = new \Tripod\Mongo\Tripod($this->defaultPodName, $this->defaultStoreName, array("async"=>array(OP_VIEWS=>false, OP_TABLES=>false, OP_SEARCH=>false)));
 
         $this->getTripodCollection($this->tripod)->drop();
         $this->tripod->setTransactionLog($this->tripodTransactionLog);
@@ -47,17 +47,17 @@ class MongoTripodTablesTest extends MongoTripodTestBase
 
         $this->tablesConstParams = array($this->tripod->getStoreName(),$this->getTripodCollection($this->tripod),'http://talisaspire.com/');
 
-        $this->tripodTables = new MongoTripodTables($this->tripod->getStoreName(),$this->getTripodCollection($this->tripod),null); // pass null context, should default to http://talisaspire.com
+        $this->tripodTables = new \Tripod\Mongo\Tables($this->tripod->getStoreName(),$this->getTripodCollection($this->tripod),null); // pass null context, should default to http://talisaspire.com
 
         // purge tables
-        foreach(MongoTripodConfig::getInstance()->getCollectionsForTables($this->tripod->getStoreName()) as $collection)
+        foreach(\Tripod\Mongo\Config::getInstance()->getCollectionsForTables($this->tripod->getStoreName()) as $collection)
         {
             $collection->drop();
         }
     }
 
     /**
-     * Generate dummy config that we can use for creating a MongoTripodConfig object
+     * Generate dummy config that we can use for creating a Config object
      * @access private
      * @return array
      */
@@ -164,7 +164,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
         $subject = $result['_id']['r'];
 
         $subjectGraph = $this->tripod->describeResource($subject);
-        $newGraph = new ExtendedGraph();
+        $newGraph = new \Tripod\ExtendedGraph();
         $newGraph->add_graph($subjectGraph);
         $newGraph->add_resource_triple($subject,'http://purl.org/dc/terms/isVersionOf','http://example.com');
 
@@ -209,7 +209,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
         $subject = $result['_id']['r'];
 
         $subjectGraph = $this->tripod->describeResource($subject);
-        $newGraph = new ExtendedGraph();
+        $newGraph = new \Tripod\ExtendedGraph();
         $newGraph->add_graph($subjectGraph);
         $newGraph->add_resource_triple($subject,'http://purl.org/dc/terms/isVersionOf','http://foobarbaz.com');
         $newGraph->add_resource_triple($subject,'http://purl.org/dc/terms/isVersionOf','http://example.com/foobarbaz');
@@ -252,7 +252,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
 
         // add a title to f340...
         $subjectGraph = $this->tripod->describeResource("http://jacs3.dataincubator.org/f340");
-        $newGraph = new ExtendedGraph();
+        $newGraph = new \Tripod\ExtendedGraph();
         $newGraph->add_graph($subjectGraph);
         $newGraph->add_resource_triple("http://jacs3.dataincubator.org/f340",'http://purl.org/dc/terms/title','Another title');
 
@@ -270,7 +270,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
 
     public function testUpdateWillDeleteItem()
     {
-        $mockTables = $this->getMock('MongoTripodTables', array('deleteTableRowsForResource','generateTableRowsForType'), $this->tablesConstParams);
+        $mockTables = $this->getMock('Tables', array('deleteTableRowsForResource','generateTableRowsForType'), $this->tablesConstParams);
         $mockTables->expects($this->once())->method('deleteTableRowsForResource')->with("http://foo","context");
         $mockTables->expects($this->never())->method('generateTableRowsForType');
 
@@ -279,7 +279,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
 
     public function testUpdateWillGenerateRows()
     {
-        $mockTables = $this->getMock('MongoTripodTables', array('deleteRowsForResource','generateTableRowsForResource'), $this->tablesConstParams);
+        $mockTables = $this->getMock('Tables', array('deleteRowsForResource','generateTableRowsForResource'), $this->tablesConstParams);
         $mockTables->expects($this->once())->method('generateTableRowsForResource')->with("http://foo","context");
         $mockTables->expects($this->never())->method('deleteTableRowsForResource');
 
@@ -381,7 +381,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
     {
         /* @var MongoTripodTables|PHPUnit_Framework_MockObject_MockObject $mockTripodTables  */
         $mockTripodTables = $this->getMock(
-            'MongoTripodTables',
+            'Tables',
             array('generateTableRows'),
             array($this->tripod->getStoreName(),$this->getTripodCollection($this->tripod),'http://talisaspire.com/')
         );
@@ -392,7 +392,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
 
         /* @var MongoTripodTables|PHPUnit_Framework_MockObject_MockObject $mockTripodTables */
         $mockTripodTables = $this->getMock(
-            'MongoTripodTables',
+            'Tables',
             array('generateTableRows'),
             array($this->tripod->getStoreName(),$this->getTripodCollection($this->tripod),'http://talisaspire.com/')
         );
@@ -452,10 +452,10 @@ class MongoTripodTablesTest extends MongoTripodTestBase
             )
         );
 
-        // Note that you need some config in order to create the MongoTripodConfig object successfully.
+        // Note that you need some config in order to create the Config object successfully.
         // Once that object has been created, we use our own table specifications to test against.
-        MongoTripodConfig::setConfig($this->generateMongoTripodTestConfig());
-        $tripodConfig = MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::setConfig($this->generateMongoTripodTestConfig());
+        $tripodConfig = \Tripod\Mongo\Config::getInstance();
 
         foreach($tableSpecifications['fields'] as $field)
         {
@@ -489,10 +489,10 @@ class MongoTripodTablesTest extends MongoTripodTestBase
             )
         );
 
-        // Note that you need some config in order to create the MongoTripodConfig object successfully.
+        // Note that you need some config in order to create the Config object successfully.
         // Once that object has been created, we use our own table specifications to test against.
-        MongoTripodConfig::setConfig($this->generateMongoTripodTestConfig());
-        $tripodConfig = MongoTripodConfig::getInstance();
+        \Tripod\Mongo\Config::setConfig($this->generateMongoTripodTestConfig());
+        $tripodConfig = \Tripod\Mongo\Config::getInstance();
 
         $tripodConfig->checkModifierFunctions($tableSpecifications['predicates'], MongoTripodTables::$predicateModifiers);
     }
@@ -813,7 +813,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
 
     public function testTableRowsGenerateWhenDefinedPredicateChanges()
     {
-        foreach(MongoTripodConfig::getInstance()->getTableSpecifications($this->tripod->getStoreName()) as $specId=>$spec)
+        foreach(\Tripod\Mongo\Config::getInstance()->getTableSpecifications($this->tripod->getStoreName()) as $specId=>$spec)
         {
             $this->generateTableRows($specId);
         }
@@ -823,7 +823,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
 
         /** @var PHPUnit_Framework_MockObject_MockObject|MongoTripod $tripod */
         $tripod = $this->getMock(
-            'MongoTripod',
+            'Tripod',
             array('getComposite'),
             array(
                 $this->defaultPodName,
@@ -844,7 +844,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
             $labeller->uri_to_alias($uri)=>array("dct:title")
         );
 
-        $tables = $this->getMock('MongoTripodTables',
+        $tables = $this->getMock('Tables',
             array('generateTableRows'),
             array(
                 $tripod->getStoreName(),
@@ -878,7 +878,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
 
         /** @var MongoTripodTables $table */
         $table = $tripod->getComposite(OP_TABLES);
-        $this->assertInstanceOf('MongoTripodTables', $table);
+        $this->assertInstanceOf('Tables', $table);
 
         $expectedImpactedSubject = new ImpactedSubject(
             array(
@@ -903,7 +903,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
 
         // This should be 0, because we mocked the actual adding of the regenerated table.  If it's zero, however,
         // it means we successfully deleted the views with $uri1 in the impactIndex
-        $collections = MongoTripodConfig::getInstance()->getCollectionsForTables($this->defaultStoreName);
+        $collections = \Tripod\Mongo\Config::getInstance()->getCollectionsForTables($this->defaultStoreName);
         foreach($collections as $collection)
         {
             $query = array(
@@ -916,7 +916,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
 
     public function testTableRowsNotGeneratedWhenUndefinedPredicateChanges()
     {
-        foreach(MongoTripodConfig::getInstance()->getTableSpecifications($this->tripod->getStoreName()) as $specId=>$spec)
+        foreach(\Tripod\Mongo\Config::getInstance()->getTableSpecifications($this->tripod->getStoreName()) as $specId=>$spec)
         {
             $this->generateTableRows($specId);
         }
@@ -933,7 +933,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
 
         $table = new MongoTripodTables(
             $this->defaultStoreName,
-            MongoTripodConfig::getInstance()->getCollectionForCBD($this->defaultStoreName, $this->defaultPodName),
+            \Tripod\Mongo\Config::getInstance()->getCollectionForCBD($this->defaultStoreName, $this->defaultPodName),
             $this->defaultContext
         );
 
@@ -948,7 +948,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
         
         /** @var MongoTripodTables|PHPUnit_Framework_MockObject_MockObject $mockTables */
         $mockTables = $this->getMock(
-            'MongoTripodTables',
+            'Tables',
             array('generateTableRows'),
             $this->tablesConstParams
         );
@@ -1019,7 +1019,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
         
 
         $labeller = new MongoTripodLabeller();
-        $graph = new ExtendedGraph();
+        $graph = new \Tripod\ExtendedGraph();
         // This should trigger a table row regeneration, even though issn isn't in the tablespec
         $graph->add_resource_triple($uri, RDF_TYPE, $labeller->qname_to_uri('acorn:Resource'));
         $graph->add_literal_triple($uri, $labeller->qname_to_uri('bibo:issn'), '1234-5678');
@@ -1032,7 +1032,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
 
         /** @var MongoTripod|PHPUnit_Framework_MockObject_MockObject $mockTripod */
         $mockTripod = $this->getMock(
-            'MongoTripod',
+            'Tripod',
             array(
                 'getDataUpdater'
             ),
@@ -1050,9 +1050,9 @@ class MongoTripodTablesTest extends MongoTripodTestBase
             )
         );
 
-        /** @var MongoTripodUpdates|PHPUnit_Framework_MockObject_MockObject $mockTripodUpdates */
+        /** @var TripodUpdates|PHPUnit_Framework_MockObject_MockObject $mockTripodUpdates */
         $mockTripodUpdates = $this->getMock(
-            'MongoTripodUpdates',
+            'Updates',
             array(
                 'processSyncOperations',
                 'queueAsyncOperations'
@@ -1089,11 +1089,11 @@ class MongoTripodTablesTest extends MongoTripodTestBase
 
         /** @var MongoTripodTables|PHPUnit_Framework_MockObject_MockObject $mockTables */
         $mockTables = $this->getMock(
-            'MongoTripodTables',
+            'Tables',
             array('generateTableRowsForType'),
             array(
                 $this->defaultStoreName,
-                MongoTripodConfig::getInstance()->getCollectionForCBD($this->defaultStoreName, $this->defaultPodName),
+                \Tripod\Mongo\Config::getInstance()->getCollectionForCBD($this->defaultStoreName, $this->defaultPodName),
                 $this->defaultContext
             )
         );
@@ -1120,7 +1120,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
             )
         );
 
-        $mockTripod->saveChanges(new ExtendedGraph(), $graph);
+        $mockTripod->saveChanges(new \Tripod\ExtendedGraph(), $graph);
 
         $impactedSubjects = $mockTables->getImpactedSubjects($subjectsAndPredicatesOfChange, $this->defaultContext);
 
@@ -1139,7 +1139,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
 
         $tables = new MongoTripodTables(
             $this->defaultStoreName,
-            MongoTripodConfig::getInstance()->getCollectionForCBD($this->defaultStoreName, $this->defaultPodName),
+            \Tripod\Mongo\Config::getInstance()->getCollectionForCBD($this->defaultStoreName, $this->defaultPodName),
             $this->defaultContext
         );
 
@@ -1172,7 +1172,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
         $labeller = new MongoTripodLabeller();
         $uriAlias = $labeller->uri_to_alias($uri);
 
-        $graph = new ExtendedGraph();
+        $graph = new \Tripod\ExtendedGraph();
         $graph->add_resource_triple($uri, RDF_TYPE, $labeller->qname_to_uri('bibo:Proceedings'));
         $graph->add_literal_triple($uri, $labeller->qname_to_uri('dct:title'), "A title");
 
@@ -1180,7 +1180,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
 
         /** @var MongoTripod|PHPUnit_Framework_MockObject_MockObject $mockTripod */
         $mockTripod = $this->getMock(
-            'MongoTripod',
+            'Tripod',
             array(
                 'getDataUpdater'
             ),
@@ -1198,9 +1198,9 @@ class MongoTripodTablesTest extends MongoTripodTestBase
             )
         );
 
-        /** @var MongoTripodUpdates|PHPUnit_Framework_MockObject_MockObject $mockTripodUpdates */
+        /** @var TripodUpdates|PHPUnit_Framework_MockObject_MockObject $mockTripodUpdates */
         $mockTripodUpdates = $this->getMock(
-            'MongoTripodUpdates',
+            'Updates',
             array(
                 'processSyncOperations',
                 'queueAsyncOperations'
@@ -1235,7 +1235,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
                 $this->defaultContext
             );
 
-        $mockTripod->saveChanges(new ExtendedGraph(), $graph);
+        $mockTripod->saveChanges(new \Tripod\ExtendedGraph(), $graph);
 
         $tables = $mockTripod->getComposite(OP_TABLES);
 
@@ -1248,7 +1248,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
         $labeller = new MongoTripodLabeller();
         $uriAlias = $labeller->uri_to_alias($uri);
 
-        $graph = new ExtendedGraph();
+        $graph = new \Tripod\ExtendedGraph();
         $graph->add_resource_triple(
             $uri,
             RDF_TYPE,
@@ -1268,7 +1268,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
         $uri2 = 'http://example.com/users/' . uniqid();
         $uriAlias2 = $labeller->uri_to_alias($uri2);
 
-        $graph2 = new ExtendedGraph();
+        $graph2 = new \Tripod\ExtendedGraph();
         $graph2->add_resource_triple(
             $uri2,
             RDF_TYPE,
@@ -1299,7 +1299,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
             )
         );
 
-        $tripod->saveChanges(new ExtendedGraph(), $graph);
+        $tripod->saveChanges(new \Tripod\ExtendedGraph(), $graph);
 
         $tableRows = $tripod->getTableRows(
             't_users',
@@ -1311,7 +1311,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
 
         $this->assertEquals(1, $tableRows['head']['count']);
 
-        $tripod->saveChanges(new ExtendedGraph(), $graph2);
+        $tripod->saveChanges(new \Tripod\ExtendedGraph(), $graph2);
 
         $tableRows = $tripod->getTableRows(
             't_users',
@@ -1323,7 +1323,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
 
         $this->assertEquals(1, $tableRows['head']['count']);
 
-        $mockTripod = $this->getMockBuilder('MongoTripod')
+        $mockTripod = $this->getMockBuilder('Tripod')
             ->setMethods(array('getDataUpdater'))
             ->setConstructorArgs(
                 array(
@@ -1340,7 +1340,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
                 )
             )->getMock();
 
-        $mockTripodUpdates = $this->getMockBuilder('MongoTripodUpdates')
+        $mockTripodUpdates = $this->getMockBuilder('Updates')
             ->setConstructorArgs(
                 array(
                     $mockTripod,
@@ -1375,7 +1375,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
         $graph->add_graph($graph2);
 
         // Delete both user resources
-        $mockTripod->saveChanges($graph, new ExtendedGraph());
+        $mockTripod->saveChanges($graph, new \Tripod\ExtendedGraph());
 
         $deletedGraph = $mockTripod->describeResources(array($uri, $uri2));
 
@@ -1443,7 +1443,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
      */
     public function testSavingMultipleNewEntitiesResultsInOneImpactedSubject()
     {
-        $tripod = $this->getMockBuilder('MongoTripod')
+        $tripod = $this->getMockBuilder('Tripod')
             ->setMethods(array('getDataUpdater'))
             ->setConstructorArgs(
                 array(
@@ -1460,7 +1460,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
                 )
             )->getMock();
 
-        $tripodUpdates = $this->getMockBuilder('MongoTripodUpdates')
+        $tripodUpdates = $this->getMockBuilder('Updates')
             ->setMethods(array('submitJob'))
             ->setConstructorArgs(
                 array(

--- a/test/unit/mongo/MongoTripodTest.php
+++ b/test/unit/mongo/MongoTripodTest.php
@@ -1,6 +1,10 @@
 <?php
 require_once 'MongoTripodTestBase.php';
 require_once 'src/mongo/Tripod.class.php';
+
+/**
+ * Class MongoTripodTest
+ */
 class MongoTripodTest extends MongoTripodTestBase
 {
     /**
@@ -20,7 +24,16 @@ class MongoTripodTest extends MongoTripodTestBase
         $this->tripodTransactionLog->purgeAllTransactions();
 
         // Stub ouf 'addToElastic' search to prevent writes into Elastic Search happening by default.
-        $this->tripod = $this->getMock('Tripod', array('addToSearchIndexQueue'), array('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/')));
+        $this->tripod = $this->getMock(
+            '\Tripod\Mongo\Tripod',
+            array('addToSearchIndexQueue'),
+            array(
+                'CBD_testing',
+                'tripod_php_testing',
+                array('defaultContext'=>'http://talisaspire.com/')
+            )
+        );
+
         $this->tripod->expects($this->any())->method('addToSearchIndexQueue');
 
         $this->getTripodCollection($this->tripod)->drop();
@@ -199,7 +212,7 @@ class MongoTripodTest extends MongoTripodTestBase
     public function testTripodSaveChangesRemovesLiteralTriple()
     {
         $oG = $this->tripod->describeResource('http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA');
-        $nG = new MongoGraph();
+        $nG = new \Tripod\Mongo\MongoGraph();
         $nG->add_graph($oG);
         $nG->remove_literal_triple('http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA', $nG->qname_to_uri('searchterms:title'), 'Physics 3rd Edition');
 
@@ -211,7 +224,7 @@ class MongoTripodTest extends MongoTripodTestBase
     public function testTripodSaveChangesAddsLiteralTriple()
     {
         $oG = $this->tripod->describeResource('http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA');
-        $nG = new MongoGraph();
+        $nG = new \Tripod\Mongo\MongoGraph();
         $nG->add_graph($oG);
         $nG->add_literal_triple('http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA', $nG->qname_to_uri('searchterms:title'), 'TEST TITLE');
 
@@ -227,9 +240,9 @@ class MongoTripodTest extends MongoTripodTestBase
      */
     public function testTripodSaveChangesRemovesLiteralTripleUsingEmptyNewGraphAndPartialOldGraph()
     {
-        $oG = new MongoGraph();
+        $oG = new \Tripod\Mongo\MongoGraph();
         $oG->add_literal_triple('http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA', $oG->qname_to_uri("bibo:isbn13"), "9780393929690");
-        $nG = new MongoGraph();
+        $nG = new \Tripod\Mongo\MongoGraph();
 
         $this->tripod->saveChanges($oG, $nG, "http://talisaspire.com/", 'my changes');
 
@@ -245,8 +258,8 @@ class MongoTripodTest extends MongoTripodTestBase
      */
     public function testTripodSaveChangesAddsLiteralTripleUsingEmptyOldGraph()
     {
-        $oG = new MongoGraph();
-        $nG = new MongoGraph();
+        $oG = new \Tripod\Mongo\MongoGraph();
+        $nG = new \Tripod\Mongo\MongoGraph();
         $nG->add_graph($oG);
         $nG->add_literal_triple('http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA', $nG->qname_to_uri('searchterms:title'), 'TEST TITLE');
 
@@ -258,7 +271,7 @@ class MongoTripodTest extends MongoTripodTestBase
     public function testTripodSaveChangesUpdatesLiteralTriple()
     {
         $oG = $this->tripod->describeResource('http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA');
-        $nG = new MongoGraph();
+        $nG = new \Tripod\Mongo\MongoGraph();
         $nG->add_graph($oG);
         $nG->remove_literal_triple('http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA', $nG->qname_to_uri('searchterms:title'), 'Physics 3rd Edition');
         $nG->add_literal_triple('http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA', $nG->qname_to_uri('searchterms:title'), 'TEST TITLE');
@@ -276,10 +289,10 @@ class MongoTripodTest extends MongoTripodTestBase
     {
         $uri = 'http://example.com/resources/1';
 
-        $g = new MongoGraph();
+        $g = new \Tripod\Mongo\MongoGraph();
         $g->add_resource_triple($uri, $g->qname_to_uri("rdf:type"), $g->qname_to_uri("acorn:Resource"));
         $g->add_literal_triple($uri, $g->qname_to_uri("dct:title"), "wibble");
-        $this->tripod->saveChanges(new MongoGraph(), $g,"http://talisaspire.com/", "something new");
+        $this->tripod->saveChanges(new \Tripod\Mongo\MongoGraph(), $g,"http://talisaspire.com/", "something new");
 
         $uG = $this->tripod->describeResource($uri);
 
@@ -293,10 +306,10 @@ class MongoTripodTest extends MongoTripodTestBase
         $uri = 'http://example.com/resources/1';
 
         // create a new entity and save it
-        $g = new MongoGraph();
+        $g = new \Tripod\Mongo\MongoGraph();
         $g->add_resource_triple($uri, $g->qname_to_uri("rdf:type"), $g->qname_to_uri("acorn:Resource"));
         $g->add_literal_triple($uri, $g->qname_to_uri("dct:title"), "wibble");
-        $this->tripod->saveChanges(new MongoGraph(), $g,"http://talisaspire.com/", "something new");
+        $this->tripod->saveChanges(new \Tripod\Mongo\MongoGraph(), $g,"http://talisaspire.com/", "something new");
 
         // retrieve it and make sure it was saved correctly
         $uG = $this->tripod->describeResource($uri);
@@ -305,7 +318,7 @@ class MongoTripodTest extends MongoTripodTestBase
         $this->assertTrue($uG->has_literal_triple( $uri, $g->qname_to_uri("dct:title"), "wibble"), "Graph should contain literal triple we added");
 
         // now remove all knowledge about it, then describe the resource again, should be an empty graph
-        $this->tripod->saveChanges($uG, new MongoGraph(),"http://talisaspire.com/", "murder death kill");
+        $this->tripod->saveChanges($uG, new \Tripod\Mongo\MongoGraph(),"http://talisaspire.com/", "murder death kill");
         $g = $this->tripod->describeResource($uri);
 
         $this->assertTrue($g->is_empty());
@@ -318,10 +331,10 @@ class MongoTripodTest extends MongoTripodTestBase
         $uri = 'http://example.com/resources/1';
 
         // create a new entity and save it
-        $oG = new MongoGraph();
+        $oG = new \Tripod\Mongo\MongoGraph();
         $oG->add_resource_triple($uri, $oG->qname_to_uri("rdf:type"), $oG->qname_to_uri("acorn:Resource"));
 
-        $nG = new MongoGraph();
+        $nG = new \Tripod\Mongo\MongoGraph();
         $nG->add_resource_triple($uri, $nG->qname_to_uri("rdf:type"), $nG->qname_to_uri("acorn:List"));
 
         $result = $this->tripod->saveChanges($oG, $nG,"http://talisaspire.com/");
@@ -333,22 +346,39 @@ class MongoTripodTest extends MongoTripodTestBase
 
         $uri = 'http://example.com/resources/1';
 
-        $g = new MongoGraph();
+        $g = new \Tripod\Mongo\MongoGraph();
         // canned response will simulate that the underlying data has changed
         $doc = array("_id"=>$uri, "rdf:type"=>array(array('value'=>$g->qname_to_uri("acorn:Resource"), 'type'=>'uri')));
 
-        $mockTripod = $this->getMock('Tripod', array('getDataUpdater'), array('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/')));
+        $mockTripod = $this->getMock(
+            '\Tripod\Mongo\Tripod',
+            array('getDataUpdater'),
+            array(
+                'CBD_testing',
+                'tripod_php_testing',
+                array('defaultContext'=>'http://talisaspire.com/')
+            )
+        );
 
-        $mockTripodUpdate = $this->getMock('Updates', array('getDocumentForUpdate'), array($mockTripod));
-        $mockTripodUpdate->expects($this->once())->method('getDocumentForUpdate')->with($uri)->will($this->returnValue($doc));
+        $mockTripodUpdate = $this->getMock(
+            '\Tripod\Mongo\Updates',
+            array('getDocumentForUpdate'),
+            array($mockTripod)
+        );
+
+        $mockTripodUpdate->expects($this->once())
+            ->method('getDocumentForUpdate')
+            ->with($uri)
+            ->will($this->returnValue($doc));
+
         $mockTripod->expects($this->atLeastOnce())
             ->method('getDataUpdater')
             ->will($this->returnValue($mockTripodUpdate));
         $mockTripod->setTransactionLog($this->tripodTransactionLog);
 
-        $oG = new MongoGraph();
+        $oG = new \Tripod\Mongo\MongoGraph();
         $oG->add_resource_triple($uri, $oG->qname_to_uri("rdf:type"), $oG->qname_to_uri("acorn:Book"));
-        $nG = new MongoGraph();
+        $nG = new \Tripod\Mongo\MongoGraph();
         $nG->add_resource_triple($uri, $nG->qname_to_uri("rdf:type"), $nG->qname_to_uri("acorn:Foo"));
 
         $result = $mockTripod->saveChanges($oG, $nG,"http://talisaspire.com/");
@@ -361,26 +391,44 @@ class MongoTripodTest extends MongoTripodTestBase
         // save some data in the store
         $uri = 'http://example.com/resources/1';
 
-        $g = new MongoGraph();
+        $g = new \Tripod\Mongo\MongoGraph();
         $g->add_resource_triple($uri, $g->qname_to_uri("rdf:type"), $g->qname_to_uri("acorn:Book"));
-        $this->tripod->saveChanges(new MongoGraph(), $g,"http://talisaspire.com/");
+        $this->tripod->saveChanges(new \Tripod\Mongo\MongoGraph(), $g,"http://talisaspire.com/");
 
         // canned response will simulate that the underlying data has changed
         $doc = array("_id"=>$uri, "_version"=>3,"rdf:type"=>array(array('value'=>$g->qname_to_uri("acorn:Resource"), 'type'=>'uri')));
 
-        $mockTripod = $this->getMock('Tripod', array('getDataUpdater'), array('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/')));
+        $mockTripod = $this->getMock(
+            '\Tripod\Mongo\Tripod',
+            array('getDataUpdater'),
+            array(
+                'CBD_testing',
+                'tripod_php_testing',
+                array('defaultContext'=>'http://talisaspire.com/')
+            )
+        );
 
-        $mockTripodUpdate = $this->getMock('Updates', array('getDocumentForUpdate'), array($mockTripod));
-        $mockTripodUpdate->expects($this->once())->method('getDocumentForUpdate')->with($uri)->will($this->returnValue($doc));
+        $mockTripodUpdate = $this->getMock(
+            '\Tripod\Mongo\Updates',
+            array('getDocumentForUpdate'),
+            array($mockTripod)
+        );
+
+        $mockTripodUpdate->expects($this->once())
+            ->method('getDocumentForUpdate')
+            ->with($uri)
+            ->will($this->returnValue($doc));
+
         $mockTripod->expects($this->atLeastOnce())
             ->method('getDataUpdater')
             ->will($this->returnValue($mockTripodUpdate));
+
         $mockTripod->setTransactionLog($this->tripodTransactionLog);
 
-        $oG = new MongoGraph();
+        $oG = new \Tripod\Mongo\MongoGraph();
         $oG->add_resource_triple($uri, $oG->qname_to_uri("rdf:type"), $oG->qname_to_uri("acorn:Resource"));
 
-        $nG = new MongoGraph();
+        $nG = new \Tripod\Mongo\MongoGraph();
         $nG->add_resource_triple($uri, $nG->qname_to_uri("rdf:type"), $nG->qname_to_uri("acorn:Foo"));
 
         $result = $mockTripod->saveChanges($oG, $nG,"http://talisaspire.com/");
@@ -391,12 +439,12 @@ class MongoTripodTest extends MongoTripodTestBase
         $uri = 'http://example.com/resources/1';
 
         // save a graph to the store
-        $oG = new MongoGraph();
+        $oG = new \Tripod\Mongo\MongoGraph();
         $oG->add_resource_triple($uri, $oG->qname_to_uri("rdf:type"), $oG->qname_to_uri("acorn:Resource"));
         $oG->add_literal_triple($uri, $oG->qname_to_uri("dct:title"), "Some title");
         $oG->add_literal_triple($uri, $oG->qname_to_uri("dct:title"), "Another title");
         $oG->add_literal_triple($uri, $oG->qname_to_uri("dct:title"), "Yet another title");
-        $this->tripod->saveChanges(new MongoGraph(), $oG,"http://talisaspire.com/");
+        $this->tripod->saveChanges(new \Tripod\Mongo\MongoGraph(), $oG,"http://talisaspire.com/");
 
         // retrieve it and make sure it was saved correctly
         $g = $this->tripod->describeResource($uri);
@@ -412,15 +460,15 @@ class MongoTripodTest extends MongoTripodTestBase
         $uri = 'http://example.com/resources/1';
 
         // save a graph to the store
-        $oG = new MongoGraph();
+        $oG = new \Tripod\Mongo\MongoGraph();
         $oG->add_resource_triple($uri, $oG->qname_to_uri("rdf:type"), $oG->qname_to_uri("acorn:Resource"));
         $oG->add_literal_triple($uri, $oG->qname_to_uri("dct:title"), "Some title");
         $oG->add_literal_triple($uri, $oG->qname_to_uri("dct:title"), "Another title");
         $oG->add_literal_triple($uri, $oG->qname_to_uri("dct:title"), "Yet another title");
-        $this->tripod->saveChanges(new MongoGraph(), $oG,"http://talisaspire.com/");
+        $this->tripod->saveChanges(new \Tripod\Mongo\MongoGraph(), $oG,"http://talisaspire.com/");
 
         // remove all three dct:title triples
-        $g2 = new MongoGraph();
+        $g2 = new \Tripod\Mongo\MongoGraph();
         $g2->add_resource_triple($uri, $oG->qname_to_uri("rdf:type"), $oG->qname_to_uri("acorn:Resource"));
         $this->tripod->saveChanges($oG, $g2,"http://talisaspire.com/");
 
@@ -437,14 +485,14 @@ class MongoTripodTest extends MongoTripodTestBase
         $uri = 'http://example.com/resources/1';
 
         // save a graph to the store
-        $oG = new MongoGraph();
+        $oG = new \Tripod\Mongo\MongoGraph();
         $oG->add_resource_triple($uri, $oG->qname_to_uri("rdf:type"), $oG->qname_to_uri("acorn:Resource"));
         $oG->add_literal_triple($uri, $oG->qname_to_uri("dct:title"), "Some title");
         $oG->add_literal_triple($uri, $oG->qname_to_uri("dct:title"), "Another title");
         $oG->add_literal_triple($uri, $oG->qname_to_uri("dct:title"), "Yet another title");
-        $this->tripod->saveChanges(new MongoGraph(), $oG,"http://talisaspire.com/");
+        $this->tripod->saveChanges(new \Tripod\Mongo\MongoGraph(), $oG,"http://talisaspire.com/");
 
-        $g2= new MongoGraph();
+        $g2= new \Tripod\Mongo\MongoGraph();
         $g2->add_resource_triple($uri, $g2->qname_to_uri("rdf:type"), $g2->qname_to_uri("acorn:Resource"));
         $g2->add_literal_triple($uri, $g2->qname_to_uri("dct:title"), "Updated Some title");
         $g2->add_literal_triple($uri, $g2->qname_to_uri("dct:title"), "Updated Another title");
@@ -471,17 +519,17 @@ class MongoTripodTest extends MongoTripodTestBase
         $uri = 'http://example.com/resources/1';
 
         // save a graph to the store
-        $oG = new MongoGraph();
+        $oG = new \Tripod\Mongo\MongoGraph();
         $oG->add_resource_triple($uri, $oG->qname_to_uri("rdf:type"), $oG->qname_to_uri("acorn:Resource"));
         $oG->add_literal_triple($uri, $oG->qname_to_uri("dct:title"), "Title one");
         $oG->add_literal_triple($uri, $oG->qname_to_uri("dct:title"), "Title two");
         $oG->add_literal_triple($uri, $oG->qname_to_uri("dct:title"), "Title three");
         $oG->add_literal_triple($uri, $oG->qname_to_uri("dct:title"), "Title four");
         $oG->add_literal_triple($uri, $oG->qname_to_uri("dct:title"), "Title five");
-        $this->tripod->saveChanges(new MongoGraph(), $oG,"http://talisaspire.com/");
+        $this->tripod->saveChanges(new \Tripod\Mongo\MongoGraph(), $oG,"http://talisaspire.com/");
 
         // new data
-        $g2= new MongoGraph();
+        $g2= new \Tripod\Mongo\MongoGraph();
         $g2->add_resource_triple($uri, $g2->qname_to_uri("rdf:type"), $g2->qname_to_uri("acorn:Resource"));
         $g2->add_literal_triple($uri, $g2->qname_to_uri("dct:title"), "New Title one");
         $g2->add_literal_triple($uri, $g2->qname_to_uri("dct:title"), "New Title two");
@@ -507,10 +555,23 @@ class MongoTripodTest extends MongoTripodTestBase
 
     public function testSetReadPreferenceWhenSavingChanges(){
         $subjectOne = "http://talisaspire.com/works/checkReadPreferencesWrite";
-        /** @var $tripodMock MongoTripod **/
-        $tripodMock = $this->getMock('Tripod', array('getDataUpdater'), array('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/')));
-        $tripodUpdate = $this->getMock('Updates',
-            array('addToSearchIndexQueue','setReadPreferenceToPrimary','resetOriginalReadPreference'), array($tripodMock));
+        /** @var $tripodMock \Tripod\Mongo\Tripod **/
+        $tripodMock = $this->getMock(
+            '\Tripod\Mongo\Tripod', 
+            array('getDataUpdater'), 
+            array(
+                'CBD_testing',
+                'tripod_php_testing',
+                array('defaultContext'=>'http://talisaspire.com/')
+            )
+        );
+        
+        $tripodUpdate = $this->getMock(
+            '\Tripod\Mongo\Updates',
+            array('addToSearchIndexQueue','setReadPreferenceToPrimary','resetOriginalReadPreference'), 
+            array($tripodMock)
+        );
+        
         $tripodUpdate
             ->expects($this->once(0))
             ->method('setReadPreferenceToPrimary');
@@ -518,14 +579,15 @@ class MongoTripodTest extends MongoTripodTestBase
         $tripodUpdate
             ->expects($this->once())
             ->method('resetOriginalReadPreference');
+        
         $tripodMock
             ->expects($this->once())
             ->method('getDataUpdater')
             ->will($this->returnValue($tripodUpdate));
 
-        $g = new MongoGraph();
+        $g = new \Tripod\Mongo\MongoGraph();
         $g->add_literal_triple($subjectOne, $g->qname_to_uri("dct:title"), "Title one");
-        $tripodMock->saveChanges(new MongoGraph(), $g,"http://talisaspire.com/");
+        $tripodMock->saveChanges(new \Tripod\Mongo\MongoGraph(), $g,"http://talisaspire.com/");
     }
 
     /**
@@ -533,10 +595,23 @@ class MongoTripodTest extends MongoTripodTestBase
      */
     public function testReadPreferencesAreRestoredWhenErrorSavingChanges(){
         $subjectOne = "http://talisaspire.com/works/checkReadPreferencesAreRestoredOnError";
-        /** @var $tripodMock MongoTripod **/
-        $tripodMock = $this->getMock('Tripod', array('getDataUpdater'), array('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/')));
-        $tripodUpdate = $this->getMock('Updates',
-            array('addToSearchIndexQueue','resetOriginalReadPreference','getContextAlias'), array($tripodMock));
+        /** @var $tripodMock \Tripod\Mongo\Tripod|PHPUnit_Framework_MockObject_MockObject **/
+        $tripodMock = $this->getMock(
+            '\Tripod\Mongo\Tripod', 
+            array('getDataUpdater'), 
+            array(
+                'CBD_testing',
+                'tripod_php_testing',
+                array('defaultContext'=>'http://talisaspire.com/')
+            )
+        );
+
+        /** @var $tripodUpdate \Tripod\Mongo\Updates|PHPUnit_Framework_MockObject_MockObject **/
+        $tripodUpdate = $this->getMock(
+            '\Tripod\Mongo\Updates',
+            array('addToSearchIndexQueue','resetOriginalReadPreference','getContextAlias'), 
+            array($tripodMock)
+        );
 
         $tripodUpdate
             ->expects($this->once())
@@ -552,9 +627,9 @@ class MongoTripodTest extends MongoTripodTestBase
             ->method('getDataUpdater')
             ->will($this->returnValue($tripodUpdate));
 
-        $g = new MongoGraph();
+        $g = new \Tripod\Mongo\MongoGraph();
         $g->add_literal_triple($subjectOne, $g->qname_to_uri("dct:title"), "Title one");
-        $tripodMock->saveChanges(new MongoGraph(), $g,"http://talisaspire.com/");
+        $tripodMock->saveChanges(new \Tripod\Mongo\MongoGraph(), $g,"http://talisaspire.com/");
     }
 
     public function testReadPreferencesOverMultipleSaves(){
@@ -567,7 +642,7 @@ class MongoTripodTest extends MongoTripodTestBase
                 array('defaultContext'=>'http://talisaspire.com/', 'readPreference'=>MongoClient::RP_SECONDARY_PREFERRED))
         );
 
-        $tripodUpdate = $this->getMock('Updates',
+        $tripodUpdate = $this->getMock('\Tripod\Mongo\Updates',
             array('addToSearchIndexQueue', 'validateGraphCardinality'), array($tripodMock));
         $tripodUpdate
             ->expects($this->any())
@@ -585,23 +660,20 @@ class MongoTripodTest extends MongoTripodTestBase
             ->will($this->returnValue($tripodUpdate));
 
         $expectedCollectionReadPreference = $tripodMock->getCollectionReadPreference();
-//        $expectedDbReadPreference = $tripodMock->db->getReadPreference();
         $this->assertEquals($expectedCollectionReadPreference['type'], MongoClient::RP_SECONDARY_PREFERRED);
-//        $this->assertEquals($expectedDbReadPreference['type'], MongoClient::RP_SECONDARY_PREFERRED);
 
         // Assert that a simple save results in read preferences being restored
-        $g = new MongoGraph();
+        $g = new \Tripod\Mongo\MongoGraph();
         $g->add_literal_triple($subjectOne, $g->qname_to_uri("dct:title"), "Title one");
-        $tripodMock->saveChanges(new MongoGraph(), $g,"http://talisaspire.com/");
+        $tripodMock->saveChanges(new \Tripod\Mongo\MongoGraph(), $g,"http://talisaspire.com/");
         $this->assertEquals($expectedCollectionReadPreference, $tripodMock->getCollectionReadPreference());
-//        $this->assertEquals($expectedDbReadPreference, $tripodMock->db->getReadPreference());
 
         // Assert a thrown exception still results in read preferences being restored
-        $g = new MongoGraph();
+        $g = new \Tripod\Mongo\MongoGraph();
         $g->add_literal_triple($subjectOne, $g->qname_to_uri("dct:title2"), "Title two");
         $exceptionThrown = false;
         try{
-            $tripodMock->saveChanges(new MongoGraph(), $g,"http://talisaspire.com/");
+            $tripodMock->saveChanges(new \Tripod\Mongo\MongoGraph(), $g,"http://talisaspire.com/");
         }
         catch(Exception $e){
             $exceptionThrown = true;
@@ -611,9 +683,9 @@ class MongoTripodTest extends MongoTripodTestBase
         $this->assertEquals($expectedCollectionReadPreference, $tripodMock->getCollectionReadPreference());
 
         // Assert that a new save after the exception still results in read preferences being restored
-        $g = new MongoGraph();
+        $g = new \Tripod\Mongo\MongoGraph();
         $g->add_literal_triple($subjectOne, $g->qname_to_uri("dct:title3"), "Title three");
-        $tripodMock->saveChanges(new MongoGraph(), $g,"http://talisaspire.com/");
+        $tripodMock->saveChanges(new \Tripod\Mongo\MongoGraph(), $g,"http://talisaspire.com/");
         $this->assertEquals($expectedCollectionReadPreference, $tripodMock->getCollectionReadPreference());
 
     }
@@ -624,12 +696,12 @@ class MongoTripodTest extends MongoTripodTestBase
 
         $this->lockDocument($subjectOne,"transaction_101");
 
-        $this->setExpectedException('Exception', "Error storing changes: Did not obtain locks on documents");
+        $this->setExpectedException('\Exception', "Error storing changes: Did not obtain locks on documents");
 
-        $g = new MongoGraph();
+        $g = new \Tripod\Mongo\MongoGraph();
         $g->add_literal_triple($subjectOne, $g->qname_to_uri("dct:title"), "Title one");
 
-        $this->tripod->saveChanges(new MongoGraph(), $g,"http://talisaspire.com/");
+        $this->tripod->saveChanges(new \Tripod\Mongo\MongoGraph(), $g,"http://talisaspire.com/");
 
     }
 
@@ -639,14 +711,14 @@ class MongoTripodTest extends MongoTripodTestBase
         $subjectTwo = 'http://example.com/resources/2';
 
         // save a graph to the store containng two completely new entities
-        $oG = new MongoGraph();
+        $oG = new \Tripod\Mongo\MongoGraph();
         $oG->add_resource_triple($subjectOne, $oG->qname_to_uri("rdf:type"), $oG->qname_to_uri("acorn:Resource"));
         $oG->add_literal_triple($subjectOne, $oG->qname_to_uri("dct:title"), "Title one");
         $oG->add_literal_triple($subjectOne, $oG->qname_to_uri("dct:title"), "Title two");
         $oG->add_resource_triple($subjectTwo, $oG->qname_to_uri("rdf:type"), $oG->qname_to_uri("acorn:Book"));
         $oG->add_literal_triple($subjectTwo, $oG->qname_to_uri("dct:title"), "Title three");
         $oG->add_literal_triple($subjectTwo, $oG->qname_to_uri("dct:title"), "Title four");
-        $this->tripod->saveChanges(new MongoGraph(), $oG,"http://talisaspire.com/");
+        $this->tripod->saveChanges(new \Tripod\Mongo\MongoGraph(), $oG,"http://talisaspire.com/");
 
         // retrieve them both, assert they are as we expect
         $g = $this->tripod->describeResources(array($subjectOne, $subjectTwo));
@@ -660,7 +732,7 @@ class MongoTripodTest extends MongoTripodTestBase
         $this->assertTrue($g->has_literal_triple($subjectTwo,  $g->qname_to_uri("dct:title"), 'Title four'));
 
         // now lets save some changes to both
-        $nG = new MongoGraph();
+        $nG = new \Tripod\Mongo\MongoGraph();
         $nG->add_graph($g);
         $nG->remove_literal_triple($subjectOne,  $g->qname_to_uri("dct:title"), 'Title one');
         $nG->add_literal_triple($subjectOne,  $g->qname_to_uri("dct:title"), 'Updated Title one');
@@ -693,17 +765,17 @@ class MongoTripodTest extends MongoTripodTestBase
         $uri = 'http://example.com/resources/1';
 
         // save a new entity, and retrieve it
-        $g = new MongoGraph();
+        $g = new \Tripod\Mongo\MongoGraph();
         $g->add_resource_triple($uri, $g->qname_to_uri("rdf:type"), $g->qname_to_uri("acorn:Resource"));
         $g->add_literal_triple($uri, $g->qname_to_uri("dct:title"), "wibble");
-        $this->tripod->saveChanges(new MongoGraph(), $g, "http://talisaspire.com/", "something new");
+        $this->tripod->saveChanges(new \Tripod\Mongo\MongoGraph(), $g, "http://talisaspire.com/", "something new");
         $uG = $this->tripod->describeResource($uri);
         $this->assertTrue($uG->has_triples_about($uri), "new entity we created was not saved");
         $this->assertTrue($uG->has_resource_triple( $uri, $g->qname_to_uri("rdf:type"), $g->qname_to_uri("acorn:Resource")), "Graph should contain resource triple we added");
         $this->assertTrue($uG->has_literal_triple( $uri, $g->qname_to_uri("dct:title"), "wibble"), "Graph should contain literal triple we added");
         $this->assertDocumentVersion(array("r"=>$uri,"c"=>"http://talisaspire.com/"), 0);
 
-        $nG = new MongoGraph();
+        $nG = new \Tripod\Mongo\MongoGraph();
         $nG->add_graph($g);
         $nG->add_literal_triple($uri, $g->qname_to_uri("dct:title"), "another title");
         $this->tripod->saveChanges($g, $nG,"http://talisaspire.com/");
@@ -713,7 +785,7 @@ class MongoTripodTest extends MongoTripodTestBase
         $this->assertTrue($uG->has_literal_triple( $uri, $g->qname_to_uri("dct:title"), "another title"), "Graph should contain literal triple we added");
         $this->assertDocumentVersion(array("r"=>$uri,"c"=>"http://talisaspire.com/"), 1);
 
-        $nG = new MongoGraph();
+        $nG = new \Tripod\Mongo\MongoGraph();
         //$nG->add_graph();
         $nG->add_literal_triple($uri, $g->qname_to_uri("dct:title"), "only a title");
         $this->tripod->saveChanges($uG, $nG,"http://talisaspire.com/");
@@ -726,13 +798,13 @@ class MongoTripodTest extends MongoTripodTestBase
         $this->assertDocumentVersion(array("r"=>$uri,"c"=>"http://talisaspire.com/"), 2);
 
         // remove it completely
-        $this->tripod->saveChanges($nG, new MongoGraph(),"http://talisaspire.com/");
+        $this->tripod->saveChanges($nG, new \Tripod\Mongo\MongoGraph(),"http://talisaspire.com/");
         $this->assertDocumentHasBeenDeleted(array("r"=>$uri,"c"=>"http://talisaspire.com/"));
     }
 
     public function testSaveChangesWithInvalidCardinality()
     {
-        $this->setExpectedException('CardinalityException', "Cardinality failed on http://foo/bar/1 for 'rdf:type' - should only have 1 value and has: http://foo/bar#Class1, http://foo/bar#Class2");
+        $this->setExpectedException('\Tripod\Exceptions\CardinalityException', "Cardinality failed on http://foo/bar/1 for 'rdf:type' - should only have 1 value and has: http://foo/bar#Class1, http://foo/bar#Class2");
 
         $config = array();
         $config['namespaces'] = array('rdf'=>'http://www.w3.org/1999/02/22-rdf-syntax-ns#');
@@ -765,10 +837,10 @@ class MongoTripodTest extends MongoTripodTestBase
         // Override the config defined in base test class as we need specific config here.
         \Tripod\Mongo\Config::setConfig($config);
 
-        $tripod = new MongoTripod('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/'));
+        $tripod = new \Tripod\Mongo\Tripod('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/'));
 
-        $oldGraph = new ExtendedGraph();
-        $newGraph = new ExtendedGraph();
+        $oldGraph = new \Tripod\ExtendedGraph();
+        $newGraph = new \Tripod\ExtendedGraph();
         $newGraph->add_resource_triple('http://foo/bar/1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://foo/bar#Class1');
         $newGraph->add_resource_triple('http://foo/bar/1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://foo/bar#Class2');
 
@@ -780,14 +852,14 @@ class MongoTripodTest extends MongoTripodTestBase
     {
         $uri_1 = "http://example.com/1";
         $uri_2 = "http://example.com/2";
-        $oG = new MongoGraph();
+        $oG = new \Tripod\Mongo\MongoGraph();
         $oG->add_resource_triple($uri_1, $oG->qname_to_uri("rdf:type"), $oG->qname_to_uri("acorn:Resource"));
         $oG->add_resource_triple($uri_2, $oG->qname_to_uri("rdf:type"), $oG->qname_to_uri("acorn:Resource"));
 
         // just updates, all three operations async
-        /** @var MongoTripod|PHPUnit_Framework_MockObject_MockObject $mockTripod */
+        /** @var \Tripod\Mongo\Tripod|PHPUnit_Framework_MockObject_MockObject $mockTripod */
         $mockTripod = $this->getMock(
-            'Tripod',
+            '\Tripod\Mongo\Tripod',
             array(
                 'getDataUpdater',
                 'getComposite'
@@ -807,7 +879,7 @@ class MongoTripodTest extends MongoTripodTestBase
         );
 
         $mockTripodUpdates = $this->getMock(
-            'Updates',
+            '\Tripod\Mongo\Updates',
             array(
                 'storeChanges',
                 'submitJob'
@@ -824,7 +896,7 @@ class MongoTripodTest extends MongoTripodTestBase
             )
         );
 
-        $labeller = new MongoTripodLabeller();
+        $labeller = new \Tripod\Mongo\Labeller();
 
         $subjectsAndPredicatesOfChange = array(
             $labeller->uri_to_alias('http://example.com/1')=>array('rdf:type'),
@@ -845,7 +917,7 @@ class MongoTripodTest extends MongoTripodTestBase
             ->method('getComposite');
         $mockTripodUpdates->expects($this->once())
             ->method('submitJob')
-            ->with(\Tripod\Mongo\Config::getDiscoverQueueName(),"DiscoverImpactedSubjects", $jobData);
+            ->with(\Tripod\Mongo\Config::getDiscoverQueueName(),"\Tripod\Mongo\DiscoverImpactedSubjects", $jobData);
 
         $mockTripodUpdates->expects($this->once())
             ->method('storeChanges')
@@ -855,19 +927,19 @@ class MongoTripodTest extends MongoTripodTestBase
             ->method('getDataUpdater')
             ->will($this->returnValue($mockTripodUpdates));
 
-        $mockTripod->saveChanges(new ExtendedGraph(), $oG,"http://talisaspire.com/");
+        $mockTripod->saveChanges(new \Tripod\ExtendedGraph(), $oG,"http://talisaspire.com/");
     }
 
     public function testDiscoverImpactedSubjectsForDeletionsSyncOpsAreDoneAsyncJobSubmitted()
     {
         $uri_1 = "http://example.com/1";
         $uri_2 = "http://example.com/2";
-        $oG = new MongoGraph();
+        $oG = new \Tripod\Mongo\MongoGraph();
         $oG->add_resource_triple($uri_1, $oG->qname_to_uri("rdf:type"), $oG->qname_to_uri("acorn:Resource"));
         $oG->add_resource_triple($uri_2, $oG->qname_to_uri("rdf:type"), $oG->qname_to_uri("acorn:Resource"));
 //        // just deletes, search only
         $mockTripod = $this->getMock(
-            'Tripod',
+            '\Tripod\Mongo\Tripod',
             array('getDataUpdater','getComposite'),
             array(
                 'CBD_testing',
@@ -880,7 +952,7 @@ class MongoTripodTest extends MongoTripodTestBase
         );
 
         $mockTripodUpdates = $this->getMock(
-            'Updates',
+            '\Tripod\Mongo\Updates',
             array(
                 'storeChanges',
                 'submitJob'
@@ -898,7 +970,7 @@ class MongoTripodTest extends MongoTripodTestBase
         );
 
         $mockViews = $this->getMock(
-            'Views',
+            '\Tripod\Mongo\Views',
             array('getImpactedSubjects', 'update'),
             array(
                 'tripod_php_testing',
@@ -908,7 +980,7 @@ class MongoTripodTest extends MongoTripodTestBase
         );
 
         $mockTables = $this->getMock(
-            'Tables',
+            '\Tripod\Mongo\Tables',
             array('getImpactedSubjects', 'update'),
             array(
                 'tripod_php_testing',
@@ -917,7 +989,7 @@ class MongoTripodTest extends MongoTripodTestBase
             )
         );
 
-        $labeller = new MongoTripodLabeller();
+        $labeller = new \Tripod\Mongo\Labeller();
 
         // The predicates should be empty arrays, since these were deletes
         $subjectsAndPredicatesOfChange = array(
@@ -935,7 +1007,7 @@ class MongoTripodTest extends MongoTripodTestBase
         );
 
         $impactedViewSubjects = array(
-            new ImpactedSubject(
+            new \Tripod\Mongo\ImpactedSubject(
                 array(
                     _ID_RESOURCE=>'http://example.com/1',
                     _ID_CONTEXT=>'http://talisaspire.com',
@@ -944,7 +1016,7 @@ class MongoTripodTest extends MongoTripodTestBase
                 'tripod_php_testing',
                 'CBD_testing'
             ),
-            new ImpactedSubject(
+            new \Tripod\Mongo\ImpactedSubject(
                 array(
                     _ID_RESOURCE=>'http://example.com/2',
                     _ID_CONTEXT=>'http://talisaspire.com',
@@ -954,7 +1026,7 @@ class MongoTripodTest extends MongoTripodTestBase
                 'CBD_testing'
             ),
             // Make up random affected subject
-            new ImpactedSubject(
+            new \Tripod\Mongo\ImpactedSubject(
                 array(
                     _ID_RESOURCE=>'http://example.com/9',
                     _ID_CONTEXT=>'http://talisaspire.com',
@@ -976,7 +1048,7 @@ class MongoTripodTest extends MongoTripodTestBase
             );
 
         $impactedTableSubjects = array(
-            new ImpactedSubject(
+            new \Tripod\Mongo\ImpactedSubject(
                 array(
                     _ID_RESOURCE=>'http://example.com/1',
                     _ID_CONTEXT=>'http://talisaspire.com',
@@ -985,7 +1057,7 @@ class MongoTripodTest extends MongoTripodTestBase
                 'tripod_php_testing',
                 'CBD_testing'
             ),
-            new ImpactedSubject(
+            new \Tripod\Mongo\ImpactedSubject(
                 array(
                     _ID_RESOURCE=>'http://example.com/2',
                     _ID_CONTEXT=>'http://talisaspire.com',
@@ -1008,7 +1080,7 @@ class MongoTripodTest extends MongoTripodTestBase
 
         $mockTripodUpdates->expects($this->once())
             ->method('submitJob')
-            ->with(\Tripod\Mongo\Config::getDiscoverQueueName(),"DiscoverImpactedSubjects", $jobData);
+            ->with(\Tripod\Mongo\Config::getDiscoverQueueName(),"\Tripod\Mongo\DiscoverImpactedSubjects", $jobData);
 
         $mockTripodUpdates->expects($this->once())
             ->method('storeChanges')
@@ -1027,27 +1099,27 @@ class MongoTripodTest extends MongoTripodTestBase
             ->method('getDataUpdater')
             ->will($this->returnValue($mockTripodUpdates));
 
-        $mockTripod->saveChanges($oG, new ExtendedGraph(),"http://talisaspire.com/");
+        $mockTripod->saveChanges($oG, new \Tripod\ExtendedGraph(),"http://talisaspire.com/");
     }
 
     public function testDiscoverImpactedSubjectsForDefaultOperationsSetting()
     {
         $uri_1 = "http://example.com/1";
         $uri_2 = "http://example.com/2";
-        $oG = new MongoGraph();
+        $oG = new \Tripod\Mongo\MongoGraph();
         $oG->add_resource_triple($uri_1, $oG->qname_to_uri("rdf:type"), $oG->qname_to_uri("acorn:Resource"));
         $oG->add_resource_triple($uri_2, $oG->qname_to_uri("rdf:type"), $oG->qname_to_uri("acorn:Resource"));
 
         // a delete and an update
-        $nG = new MongoGraph();
+        $nG = new \Tripod\Mongo\MongoGraph();
         $nG->add_graph($oG);
         // This should
         $nG->add_literal_triple($uri_1, $nG->qname_to_uri("searchterms:title"), "wibble");
         $nG->remove_resource_triple($uri_2, $oG->qname_to_uri("rdf:type"), "http://foo/bar#Class2");
 
-        /** @var MongoTripod|PHPUnit_Framework_MockObject_MockObject $mockTripod */
+        /** @var \Tripod\Mongo\Tripod|PHPUnit_Framework_MockObject_MockObject $mockTripod */
         $mockTripod = $this->getMock(
-            'Tripod',
+            '\Tripod\Mongo\Tripod',
             array(
                 'getComposite',
                 'getDataUpdater'
@@ -1060,7 +1132,7 @@ class MongoTripodTest extends MongoTripodTestBase
         );
 
         $mockTripodUpdates = $this->getMock(
-            'Updates',
+            '\Tripod\Mongo\Updates',
             array(
                 'storeChanges',
                 'submitJob'
@@ -1079,7 +1151,7 @@ class MongoTripodTest extends MongoTripodTestBase
         );
 
         $mockViews = $this->getMock(
-            'Views',
+            '\Tripod\Mongo\Views',
             array('getImpactedSubjects', 'update'),
             array(
                 'tripod_php_testing',
@@ -1089,7 +1161,7 @@ class MongoTripodTest extends MongoTripodTestBase
         );
 
         $impactedViewSubjects = array(
-            new ImpactedSubject(
+            new \Tripod\Mongo\ImpactedSubject(
                 array(
                     _ID_RESOURCE=>$uri_1,
                     _ID_CONTEXT=>'http://talisaspire.com',
@@ -1098,7 +1170,7 @@ class MongoTripodTest extends MongoTripodTestBase
                 'tripod_php_testing',
                 'CBD_testing'
             ),
-            new ImpactedSubject(
+            new \Tripod\Mongo\ImpactedSubject(
                 array(
                     _ID_RESOURCE=>$uri_2,
                     _ID_CONTEXT=>'http://talisaspire.com',
@@ -1109,7 +1181,7 @@ class MongoTripodTest extends MongoTripodTestBase
             ),
         );
 
-        $labeller = new MongoTripodLabeller();
+        $labeller = new \Tripod\Mongo\Labeller();
 
         $subjectsAndPredicatesOfChange = array(
             $labeller->uri_to_alias($uri_1)=>array('searchterms:title'),
@@ -1133,7 +1205,7 @@ class MongoTripodTest extends MongoTripodTestBase
 
         $mockTripodUpdates->expects($this->once())
             ->method('submitJob')
-            ->with(\Tripod\Mongo\Config::getDiscoverQueueName(),"DiscoverImpactedSubjects", $jobData);
+            ->with(\Tripod\Mongo\Config::getDiscoverQueueName(),"\Tripod\Mongo\DiscoverImpactedSubjects", $jobData);
 
         $mockTripodUpdates->expects($this->once())
             ->method('storeChanges')
@@ -1161,11 +1233,11 @@ class MongoTripodTest extends MongoTripodTestBase
     {
 //        Exception: testing:SOME_COLLECTION is not referenced within config, so cannot be written to
         $this->setExpectedException(
-            'MongoTripodConfigException',
+            '\Tripod\Exceptions\ConfigException',
             'Collection name \'SOME_COLLECTION\' not in configuration');
 
-        $tripod = new MongoTripod("SOME_COLLECTION","tripod_php_testing");
-        $tripod->saveChanges(new ExtendedGraph(), new ExtendedGraph(), 'http://talisaspire.com/');
+        $tripod = new \Tripod\Mongo\Tripod("SOME_COLLECTION","tripod_php_testing");
+        $tripod->saveChanges(new \Tripod\ExtendedGraph(), new \Tripod\ExtendedGraph(), 'http://talisaspire.com/');
     }
 
     // NAMESPACE TESTS
@@ -1177,8 +1249,8 @@ class MongoTripodTest extends MongoTripodTestBase
      */
     public function testTripodSaveChangesAddsLiteralTripleUsingEmptyOldGraphWithNamespacableIDAndContext()
     {
-        $oG = new MongoGraph();
-        $nG = new MongoGraph();
+        $oG = new \Tripod\Mongo\MongoGraph();
+        $nG = new \Tripod\Mongo\MongoGraph();
         $nG->add_graph($oG);
 
         // resource and context are namespaced in base data this time around...
@@ -1196,8 +1268,8 @@ class MongoTripodTest extends MongoTripodTestBase
      */
     public function testTripodSaveChangesAddsLiteralTripleUsingEmptyOldGraphWithNamespacedContext()
     {
-        $oG = new MongoGraph();
-        $nG = new MongoGraph();
+        $oG = new \Tripod\Mongo\MongoGraph();
+        $nG = new \Tripod\Mongo\MongoGraph();
         $nG->add_graph($oG);
 
         // resource and context are namespaced in base data this time around...
@@ -1231,26 +1303,6 @@ class MongoTripodTest extends MongoTripodTestBase
         $this->assertEquals($noNsG->to_rdfxml(),$nsContextG->to_rdfxml(),"Non ns and nsContext not equal");
         $this->assertEquals($noNsG->to_rdfxml(),$nsBothG->to_rdfxml(),"Non ns and nsBoth not equal");
     }
-
-// TODO: re-write this test now that operations are defined as part of the ModifiedSubjects that are passed to queueAsync
-//    public function testAsyncOperationsDoNotContainSearchIfNoESConfig()
-//    {
-//        $configFileName = dirname(__FILE__).'/data/config.json';
-//        $config = json_decode(file_get_contents($configFileName), true);
-//
-//        $config['search_config'] = array();
-//        Config::setConfig($config);
-//
-//        $uri_1 = "http://example.com/1";
-//        $oG = new MongoGraph();
-//        $oG->add_resource_triple($uri_1, $oG->qname_to_uri("rdf:type"), $oG->qname_to_uri("acorn:Resource"));
-//
-//        // just updates, all three operations async
-//        $mockTripod = $this->getMock('Tripod', array('queueASyncOperations','processOperations'), array('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/',"async"=>array(OP_TABLES=>true,OP_VIEWS=>true,OP_SEARCH=>true))));
-//        $mockTripod->expects($this->once())->method('queueASyncOperations')->with(array('http://example.com/1'), array(), 'http://talisaspire.com/', array(OP_VIEWS, OP_TABLES));
-//        $mockTripod->expects($this->never())->method('processOperations');
-//        $mockTripod->saveChanges(new ExtendedGraph(), $oG,"http://talisaspire.com/");
-//    }
 
     public function testSelectSingleValueWithNamespaceContextQueryDoesntContainID()
     {
@@ -1427,7 +1479,7 @@ class MongoTripodTest extends MongoTripodTestBase
         $table = "t_nothing_to_see_here";
 
         $this->setExpectedException(
-            'MongoTripodConfigException',
+            '\Tripod\Exceptions\ConfigException',
             'Table id \'t_nothing_to_see_here\' not in configuration'
         );
         $results = $this->tripod->getDistinctTableColumnValues($table, "value.foo");
@@ -1553,8 +1605,8 @@ class MongoTripodTest extends MongoTripodTestBase
             ->will($this->throwException(new Exception('Some unexpected error occurred.')));
 
         /* @var $tripod PHPUnit_Framework_MockObject_MockObject */
-        $tripod = $this->getMock('Tripod', array('getDataUpdater'), array('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/')));
-        $tripodUpdate = $this->getMock('Updates', array('getAuditManualRollbacksCollection'), array($tripod));
+        $tripod = $this->getMock('\Tripod\Mongo\Tripod', array('getDataUpdater'), array('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/')));
+        $tripodUpdate = $this->getMock('\Tripod\Mongo\Updates', array('getAuditManualRollbacksCollection'), array($tripod));
 
         $tripodUpdate
             ->expects($this->once())
@@ -1590,8 +1642,8 @@ class MongoTripodTest extends MongoTripodTestBase
             ->with(array("_id" => $mongoDocumentId), array('$set' => array("status" => AUDIT_STATUS_ERROR, _UPDATED_TS => $mongoDate, 'error' => 'Some unexpected error occurred.')));
 
         /* @var $tripod PHPUnit_Framework_MockObject_MockObject */
-        $tripod = $this->getMock('Tripod', array('getDataUpdater'), array('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/')));
-        $tripodUpdate = $this->getMock('Updates',
+        $tripod = $this->getMock('\Tripod\Mongo\Tripod', array('getDataUpdater'), array('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/')));
+        $tripodUpdate = $this->getMock('\Tripod\Mongo\Updates',
             array('unlockAllDocuments', 'generateIdForNewMongoDocument', 'getMongoDate', 'getAuditManualRollbacksCollection'),
             array($tripod));
         
@@ -1648,9 +1700,9 @@ class MongoTripodTest extends MongoTripodTestBase
             ->method('update')
             ->with(array("_id" => $mongoDocumentId), array('$set' => array("status" => AUDIT_STATUS_COMPLETED, _UPDATED_TS => $mongoDate)));
 
-        /* @var MongoTripod PHPUnit_Framework_MockObject_MockObject */
-        $tripod = $this->getMock('Tripod', array('getDataUpdater'), array('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/')));
-        $tripodUpdate = $this->getMock('Updates',
+        /* @var \Tripod\Mongo\Tripod PHPUnit_Framework_MockObject_MockObject */
+        $tripod = $this->getMock('\Tripod\Mongo\Tripod', array('getDataUpdater'), array('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/')));
+        $tripodUpdate = $this->getMock('\Tripod\Mongo\Updates',
             array('unlockAllDocuments', 'generateIdForNewMongoDocument', 'getMongoDate', 'getAuditManualRollbacksCollection'),
             array($tripod));
         
@@ -1689,29 +1741,4 @@ class MongoTripodTest extends MongoTripodTestBase
 
 
     /** END: removeInertLocks tests */
-
-//TODO Need to discuss the switch from a db->find() to get types to looking in ExtendedGraph a bit more
-//     before enabling this test otherwise we'll have a create another resource that gets loaded into
-//     mongo to query or change the code to make the db->find() mockable.
-//    public function testSaveChangesCallsGenerateIndexWhenOneType()
-//    {
-//        $oldGraph = new ExtendedGraph();
-//        $newGraph = new ExtendedGraph();
-//
-//        $oldGraph->add_literal_triple('http://talisaspire.com/foo/1', 'http://talisaspire.com/schema#foo1', 'foo1');
-//        $oldGraph->add_resource_triple('http://talisaspire.com/foo/1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://purl.org/ontology/bibo/Book');
-//
-//        $newGraph->add_literal_triple('http://talisaspire.com/foo/1', 'http://talisaspire.com/schema#foo1', 'foo1');
-//        $newGraph->add_resource_triple('http://talisaspire.com/foo/1', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://purl.org/ontology/bibo/Book');
-//        $newGraph->add_literal_triple('http://talisaspire.com/foo/1', 'http://talisaspire.com/schema#foo1', 'foo2');
-//
-//        // Prevent writes to Mongo but check what should be send to Elastic Search
-//        $mockTripod = $this->getMock('Tripod', array('generateSearchDocument', 'storeChanges'), array('CBD_testing','tripod_php_testing'));
-//        $mockTripod->expects($this->any())->method('storeChanges')->will($this->returnValue(true));
-//        $mockTripod->expects($this->any())->method('generateSearchDocument');
-//        //$mockTripod->expects($this->once())->method('generateSearchDocument')->with('http://purl.org/ontology/bibo/Book', 'http://talisaspire.com/foo/1');
-//
-//        $mockTripod->saveChanges($oldGraph, $newGraph);
-//    }
-
 }

--- a/test/unit/mongo/MongoTripodTestBase.php
+++ b/test/unit/mongo/MongoTripodTestBase.php
@@ -17,6 +17,9 @@ define('MONGO_MAIN_DB', 'acorn');
 define('MONGO_MAIN_COLLECTION', 'CBD_harvest');
 define('MONGO_USER_COLLECTION', 'CBD_user');
 
+/**
+ * Class MongoTripodTestBase
+ */
 class MongoTripodTestBase extends PHPUnit_Framework_TestCase
 {
 
@@ -55,6 +58,9 @@ class MongoTripodTestBase extends PHPUnit_Framework_TestCase
         $this->loadDataViaTripod('/data/searchData.json');
     }
 
+    /**
+     * @param string $filename
+     */
     private function loadDataViaTripod($filename){
         $docs = json_decode(file_get_contents(dirname(__FILE__).$filename), true);
         foreach ($docs as $d)
@@ -108,6 +114,9 @@ class MongoTripodTestBase extends PHPUnit_Framework_TestCase
         }
     }
 
+    /**
+     * @return MongoCollection
+     */
     protected function getTlogCollection()
     {
         $config = \Tripod\Mongo\Config::getInstance();
@@ -115,6 +124,10 @@ class MongoTripodTestBase extends PHPUnit_Framework_TestCase
         return $config->getTransactionLogDatabase()->selectCollection($tLogConfig['collection']);
     }
 
+    /**
+     * @param \Tripod\Mongo\Tripod $tripod
+     * @return MongoCollection
+     */
     protected function getTripodCollection(\Tripod\Mongo\Tripod $tripod)
     {
         $config = \Tripod\Mongo\Config::getInstance();
@@ -127,6 +140,12 @@ class MongoTripodTestBase extends PHPUnit_Framework_TestCase
         )->selectCollection($tripod->getPodName());
     }
 
+    /**
+     * @param mixed $_id
+     * @param \MongoCollection|null $collection
+     * @param bool $fromTransactionLog
+     * @return array|null
+     */
     protected function getDocument($_id, $collection=null, $fromTransactionLog=false)
     {
         if($fromTransactionLog==true)
@@ -148,7 +167,13 @@ class MongoTripodTestBase extends PHPUnit_Framework_TestCase
         }
     }
 
-    protected function assertChangesForGivenSubject($changes, $subjectOfChange, $expectedNumberOfAdditions, $expectedNumberOfRemovals)
+    /**
+     * @param array $changes
+     * @param string $subjectOfChange
+     * @param int $expectedNumberOfAdditions
+     * @param int $expectedNumberOfRemovals
+     */
+    protected function assertChangesForGivenSubject(Array $changes, $subjectOfChange, $expectedNumberOfAdditions, $expectedNumberOfRemovals)
     {
         $changeSet = null;
 
@@ -195,13 +220,24 @@ class MongoTripodTestBase extends PHPUnit_Framework_TestCase
         $this->assertEquals($expectedNumberOfRemovals, $actualRemovals, "Number of removals did not match expectd value");
     }
 
-    protected function assertTransactionDate($doc, $key)
+    /**
+     * @param array $doc
+     * @param string $key
+     */
+    protected function assertTransactionDate(Array $doc, $key)
     {
         $this->assertTrue(isset($doc[$key]), 'the date property: {$key} was not present in document');
         $this->assertTrue(!empty($doc[$key]->sec),'the date property: {$key} does not have a "sec" property');
         $this->assertTrue(!empty($doc[$key]->usec), 'the date property: {$key} does not have a "usec" property');
     }
 
+    /**
+     * @param mixed $_id
+     * @param int|null $expectedValue
+     * @param bool $hasVersion
+     * @param \Tripod\Mongo\Tripod|null $tripod
+     * @param bool $fromTransactionLog
+     */
     protected function assertDocumentVersion($_id, $expectedValue=null, $hasVersion=true, $tripod=null, $fromTransactionLog=false)
     {
         // just make sure $_id is aliased
@@ -273,6 +309,11 @@ class MongoTripodTestBase extends PHPUnit_Framework_TestCase
     }
 
 
+    /**
+     * @param mixed $_id
+     * @param \Tripod\Mongo\Tripod|null $tripod
+     * @param bool $fromTransactionLog
+     */
     protected function assertDocumentExists($_id, $tripod=null, $fromTransactionLog=false)
     {
         $doc = $this->getDocument($_id, $tripod, $fromTransactionLog);
@@ -280,9 +321,13 @@ class MongoTripodTestBase extends PHPUnit_Framework_TestCase
         $this->assertEquals($_id, $doc["_id"], "Actual Document _id :[" . print_r($doc['_id'], true) . "] did not match expected value of " . print_r($_id, true));
     }
 
+    /**
+     * @param mixed $_id
+     * @param \Tripod\Mongo\Tripod|null $tripod
+     * @param bool $useTransactionTripod
+     */
     protected function assertDocumentHasBeenDeleted($_id, $tripod=null, $useTransactionTripod=false)
     {
-        //$this->assertNull($this->getDocument($_id, $useTransactionTripod), "Document with _id:[{$_id}] exists, but it should not");
         $doc = $this->getDocument($_id, $tripod, $useTransactionTripod);
         if($useTransactionTripod)
         {
@@ -300,26 +345,54 @@ class MongoTripodTestBase extends PHPUnit_Framework_TestCase
         }
     }
 
+    /**
+     * @param \Tripod\ExtendedGraph $graph
+     * @param string $s
+     * @param string $p
+     * @param string $o
+     */
     protected function assertHasLiteralTriple(\Tripod\ExtendedGraph $graph, $s, $p, $o)
     {
         $this->assertTrue($graph->has_literal_triple($s, $p, $o), "Graph did not contain the literal triple: <{$s}> <{$p}> \"{$o}\"");
     }
 
+    /**
+     * @param \Tripod\ExtendedGraph $graph
+     * @param string $s
+     * @param string $p
+     * @param string $o
+     */
     protected function assertHasResourceTriple(\Tripod\ExtendedGraph $graph, $s, $p, $o)
     {
         $this->assertTrue($graph->has_resource_triple($s, $p, $o), "Graph did not contain the resource triple: <{$s}> <{$p}> <{$o}>");
     }
 
+    /**
+     * @param \Tripod\ExtendedGraph $graph
+     * @param string $s
+     * @param string $p
+     * @param string $o
+     */
     protected function assertDoesNotHaveLiteralTriple(\Tripod\ExtendedGraph $graph, $s, $p, $o)
     {
         $this->assertFalse($graph->has_literal_triple($s, $p, $o), "Graph should not contain the literal triple: <{$s}> <{$p}> \"{$o}\"");
     }
 
+    /**
+     * @param \Tripod\ExtendedGraph $graph
+     * @param string $s
+     * @param string $p
+     * @param string $o
+     */
     protected function assertDoesNotHaveResourceTriple(\Tripod\ExtendedGraph $graph, $s, $p, $o)
     {
         $this->assertFalse($graph->has_resource_triple($s, $p, $o), "Graph should not contain the resource triple: <{$s}> <{$p}> <{$o}>");
     }
 
+    /**
+     * @param string $subject
+     * @param string $transaction_id
+     */
     protected function lockDocument($subject, $transaction_id)
     {
         $collection = \Tripod\Mongo\Config::getInstance()->getCollectionForLocks('tripod_php_testing');
@@ -333,17 +406,33 @@ class MongoTripodTestBase extends PHPUnit_Framework_TestCase
     }
 }
 
+/**
+ * Class TestTripod
+ */
 class TestTripod extends \Tripod\Mongo\Tripod
 {
+    /**
+     * @return array
+     */
     public function getCollectionReadPreference()
     {
         return $this->collection->getReadPreference();
     }
 }
 
+/**
+ * Class TripodTestConfig
+ */
 class TripodTestConfig extends \Tripod\Mongo\Config
 {
+    /**
+     * Constructor
+     */
     public function __construct() {}
+
+    /**
+     * @param array $config
+     */
     public function loadConfig(array $config)
     {
         parent::loadConfig($config);

--- a/test/unit/mongo/MongoTripodTestBase.php
+++ b/test/unit/mongo/MongoTripodTestBase.php
@@ -8,7 +8,7 @@ set_include_path(
 
 require_once('tripod.inc.php');
 require_once TRIPOD_DIR . 'mongo/Config.class.php';
-require_once TRIPOD_DIR . 'mongo/base/TripodBase.class.php';
+require_once TRIPOD_DIR . 'mongo/base/DriverBase.class.php';
 
 /**
  * Mongo Config For Main DB
@@ -24,7 +24,7 @@ class MongoTripodTestBase extends PHPUnit_Framework_TestCase
 {
 
     /**
-     * @var \Tripod\Mongo\Tripod
+     * @var \Tripod\Mongo\Driver
      */
     protected $tripod = null;
     /**
@@ -94,7 +94,7 @@ class MongoTripodTestBase extends PHPUnit_Framework_TestCase
         // make sure log statements don't go to stdout during tests...
         $log = new \Monolog\Logger("unittest");
         $log->pushHandler(new \Monolog\Handler\NullHandler());
-        \Tripod\Mongo\TripodBase::$logger = $log;
+        \Tripod\Mongo\DriverBase::$logger = $log;
     }
 
 
@@ -125,10 +125,10 @@ class MongoTripodTestBase extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @param \Tripod\Mongo\Tripod $tripod
+     * @param \Tripod\Mongo\Driver $tripod
      * @return MongoCollection
      */
-    protected function getTripodCollection(\Tripod\Mongo\Tripod $tripod)
+    protected function getTripodCollection(\Tripod\Mongo\Driver $tripod)
     {
         $config = \Tripod\Mongo\Config::getInstance();
         $pods = $config->getPods($tripod->getStoreName());
@@ -157,7 +157,7 @@ class MongoTripodTestBase extends PHPUnit_Framework_TestCase
         {
             return $this->getTripodCollection($this->tripod)->findOne(array("_id"=>$_id));
         }
-        elseif($collection instanceof \Tripod\Mongo\Tripod)
+        elseif($collection instanceof \Tripod\Mongo\Driver)
         {
             return $this->getTripodCollection($collection)->findOne(array("_id"=>$_id));
         }
@@ -235,7 +235,7 @@ class MongoTripodTestBase extends PHPUnit_Framework_TestCase
      * @param mixed $_id
      * @param int|null $expectedValue
      * @param bool $hasVersion
-     * @param \Tripod\Mongo\Tripod|null $tripod
+     * @param \Tripod\Mongo\Driver|null $tripod
      * @param bool $fromTransactionLog
      */
     protected function assertDocumentVersion($_id, $expectedValue=null, $hasVersion=true, $tripod=null, $fromTransactionLog=false)
@@ -311,7 +311,7 @@ class MongoTripodTestBase extends PHPUnit_Framework_TestCase
 
     /**
      * @param mixed $_id
-     * @param \Tripod\Mongo\Tripod|null $tripod
+     * @param \Tripod\Mongo\Driver|null $tripod
      * @param bool $fromTransactionLog
      */
     protected function assertDocumentExists($_id, $tripod=null, $fromTransactionLog=false)
@@ -323,7 +323,7 @@ class MongoTripodTestBase extends PHPUnit_Framework_TestCase
 
     /**
      * @param mixed $_id
-     * @param \Tripod\Mongo\Tripod|null $tripod
+     * @param \Tripod\Mongo\Driver|null $tripod
      * @param bool $useTransactionTripod
      */
     protected function assertDocumentHasBeenDeleted($_id, $tripod=null, $useTransactionTripod=false)
@@ -409,7 +409,7 @@ class MongoTripodTestBase extends PHPUnit_Framework_TestCase
 /**
  * Class TestTripod
  */
-class TestTripod extends \Tripod\Mongo\Tripod
+class TestTripod extends \Tripod\Mongo\Driver
 {
     /**
      * @return array

--- a/test/unit/mongo/MongoTripodTransactionRollbackTest.php
+++ b/test/unit/mongo/MongoTripodTransactionRollbackTest.php
@@ -1,10 +1,10 @@
 <?php
 require_once 'MongoTripodTestBase.php';
 /** @noinspection PhpIncludeInspection */
-require_once 'src/mongo/Tripod.class.php';
+require_once 'src/mongo/Driver.class.php';
 /**
  * This test suite was added to specifically verify behaviour of code
- * during Tripod->storeChanges.
+ * during Driver->storeChanges.
  * namely that documents are locked, transactions created, documents unlocked etc.
  *
  * Class MongoTripodTransactionRollbackTest
@@ -12,7 +12,7 @@ require_once 'src/mongo/Tripod.class.php';
 class MongoTripodTransactionRollbackTest extends MongoTripodTestBase
 {
     /**
-     * @var \Tripod\Mongo\Tripod
+     * @var \Tripod\Mongo\Driver
      */
     protected $tripod = null;
     /**
@@ -35,13 +35,13 @@ class MongoTripodTransactionRollbackTest extends MongoTripodTestBase
         $this->labeller = new \Tripod\Mongo\Labeller();
 
         // Stub out 'addToElastic' search to prevent writes into Elastic Search happening by default.
-        $tripod = $this->getMock('\Tripod\Mongo\Tripod', array('addToSearchIndexQueue'), array('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/')));
+        $tripod = $this->getMock('\Tripod\Mongo\Driver', array('addToSearchIndexQueue'), array('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/')));
         $tripod->expects($this->any())->method('addToSearchIndexQueue');
 
-        /** @var $tripod \Tripod\Mongo\Tripod */
+        /** @var $tripod \Tripod\Mongo\Driver */
         \Tripod\Mongo\Config::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing')->drop();
 
-        // Lock collection no longer available from Tripod, so drop it manually
+        // Lock collection no longer available from Driver, so drop it manually
         \Tripod\Mongo\Config::getInstance()->getCollectionForLocks('tripod_php_testing')->drop();
 
         $tripod->setTransactionLog($this->tripodTransactionLog);
@@ -91,7 +91,7 @@ class MongoTripodTransactionRollbackTest extends MongoTripodTestBase
         $nG->add_literal_triple($subjectTwo, $nG->qname_to_uri("dct:title"), "Updated Title three");
 
         $mockTransactionId = 'transaction_1';
-        $mockTripod = $this->getMock('\Tripod\Mongo\Tripod', array('getDataUpdater'), array('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/')));
+        $mockTripod = $this->getMock('\Tripod\Mongo\Driver', array('getDataUpdater'), array('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/')));
         $mockTripodUpdate = $this->getMock('\Tripod\Mongo\Updates', array('generateTransactionId','lockSingleDocument'), array($mockTripod));
 
         $mockTripodUpdate->expects($this->exactly(1))
@@ -105,7 +105,7 @@ class MongoTripodTransactionRollbackTest extends MongoTripodTestBase
             ->method('getDataUpdater')
             ->will($this->returnValue($mockTripodUpdate));
 
-        /** @var $mockTripod \Tripod\Mongo\Tripod */
+        /** @var $mockTripod \Tripod\Mongo\Driver */
         $mockTripod->setTransactionLog($this->tripodTransactionLog);
 
 
@@ -158,7 +158,7 @@ class MongoTripodTransactionRollbackTest extends MongoTripodTestBase
         $nG->add_literal_triple($subjectTwo, $nG->qname_to_uri("dct:title"), "Title four");
 
         $mockTransactionId = 'transaction_1';
-        $mockTripod = $this->getMock('\Tripod\Mongo\Tripod', array('getDataUpdater'), array('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/')));
+        $mockTripod = $this->getMock('\Tripod\Mongo\Driver', array('getDataUpdater'), array('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/')));
         $mockTripodUpdate = $this->getMock('\Tripod\Mongo\Updates', array('generateTransactionId','lockSingleDocument'), array($mockTripod));
 
         $mockTripodUpdate->expects($this->exactly(1))
@@ -172,7 +172,7 @@ class MongoTripodTransactionRollbackTest extends MongoTripodTestBase
             ->method('getDataUpdater')
             ->will($this->returnValue($mockTripodUpdate));
 
-        /** @var $mockTripod \Tripod\Mongo\Tripod */
+        /** @var $mockTripod \Tripod\Mongo\Driver */
         $mockTripod->setTransactionLog($this->tripodTransactionLog);
 
         try
@@ -257,7 +257,7 @@ class MongoTripodTransactionRollbackTest extends MongoTripodTestBase
             ->method('failTransaction')
             ->with($this->equalTo($mockTransactionId));
 
-        $mockTripod = $this->getMock('\Tripod\Mongo\Tripod', array('getDataUpdater'), array('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/')));
+        $mockTripod = $this->getMock('\Tripod\Mongo\Driver', array('getDataUpdater'), array('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/')));
         $mockTripodUpdate = $this->getMock('\Tripod\Mongo\Updates', array('generateTransactionId','lockSingleDocument', 'getTransactionLog'), array($mockTripod));
 
         $mockTripodUpdate->expects($this->once())
@@ -275,7 +275,7 @@ class MongoTripodTransactionRollbackTest extends MongoTripodTestBase
 
         try
         {
-            /* @var $mockTripod \Tripod\Mongo\Tripod */
+            /* @var $mockTripod \Tripod\Mongo\Driver */
             $mockTripod->saveChanges($oG, $nG,"http://talisaspire.com/");
             $this->fail('Exception should have been thrown');
         }
@@ -344,7 +344,7 @@ class MongoTripodTransactionRollbackTest extends MongoTripodTestBase
         $nG->add_literal_triple($subjectTwo, $nG->qname_to_uri("dct:title"), "Updated Title three");
 
         $mockTransactionId = 'transaction_1';
-        $mockTripod = $this->getMock('\Tripod\Mongo\Tripod', array('getDataUpdater'),
+        $mockTripod = $this->getMock('\Tripod\Mongo\Driver', array('getDataUpdater'),
             array('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/')));
         $mockTripodUpdate = $this->getMock('\Tripod\Mongo\Updates',
             array('generateTransactionId','lockSingleDocument','applyChangeSet'), array($mockTripod));
@@ -359,7 +359,7 @@ class MongoTripodTransactionRollbackTest extends MongoTripodTestBase
             ->method('getDataUpdater')
             ->will($this->returnValue($mockTripodUpdate));
 
-        /** @var $mockTripod \Tripod\Mongo\Tripod */
+        /** @var $mockTripod \Tripod\Mongo\Driver */
         $mockTripod->setTransactionLog($this->tripodTransactionLog);
 
         try
@@ -400,7 +400,7 @@ class MongoTripodTransactionRollbackTest extends MongoTripodTestBase
 
     /**
      * This helper function is a callback that assumes that the document being changed does not already exist in the db
-     * Depending on the values passed it either mimics the behaviour of the real lockSingleDocument method on Tripod, or it
+     * Depending on the values passed it either mimics the behaviour of the real lockSingleDocument method on Driver, or it
      * returns an empty array. Have to do this because I want to mock the behavour of lockSingleDocument so I can throw an error for one subject
      * but allow it go through normally for another which you cant do with a mock, hence this hack!
      * @param $s
@@ -419,7 +419,7 @@ class MongoTripodTransactionRollbackTest extends MongoTripodTestBase
     }
 
     /**
-     * This is a private method that performs exactly the same operation as Tripod::lockSingleDocument, the reason this is duplicated here
+     * This is a private method that performs exactly the same operation as Driver::lockSingleDocument, the reason this is duplicated here
      * is so that we can simulate the correct locking of documents as part of mocking a workflow that will lock a document correctly but not another
      * @param $s
      * @param $transaction_id
@@ -451,7 +451,7 @@ class MongoTripodTransactionRollbackTest extends MongoTripodTestBase
             catch(Exception $e) { //Subject is already locked or unable to lock
                 $this->debugLog(MONGO_LOCK,
                     array(
-                        'description'=>'Tripod::lockSingleDocument - failed with exception',
+                        'description'=>'Driver::lockSingleDocument - failed with exception',
                         'transaction_id'=>$transaction_id,
                         'subject'=>$s,
                         'exception-message' => $e->getMessage()
@@ -479,7 +479,7 @@ class MongoTripodTransactionRollbackTest extends MongoTripodTestBase
                 catch(\Exception $e){
                     $this->errorLog(MONGO_LOCK,
                         array(
-                            'description'=>'Tripod::lockSingleDocument - failed when creating new document',
+                            'description'=>'Driver::lockSingleDocument - failed when creating new document',
                             'transaction_id'=>$transaction_id,
                             'subject'=>$s,
                             'exception-message' => $e->getMessage()

--- a/test/unit/mongo/MongoTripodTransactionRollbackTest.php
+++ b/test/unit/mongo/MongoTripodTransactionRollbackTest.php
@@ -12,30 +12,33 @@ require_once 'src/mongo/Tripod.class.php';
 class MongoTripodTransactionRollbackTest extends MongoTripodTestBase
 {
     /**
-     * @var MongoTripod
+     * @var \Tripod\Mongo\Tripod
      */
     protected $tripod = null;
     /**
-     * @var TransactionLog
+     * @var \Tripod\Mongo\TransactionLog
      */
     protected $tripodTransactionLog = null;
 
+    /**
+     * @var \Tripod\Mongo\Labeller
+     */
     protected $labeller = null;
 
     protected function setUp()
     {
         parent::setup();
 
-        $this->tripodTransactionLog = new TransactionLog();
+        $this->tripodTransactionLog = new \Tripod\Mongo\TransactionLog();
         $this->tripodTransactionLog->purgeAllTransactions();
 
-        $this->labeller = new Labeller();
+        $this->labeller = new \Tripod\Mongo\Labeller();
 
         // Stub out 'addToElastic' search to prevent writes into Elastic Search happening by default.
-        $tripod = $this->getMock('Tripod', array('addToSearchIndexQueue'), array('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/')));
+        $tripod = $this->getMock('\Tripod\Mongo\Tripod', array('addToSearchIndexQueue'), array('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/')));
         $tripod->expects($this->any())->method('addToSearchIndexQueue');
 
-        /** @var $tripod MongoTripod */
+        /** @var $tripod \Tripod\Mongo\Tripod */
         \Tripod\Mongo\Config::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing')->drop();
 
         // Lock collection no longer available from Tripod, so drop it manually
@@ -75,11 +78,11 @@ class MongoTripodTransactionRollbackTest extends MongoTripodTestBase
         $g1 = $this->tripod->describeResources(array($subjectOne),'http://talisaspire.com/');
         $g2 = $this->tripod->describeResources(array($subjectTwo),'http://talisaspire.com/');
 
-        $oG = new MongoGraph();
+        $oG = new \Tripod\Mongo\MongoGraph();
         $oG->add_graph($g1);
         $oG->add_graph($g2);
 
-        $nG = new MongoGraph();
+        $nG = new \Tripod\Mongo\MongoGraph();
         $nG->add_graph($g1);
         $nG->add_graph($g2);
         $nG->remove_literal_triple($subjectOne, $nG->qname_to_uri("dct:title"), "Title one");
@@ -88,8 +91,8 @@ class MongoTripodTransactionRollbackTest extends MongoTripodTestBase
         $nG->add_literal_triple($subjectTwo, $nG->qname_to_uri("dct:title"), "Updated Title three");
 
         $mockTransactionId = 'transaction_1';
-        $mockTripod = $this->getMock('Tripod', array('getDataUpdater'), array('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/')));
-        $mockTripodUpdate = $this->getMock('Updates', array('generateTransactionId','lockSingleDocument'), array($mockTripod));
+        $mockTripod = $this->getMock('\Tripod\Mongo\Tripod', array('getDataUpdater'), array('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/')));
+        $mockTripodUpdate = $this->getMock('\Tripod\Mongo\Updates', array('generateTransactionId','lockSingleDocument'), array($mockTripod));
 
         $mockTripodUpdate->expects($this->exactly(1))
             ->method('generateTransactionId')
@@ -102,7 +105,7 @@ class MongoTripodTransactionRollbackTest extends MongoTripodTestBase
             ->method('getDataUpdater')
             ->will($this->returnValue($mockTripodUpdate));
 
-        /** @var $mockTripod MongoTripod */
+        /** @var $mockTripod \Tripod\Mongo\Tripod */
         $mockTripod->setTransactionLog($this->tripodTransactionLog);
 
 
@@ -111,7 +114,7 @@ class MongoTripodTransactionRollbackTest extends MongoTripodTestBase
             $mockTripod->saveChanges($oG, $nG,"http://talisaspire.com/");
             $this->fail('Exception should have been thrown');
         }
-        catch (TripodException $e)
+        catch (\Tripod\Exceptions\Exception $e)
         {
             // Squash the exception here as we need to continue running the assertions.
         }
@@ -144,8 +147,8 @@ class MongoTripodTransactionRollbackTest extends MongoTripodTestBase
         $subjectOne = 'http://example.com/resources/1';
         $subjectTwo = 'http://example.com/resources/2';
 
-        $oG = new MongoGraph();
-        $nG = new MongoGraph();
+        $oG = new \Tripod\Mongo\MongoGraph();
+        $nG = new \Tripod\Mongo\MongoGraph();
         // save two completely new entities
         $nG->add_resource_triple($subjectOne, $nG->qname_to_uri("rdf:type"), $nG->qname_to_uri("acorn:Resource"));
         $nG->add_literal_triple($subjectOne, $nG->qname_to_uri("dct:title"), "Title one");
@@ -155,8 +158,8 @@ class MongoTripodTransactionRollbackTest extends MongoTripodTestBase
         $nG->add_literal_triple($subjectTwo, $nG->qname_to_uri("dct:title"), "Title four");
 
         $mockTransactionId = 'transaction_1';
-        $mockTripod = $this->getMock('Tripod', array('getDataUpdater'), array('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/')));
-        $mockTripodUpdate = $this->getMock('Updates', array('generateTransactionId','lockSingleDocument'), array($mockTripod));
+        $mockTripod = $this->getMock('\Tripod\Mongo\Tripod', array('getDataUpdater'), array('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/')));
+        $mockTripodUpdate = $this->getMock('\Tripod\Mongo\Updates', array('generateTransactionId','lockSingleDocument'), array($mockTripod));
 
         $mockTripodUpdate->expects($this->exactly(1))
             ->method('generateTransactionId')
@@ -169,7 +172,7 @@ class MongoTripodTransactionRollbackTest extends MongoTripodTestBase
             ->method('getDataUpdater')
             ->will($this->returnValue($mockTripodUpdate));
 
-        /** @var $mockTripod MongoTripod */
+        /** @var $mockTripod \Tripod\Mongo\Tripod */
         $mockTripod->setTransactionLog($this->tripodTransactionLog);
 
         try
@@ -177,7 +180,7 @@ class MongoTripodTransactionRollbackTest extends MongoTripodTestBase
             $mockTripod->saveChanges($oG, $nG,"http://talisaspire.com/");
             $this->fail('Exception should have been thrown');
         }
-        catch (TripodException $e)
+        catch (\Tripod\Exceptions\Exception $e)
         {
             // Squash the exception here as we need to continue running the assertions.
         }
@@ -208,8 +211,8 @@ class MongoTripodTransactionRollbackTest extends MongoTripodTestBase
             'rdf:type'=>array('u'=>'acorn:Resource'),
             'dct:title'=>array(array('l'=>'Title one'),array('l'=>'Title two')),
             '_version'=>0,
-            '_cts'=> new MongoDate(strtotime("2013-03-21 00:00:00")),
-            '_uts'=> new MongoDate(strtotime("2013-03-21 00:00:00"))
+            '_cts'=> new \MongoDate(strtotime("2013-03-21 00:00:00")),
+            '_uts'=> new \MongoDate(strtotime("2013-03-21 00:00:00"))
         );
 
         $doc2 = array(
@@ -217,8 +220,8 @@ class MongoTripodTransactionRollbackTest extends MongoTripodTestBase
             'rdf:type'=>array('u'=>'acorn:Book'),
             'dct:title'=>array(array('l'=>'Title three'),array('l'=>'Title four')),
             '_version'=>0,
-            '_cts'=> new MongoDate(strtotime("2013-03-21 00:00:00")),
-            '_uts'=> new MongoDate(strtotime("2013-03-21 00:00:00"))
+            '_cts'=> new \MongoDate(strtotime("2013-03-21 00:00:00")),
+            '_uts'=> new \MongoDate(strtotime("2013-03-21 00:00:00"))
         );
         $this->addDocument($doc1);
         $this->addDocument($doc2);
@@ -227,11 +230,11 @@ class MongoTripodTransactionRollbackTest extends MongoTripodTestBase
         $g1 = $this->tripod->describeResources(array($subjectOne),'http://talisaspire.com/');
         $g2 = $this->tripod->describeResources(array($subjectTwo),'http://talisaspire.com/');
 
-        $oG = new MongoGraph();
+        $oG = new \Tripod\Mongo\MongoGraph();
         $oG->add_graph($g1);
         $oG->add_graph($g2);
 
-        $nG = new MongoGraph();
+        $nG = new \Tripod\Mongo\MongoGraph();
         $nG->add_graph($g1);
         $nG->add_graph($g2);
         $nG->remove_literal_triple($subjectOne, $nG->qname_to_uri("dct:title"), "Title one");
@@ -240,10 +243,10 @@ class MongoTripodTransactionRollbackTest extends MongoTripodTestBase
         $nG->add_literal_triple($subjectTwo, $nG->qname_to_uri("dct:title"), "Updated Title three");
 
         // some values we want explicitly returned from mocks
-        $mockExpectedException = new TripodException('Error creating new transaction');
+        $mockExpectedException = new \Tripod\Exceptions\Exception('Error creating new transaction');
         $mockTransactionId = 'transaction_1';
 
-        $mockTransactionLog = $this->getMock('TransactionLog', array('createNewTransaction', 'cancelTransaction','failTransaction'), array(),'',false, false);
+        $mockTransactionLog = $this->getMock('\Tripod\Mongo\TransactionLog', array('createNewTransaction', 'cancelTransaction','failTransaction'), array(),'',false, false);
         $mockTransactionLog->expects($this->once())
             ->method('createNewTransaction')
             ->will($this->throwException($mockExpectedException));
@@ -254,8 +257,8 @@ class MongoTripodTransactionRollbackTest extends MongoTripodTestBase
             ->method('failTransaction')
             ->with($this->equalTo($mockTransactionId));
 
-        $mockTripod = $this->getMock('Tripod', array('getDataUpdater'), array('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/')));
-        $mockTripodUpdate = $this->getMock('Updates', array('generateTransactionId','lockSingleDocument', 'getTransactionLog'), array($mockTripod));
+        $mockTripod = $this->getMock('\Tripod\Mongo\Tripod', array('getDataUpdater'), array('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/')));
+        $mockTripodUpdate = $this->getMock('\Tripod\Mongo\Updates', array('generateTransactionId','lockSingleDocument', 'getTransactionLog'), array($mockTripod));
 
         $mockTripodUpdate->expects($this->once())
             ->method('generateTransactionId')
@@ -272,11 +275,11 @@ class MongoTripodTransactionRollbackTest extends MongoTripodTestBase
 
         try
         {
-            /* @var $mockTripod MongoTripod */
+            /* @var $mockTripod \Tripod\Mongo\Tripod */
             $mockTripod->saveChanges($oG, $nG,"http://talisaspire.com/");
             $this->fail('Exception should have been thrown');
         }
-        catch (TripodException $e)
+        catch (\Tripod\Exceptions\Exception $e)
         {
             // Squash the exception here as we need to continue running the assertions.
         }
@@ -328,11 +331,11 @@ class MongoTripodTransactionRollbackTest extends MongoTripodTestBase
         $g1 = $this->tripod->describeResources(array($subjectOne),'http://talisaspire.com/');
         $g2 = $this->tripod->describeResources(array($subjectTwo),'http://talisaspire.com/');
 
-        $oG = new MongoGraph();
+        $oG = new \Tripod\Mongo\MongoGraph();
         $oG->add_graph($g1);
         $oG->add_graph($g2);
 
-        $nG = new MongoGraph();
+        $nG = new \Tripod\Mongo\MongoGraph();
         $nG->add_graph($oG);
 
         $nG->remove_literal_triple($subjectOne, $nG->qname_to_uri("dct:title"), "Title one");
@@ -341,9 +344,9 @@ class MongoTripodTransactionRollbackTest extends MongoTripodTestBase
         $nG->add_literal_triple($subjectTwo, $nG->qname_to_uri("dct:title"), "Updated Title three");
 
         $mockTransactionId = 'transaction_1';
-        $mockTripod = $this->getMock('Tripod', array('getDataUpdater'),
+        $mockTripod = $this->getMock('\Tripod\Mongo\Tripod', array('getDataUpdater'),
             array('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/')));
-        $mockTripodUpdate = $this->getMock('Updates',
+        $mockTripodUpdate = $this->getMock('\Tripod\Mongo\Updates',
             array('generateTransactionId','lockSingleDocument','applyChangeSet'), array($mockTripod));
         $mockTripodUpdate->expects($this->exactly(1))
             ->method('generateTransactionId')
@@ -356,7 +359,7 @@ class MongoTripodTransactionRollbackTest extends MongoTripodTestBase
             ->method('getDataUpdater')
             ->will($this->returnValue($mockTripodUpdate));
 
-        /** @var $mockTripod MongoTripod */
+        /** @var $mockTripod \Tripod\Mongo\Tripod */
         $mockTripod->setTransactionLog($this->tripodTransactionLog);
 
         try
@@ -364,7 +367,7 @@ class MongoTripodTransactionRollbackTest extends MongoTripodTestBase
             $mockTripod->saveChanges($oG, $nG,"http://talisaspire.com/");
             $this->fail('Exception should have been thrown');
         }
-        catch (TripodException $e)
+        catch (\Tripod\Exceptions\Exception $e)
         {
             // Squash the exception here as we need to continue running the assertions.
         }
@@ -473,7 +476,7 @@ class MongoTripodTransactionRollbackTest extends MongoTripodTestBase
                     }
                     $document  = $this->getTripodCollection($this->tripod)->findOne(array('_id' => array(_ID_RESOURCE => $this->labeller->uri_to_alias($s), _ID_CONTEXT => $contextAlias)));
                 }
-                catch(Exception $e){
+                catch(\Exception $e){
                     $this->errorLog(MONGO_LOCK,
                         array(
                             'description'=>'Tripod::lockSingleDocument - failed when creating new document',

--- a/test/unit/mongo/MongoTripodViewsTest.php
+++ b/test/unit/mongo/MongoTripodViewsTest.php
@@ -4,9 +4,11 @@ require_once 'MongoTripodTestBase.php';
 require_once 'src/mongo/Tripod.class.php';
 require_once 'src/mongo/delegates/Views.class.php';
 
+use \Tripod\Mongo\Views;
+
 class MongoTripodViewsTest extends MongoTripodTestBase {
     /**
-     * @var Views
+     * @var \Tripod\Mongo\Views
      */
     protected $tripodViews = null;
 
@@ -19,9 +21,9 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         $this->tripodTransactionLog->purgeAllTransactions();
 
         // Stub ouf 'addToElastic' search to prevent writes into Elastic Search happening by default.
-        /** @var Tripod|PHPUnit_Framework_MockObject_MockObject $this->tripod */
+        /** @var \Tripod\Mongo\Tripod|PHPUnit_Framework_MockObject_MockObject $this->tripod */
         $this->tripod = $this->getMock(
-            'Tripod',
+            '\Tripod\Mongo\Tripod',
             array('addToSearchIndexQueue'),
             array('CBD_testing','tripod_php_testing',
                 array(
@@ -107,7 +109,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
     public function testGenerateViewWithTTL()
     {
         $expiryDate = new MongoDate(time()+300);
-        $mockTripodViews = $this->getMock('Views', array('getExpirySecFromNow'), $this->viewsConstParams);
+        $mockTripodViews = $this->getMock('\Tripod\Mongo\Views', array('getExpirySecFromNow'), $this->viewsConstParams);
         $mockTripodViews->expects($this->once())->method('getExpirySecFromNow')->with(300)->will($this->returnValue((time()+300)));
 
         $mockTripodViews->getViewForResource("http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA","v_resource_full_ttl");
@@ -184,13 +186,13 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
     public function testTTLViewIsRegeneratedOnFetch()
     {
         // make mock return expiry date in past...
-        $mockTripodViews = $this->getMock('Views', array('getExpirySecFromNow'), $this->viewsConstParams);
+        $mockTripodViews = $this->getMock('\Tripod\Mongo\Views', array('getExpirySecFromNow'), $this->viewsConstParams);
         $mockTripodViews->expects($this->once())->method('getExpirySecFromNow')->with(300)->will($this->returnValue((time()-300)));
 
         $mockTripodViews->generateView("v_resource_full_ttl","http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA");
 
         // now mock out generate views and check it's called...
-        $mockTripodViews2 = $this->getMock('Views', array('generateView'), $this->viewsConstParams);
+        $mockTripodViews2 = $this->getMock('\Tripod\Mongo\Views', array('generateView'), $this->viewsConstParams);
         $mockTripodViews2->expects($this->once())->method('generateView')->with('v_resource_full_ttl','http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA');
 
         $mockTripodViews2->getViewForResource('http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA','v_resource_full_ttl');
@@ -202,7 +204,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         /**
          * @var $mockTripodViews \Tripod\Mongo\Views
          */
-        $mockTripodViews = $this->getMock('Views', array('getExpirySecFromNow'), $this->viewsConstParams);
+        $mockTripodViews = $this->getMock('\Tripod\Mongo\Views', array('getExpirySecFromNow'), $this->viewsConstParams);
         $mockTripodViews->expects($this->once())->method('getExpirySecFromNow')->with(300)->will($this->returnValue((time()+300)));
 
         $mockTripodViews->getViewForResource("http://talisaspire.com/works/4d101f63c10a6","v_counts");
@@ -270,7 +272,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         // use a mock heron-in to make sure generateView is not called again for different combinations of qname/full uri
 
         /* @var $mockTripodViews \Tripod\Mongo\Views */
-        $mockTripodViews = $this->getMock('Views', array('generateView'), $this->viewsConstParams);
+        $mockTripodViews = $this->getMock('\Tripod\Mongo\Views', array('generateView'), $this->viewsConstParams);
         $mockTripodViews->expects($this->never())->method('generateView');
 
         $g3 = $mockTripodViews->getViewForResource("http://basedata.com/b/2","v_work_see_also","http://basedata.com/b/DefaultGraph");
@@ -284,14 +286,14 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
     public function testGenerateViewsForResourcesOfTypeWithNamespace()
     {
         /* @var $mockTripodViews \Tripod\Mongo\Views */
-        $mockTripodViews = $this->getMock('Views', array('generateView'), $this->viewsConstParams);
+        $mockTripodViews = $this->getMock('\Tripod\Mongo\Views', array('generateView'), $this->viewsConstParams);
         $mockTripodViews->expects($this->atLeastOnce())->method('generateView')->will($this->returnValue(array("ok"=>true)));
 
         // spec is namespaced, acorn:Work, can it resolve?
         $mockTripodViews->generateViewsForResourcesOfType("http://talisaspire.com/schema#Work");
 
         /* @var $mockTripodViews \Tripod\Mongo\Views */
-        $mockTripodViews = $this->getMock('Views', array('generateView'), $this->viewsConstParams);
+        $mockTripodViews = $this->getMock('\Tripod\Mongo\Views', array('generateView'), $this->viewsConstParams);
         $mockTripodViews->expects($this->atLeastOnce())->method('generateView')->will($this->returnValue(array("ok"=>true)));
 
         // spec is fully qualified, http://talisaspire.com/shema#Work2, can it resolve?
@@ -317,7 +319,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             )
         );
 
-        $returnedGraph = new ExtendedGraph();
+        $returnedGraph = new \Tripod\ExtendedGraph();
         $returnedGraph->add_literal_triple($uri1,'http://somepred','someval');
 
         $mockDb = $this->getMock("MongoDB", array("selectCollection"),array(new MongoClient(),"test"));
@@ -348,8 +350,8 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
 
         /* @var $mockTripodViews|PHPUnit_Framework_MockObject_MockObject Views */
         $mockTripodViews = $this->getMock(
-            'Views',
-            array('generateView','fetchGraph', 'getMongoTripodConfigInstance'),
+            '\Tripod\Mongo\Views',
+            array('generateView','fetchGraph', 'getConfigInstance'),
             array('tripod_php_testing',$mockColl,$context)
         );
 
@@ -362,7 +364,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             ->will($this->returnValue($returnedGraph));
 
         $mockTripodViews->expects($this->atLeastOnce())
-            ->method('getMongoTripodConfigInstance')
+            ->method('getConfigInstance')
             ->will($this->returnValue($mockConfig));
 
         $resultGraph = $mockTripodViews->getViewForResources(array($uri1,$uri2),$viewType,$context);
@@ -407,8 +409,8 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
 
         /* @var $mockTripodViews \Tripod\Mongo\Views */
         $mockTripodViews = $this->getMock(
-            'Views',
-            array('generateView','fetchGraph','getMongoTripodConfigInstance'),
+            '\Tripod\Mongo\Views',
+            array('generateView','fetchGraph','getConfigInstance'),
             array('tripod_php_testing',$mockColl,$context)
         );
 
@@ -422,12 +424,12 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             ->will($this->returnCallback(array($this, 'fetchGraphInGetViewForResourcesCallback')));
 
         $mockTripodViews->expects($this->atLeastOnce())
-            ->method('getMongoTripodConfigInstance')
+            ->method('getConfigInstance')
             ->will($this->returnValue($mockConfig));
 
         $resultGraph = $mockTripodViews->getViewForResources(array($uri1,$uri2),$viewType,$context);
 
-        $expectedGraph = new ExtendedGraph();
+        $expectedGraph = new \Tripod\ExtendedGraph();
         $expectedGraph->add_literal_triple($uri1,'http://somepred','someval');
         $expectedGraph->add_literal_triple($uri2,'http://somepred','someval');
 
@@ -438,9 +440,9 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
     {
         $context = 'http://talisaspire.com/';
 
-        $labeller = new MongoTripodLabeller();
+        $labeller = new \Tripod\Mongo\Labeller();
         // First add a graph
-        $originalGraph = new ExtendedGraph();
+        $originalGraph = new \Tripod\ExtendedGraph();
 
         $uri1 = 'http://example.com/resources/' . uniqid();
         $originalGraph->add_resource_triple($uri1, RDF_TYPE, $labeller->qname_to_uri('acorn:Resource'));
@@ -451,8 +453,8 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         $originalGraph->add_literal_triple($uri2, $labeller->qname_to_uri('dct:subject'), 'Things grouped by no specific criteria');
 
         $originalGraph->add_resource_triple($uri1, $labeller->qname_to_uri('dct:isVersionOf'), $uri2);
-        $tripod = new MongoTripod('CBD_testing', 'tripod_php_testing', array('defaultContext'=>$context));
-        $tripod->saveChanges(new ExtendedGraph(), $originalGraph);
+        $tripod = new \Tripod\Mongo\Tripod('CBD_testing', 'tripod_php_testing', array('defaultContext'=>$context));
+        $tripod->saveChanges(new \Tripod\ExtendedGraph(), $originalGraph);
 
         $collections = \Tripod\Mongo\Config::getInstance()->getCollectionsForViews('tripod_php_testing', array('v_resource_full', 'v_resource_full_ttl', 'v_resource_to_single_source'));
 
@@ -467,9 +469,9 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             )
         );
 
-        /** @var MongoTripod|PHPUnit_Framework_MockObject_MockObject $mockTripod */
+        /** @var \Tripod\Mongo\Tripod|PHPUnit_Framework_MockObject_MockObject $mockTripod */
         $mockTripod = $this->getMock(
-            'Tripod',
+            '\Tripod\Mongo\Tripod',
             array(
                 'getDataUpdater', 'getComposite'
             ),
@@ -488,7 +490,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         );
 
         $mockTripodUpdates = $this->getMock(
-            'Updates',
+            '\Tripod\Mongo\Updates',
             array(
                 'processSyncOperations',
                 'queueAsyncOperations'
@@ -505,7 +507,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             )
         );
 
-        $mockViews = $this->getMock('Views',
+        $mockViews = $this->getMock('\Tripod\Mongo\Views',
             array('generateViewsForResourcesOfType'),
             array(
                 'tripod_php_testing',
@@ -541,16 +543,16 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             ->method('generateViewsForResourcesOfType');
 
 
-        $mockTripod->saveChanges($originalGraph->get_subject_subgraph($uri1), new ExtendedGraph());
+        $mockTripod->saveChanges($originalGraph->get_subject_subgraph($uri1), new \Tripod\ExtendedGraph());
 
         // Walk through the processSyncOperations process manually for views
 
         /** @var \Tripod\Mongo\Views $view */
         $view = $mockTripod->getComposite(OP_VIEWS);
-        $this->assertInstanceOf('Views', $view);
+        $this->assertInstanceOf('\Tripod\Mongo\Views', $view);
 
         $expectedImpactedSubjects = array(
-            new ImpactedSubject(
+            new \Tripod\Mongo\ImpactedSubject(
                 array(
                     _ID_RESOURCE=>$labeller->uri_to_alias($uri1),
                     _ID_CONTEXT=>$context
@@ -587,9 +589,9 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
     {
         $context = 'http://talisaspire.com/';
 
-        $labeller = new MongoTripodLabeller();
+        $labeller = new \Tripod\Mongo\Labeller();
         // First add a graph
-        $originalGraph = new ExtendedGraph();
+        $originalGraph = new \Tripod\ExtendedGraph();
 
         $uri1 = 'http://example.com/resources/' . uniqid();
         $originalGraph->add_resource_triple($uri1, RDF_TYPE, $labeller->qname_to_uri('acorn:Resource'));
@@ -600,8 +602,8 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         $originalGraph->add_literal_triple($uri2, $labeller->qname_to_uri('dct:subject'), 'Things grouped by no specific criteria');
 
         $originalGraph->add_resource_triple($uri1, $labeller->qname_to_uri('dct:isVersionOf'), $uri2);
-        $tripod = new MongoTripod('CBD_testing', 'tripod_php_testing', array('defaultContext'=>$context));
-        $tripod->saveChanges(new ExtendedGraph(), $originalGraph);
+        $tripod = new \Tripod\Mongo\Tripod('CBD_testing', 'tripod_php_testing', array('defaultContext'=>$context));
+        $tripod->saveChanges(new \Tripod\ExtendedGraph(), $originalGraph);
 
         $collections = \Tripod\Mongo\Config::getInstance()->getCollectionsForViews('tripod_php_testing', array('v_resource_full', 'v_resource_full_ttl', 'v_resource_to_single_source'));
 
@@ -616,9 +618,9 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             )
         );
 
-        /** @var MongoTripod|PHPUnit_Framework_MockObject_MockObject $mockTripod */
+        /** @var \Tripod\Mongo\Tripod|PHPUnit_Framework_MockObject_MockObject $mockTripod */
         $mockTripod = $this->getMock(
-            'Tripod',
+            '\Tripod\Mongo\Tripod',
             array(
                 'getDataUpdater', 'getComposite'
             ),
@@ -637,7 +639,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         );
 
         $mockTripodUpdates = $this->getMock(
-            'Updates',
+            '\Tripod\Mongo\Updates',
             array(
                 'processSyncOperations',
                 'queueAsyncOperations'
@@ -654,7 +656,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             )
         );
 
-        $mockViews = $this->getMock('Views',
+        $mockViews = $this->getMock('\Tripod\Mongo\Views',
             array('generateView'),
             array(
                 'tripod_php_testing',
@@ -708,16 +710,16 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             );
 
 
-        $mockTripod->saveChanges($originalGraph->get_subject_subgraph($uri2), new ExtendedGraph());
+        $mockTripod->saveChanges($originalGraph->get_subject_subgraph($uri2), new \Tripod\ExtendedGraph());
 
         // Walk through the processSyncOperations process manually for views
 
         /** @var \Tripod\Mongo\Views $view */
         $view = $mockTripod->getComposite(OP_VIEWS);
-        $this->assertInstanceOf('Views', $view);
+        $this->assertInstanceOf('\Tripod\Mongo\Views', $view);
 
         $expectedImpactedSubjects = array(
-            new ImpactedSubject(
+            new \Tripod\Mongo\ImpactedSubject(
                 array(
                     _ID_RESOURCE=>$labeller->uri_to_alias($uri1), // The impacted subject should still be $uri, since $uri2 is just in the impactIndex
                     _ID_CONTEXT=>$context
@@ -755,9 +757,9 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
     {
         $context = 'http://talisaspire.com/';
 
-        $labeller = new MongoTripodLabeller();
+        $labeller = new \Tripod\Mongo\Labeller();
         // First add a graph
-        $originalGraph = new ExtendedGraph();
+        $originalGraph = new \Tripod\ExtendedGraph();
 
         $uri1 = 'http://example.com/resources/' . uniqid();
         $originalGraph->add_resource_triple($uri1, RDF_TYPE, $labeller->qname_to_uri('acorn:Resource'));
@@ -768,8 +770,8 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         $originalGraph->add_literal_triple($uri2, $labeller->qname_to_uri('dct:subject'), 'Things grouped by no specific criteria');
 
         $originalGraph->add_resource_triple($uri1, $labeller->qname_to_uri('dct:isVersionOf'), $uri2);
-        $tripod = new MongoTripod('CBD_testing', 'tripod_php_testing', array('defaultContext'=>$context));
-        $tripod->saveChanges(new ExtendedGraph(), $originalGraph);
+        $tripod = new \Tripod\Mongo\Tripod('CBD_testing', 'tripod_php_testing', array('defaultContext'=>$context));
+        $tripod->saveChanges(new \Tripod\ExtendedGraph(), $originalGraph);
 
         $collections = \Tripod\Mongo\Config::getInstance()->getCollectionsForViews('tripod_php_testing', array('v_resource_full', 'v_resource_full_ttl', 'v_resource_to_single_source'));
 
@@ -782,9 +784,9 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             $labeller->uri_to_alias($uri2)=>array('dct:subject')
         );
 
-        /** @var MongoTripod|PHPUnit_Framework_MockObject_MockObject $mockTripod */
+        /** @var \Tripod\Mongo\Tripod|PHPUnit_Framework_MockObject_MockObject $mockTripod */
         $mockTripod = $this->getMock(
-            'Tripod',
+            '\Tripod\Mongo\Tripod',
             array(
                 'getDataUpdater', 'getComposite'
             ),
@@ -803,7 +805,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         );
 
         $mockTripodUpdates = $this->getMock(
-            'Updates',
+            '\Tripod\Mongo\Updates',
             array(
                 'processSyncOperations',
                 'queueAsyncOperations'
@@ -820,7 +822,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             )
         );
 
-        $mockViews = $this->getMock('Views',
+        $mockViews = $this->getMock('\Tripod\Mongo\Views',
             array('generateView'),
             array(
                 'tripod_php_testing',
@@ -882,10 +884,10 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
 
         /** @var \Tripod\Mongo\Views $view */
         $view = $mockTripod->getComposite(OP_VIEWS);
-        $this->assertInstanceOf('Views', $view);
+        $this->assertInstanceOf('\Tripod\Mongo\Views', $view);
 
         $expectedImpactedSubjects = array(
-            new ImpactedSubject(
+            new \Tripod\Mongo\ImpactedSubject(
                 array(
                     _ID_RESOURCE=>$labeller->uri_to_alias($uri1), // The impacted subject should still be $uri, since $uri2 is just in the impactIndex
                     _ID_CONTEXT=>$context
@@ -922,9 +924,9 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
     {
         $context = 'http://talisaspire.com/';
 
-        $labeller = new MongoTripodLabeller();
+        $labeller = new \Tripod\Mongo\Labeller();
         // First add a graph
-        $originalGraph = new ExtendedGraph();
+        $originalGraph = new \Tripod\ExtendedGraph();
 
         $uri1 = 'http://example.com/resources/' . uniqid();
         $originalGraph->add_resource_triple($uri1, RDF_TYPE, $labeller->qname_to_uri('acorn:Resource'));
@@ -935,8 +937,8 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         $originalGraph->add_literal_triple($uri2, $labeller->qname_to_uri('dct:subject'), 'Things grouped by no specific criteria');
 
         $originalGraph->add_resource_triple($uri1, $labeller->qname_to_uri('dct:isVersionOf'), $uri2);
-        $tripod = new MongoTripod('CBD_testing', 'tripod_php_testing', array('defaultContext'=>$context));
-        $tripod->saveChanges(new ExtendedGraph(), $originalGraph);
+        $tripod = new \Tripod\Mongo\Tripod('CBD_testing', 'tripod_php_testing', array('defaultContext'=>$context));
+        $tripod->saveChanges(new \Tripod\ExtendedGraph(), $originalGraph);
 
         $collections = \Tripod\Mongo\Config::getInstance()->getCollectionsForViews('tripod_php_testing', array('v_resource_full', 'v_resource_full_ttl', 'v_resource_to_single_source'));
 
@@ -949,9 +951,9 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             $labeller->uri_to_alias($uri1)=>array('dct:title')
         );
 
-        /** @var MongoTripod|PHPUnit_Framework_MockObject_MockObject $mockTripod */
+        /** @var \Tripod\Mongo\Tripod|PHPUnit_Framework_MockObject_MockObject $mockTripod */
         $mockTripod = $this->getMock(
-            'Tripod',
+            '\Tripod\Mongo\Tripod',
             array(
                 'getDataUpdater', 'getComposite'
             ),
@@ -970,7 +972,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         );
 
         $mockTripodUpdates = $this->getMock(
-            'Updates',
+            '\Tripod\Mongo\Updates',
             array(
                 'processSyncOperations',
                 'queueAsyncOperations'
@@ -987,7 +989,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             )
         );
 
-        $mockViews = $this->getMock('Views',
+        $mockViews = $this->getMock('\Tripod\Mongo\Views',
             array('generateView'),
             array(
                 'tripod_php_testing',
@@ -1048,10 +1050,10 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
 
         /** @var \Tripod\Mongo\Views $view */
         $view = $mockTripod->getComposite(OP_VIEWS);
-        $this->assertInstanceOf('Views', $view);
+        $this->assertInstanceOf('\Tripod\Mongo\Views', $view);
 
         $expectedImpactedSubjects = array(
-            new ImpactedSubject(
+            new \Tripod\Mongo\ImpactedSubject(
                 array(
                     _ID_RESOURCE=>$labeller->uri_to_alias($uri1), // The impacted subject should still be $uri, since $uri2 is just in the impactIndex
                     _ID_CONTEXT=>$context
@@ -1088,9 +1090,9 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
     {
         $context = 'http://talisaspire.com/';
 
-        $labeller = new MongoTripodLabeller();
+        $labeller = new \Tripod\Mongo\Labeller();
         // First add a graph
-        $originalGraph = new ExtendedGraph();
+        $originalGraph = new \Tripod\ExtendedGraph();
 
         $uri1 = 'http://example.com/resources/' . uniqid();
         $originalGraph->add_resource_triple($uri1, RDF_TYPE, $labeller->qname_to_uri('bibo:Document'));
@@ -1106,9 +1108,9 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             $labeller->uri_to_alias($uri1)=>array('dct:subject')
         );
 
-        /** @var MongoTripod|PHPUnit_Framework_MockObject_MockObject $mockTripod */
+        /** @var \Tripod\Mongo\Tripod|PHPUnit_Framework_MockObject_MockObject $mockTripod */
         $mockTripod = $this->getMock(
-            'Tripod',
+            '\Tripod\Mongo\Tripod',
             array(
                 'getDataUpdater', 'getComposite'
             ),
@@ -1127,7 +1129,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         );
 
         $mockTripodUpdates = $this->getMock(
-            'Updates',
+            '\Tripod\Mongo\Updates',
             array(
                 'processSyncOperations',
                 'queueAsyncOperations'
@@ -1144,7 +1146,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             )
         );
 
-        $mockViews = $this->getMock('Views',
+        $mockViews = $this->getMock('\Tripod\Mongo\Views',
             array('generateViewsForResourcesOfType'),
             array(
                 'tripod_php_testing',
@@ -1191,11 +1193,11 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         $mockViews->expects($this->never())
             ->method('generateViewsForResourcesOfType');
 
-        $mockTripod->saveChanges(new ExtendedGraph(), $originalGraph);
+        $mockTripod->saveChanges(new \Tripod\ExtendedGraph(), $originalGraph);
 
         /** @var \Tripod\Mongo\Views $view */
         $view = $mockTripod->getComposite(OP_VIEWS);
-        $this->assertInstanceOf('Views', $view);
+        $this->assertInstanceOf('\Tripod\Mongo\Views', $view);
 
         $impactedSubjects = $view->getImpactedSubjects($originalSubjectsAndPredicatesOfChange, $context);
 
@@ -1209,7 +1211,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
 
         /** @var \Tripod\Mongo\Views $view */
         $view = $mockTripod->getComposite(OP_VIEWS);
-        $this->assertInstanceOf('Views', $view);
+        $this->assertInstanceOf('\Tripod\Mongo\Views', $view);
 
         $impactedSubjects = $view->getImpactedSubjects($updatedSubjectsAndPredicatesOfChange, $context);
 
@@ -1223,7 +1225,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
      */
     public function testSavingMultipleNewEntitiesResultsInOneImpactedSubject()
     {
-        $tripod = $this->getMockBuilder('Tripod')
+        $tripod = $this->getMockBuilder('\Tripod\Mongo\Tripod')
             ->setMethods(array('getDataUpdater'))
             ->setConstructorArgs(
                 array(
@@ -1240,7 +1242,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
                 )
             )->getMock();
 
-        $tripodUpdates = $this->getMockBuilder('Updates')
+        $tripodUpdates = $this->getMockBuilder('\Tripod\Mongo\Updates')
             ->setMethods(array('submitJob'))
             ->setConstructorArgs(
                 array(
@@ -1261,7 +1263,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             ->will($this->returnValue($tripodUpdates));
 
         // first lets add a book, which should trigger a search doc, view and table gen for a single item
-        $g = new MongoGraph();
+        $g = new \Tripod\Mongo\MongoGraph();
         $newSubjectUri1 = "http://talisaspire.com/resources/newdoc1";
         $newSubjectUri2 = "http://talisaspire.com/resources/newdoc2";
         $newSubjectUri3 = "http://talisaspire.com/resources/newdoc3";
@@ -1289,13 +1291,13 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             $newSubjectUri2=>array('rdf:type','dct:creator','dct:title','dct:subject'),
             $newSubjectUri3=>array('rdf:type','dct:creator','dct:title','dct:subject')
         );
-        $tripod->saveChanges(new MongoGraph(), $g);
+        $tripod->saveChanges(new \Tripod\Mongo\MongoGraph(), $g);
 
         /** @var \Tripod\Mongo\Views $views */
         $views = $tripod->getComposite(OP_VIEWS);
 
         $expectedImpactedSubjects = array(
-            new ImpactedSubject(
+            new \Tripod\Mongo\ImpactedSubject(
                 array(
                     _ID_RESOURCE=>$newSubjectUri2,
                     _ID_CONTEXT=>'http://talisaspire.com/'
@@ -1311,7 +1313,10 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         $this->assertEquals($expectedImpactedSubjects, $impactedSubjects);
     }
 
-    function fetchGraphInGetViewForResourcesCallback()
+    /**
+     * @return \Tripod\ExtendedGraph
+     */
+    public function fetchGraphInGetViewForResourcesCallback()
     {
         $uri1 = "http://uri1";
         $uri2 = "http://uri2";
@@ -1322,17 +1327,18 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         $query1 = array("_id"=>array('$in'=>array(array("r"=>$uri1,"c"=>$context,"type"=>$viewType),array("r"=>$uri2,"c"=>$context,"type"=>$viewType))));
         $query2 = array("_id"=>array('$in'=>array(array("r"=>$uri2,"c"=>$context,"type"=>$viewType))));
 
-        $returnedGraph1 = new ExtendedGraph();
+        $returnedGraph1 = new \Tripod\ExtendedGraph();
         $returnedGraph1->add_literal_triple($uri1,'http://somepred','someval');
 
-        $returnedGraph2 = new ExtendedGraph();
+        $returnedGraph2 = new \Tripod\ExtendedGraph();
         $returnedGraph2->add_literal_triple($uri2,'http://somepred','someval');
 
         $args = func_get_args();
         if($args[0]==$query1){
             return $returnedGraph1;
         }
-        else if($args[0]==$query2){
+        elseif($args[0]==$query2)
+        {
             return $returnedGraph2;
         }
         else

--- a/test/unit/mongo/MongoTripodViewsTest.php
+++ b/test/unit/mongo/MongoTripodViewsTest.php
@@ -254,8 +254,6 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         );
 
         $actualView = \Tripod\Mongo\Config::getInstance()->getCollectionForView('tripod_php_testing', 'v_counts')->findOne(array('_id'=>array("r"=>'http://talisaspire.com/works/4d101f63c10a6',"c"=>"http://talisaspire.com/","type"=>'v_counts')));
-//        var_dump($actualView); die;
-//        var_dump($expectedView);
         $this->assertEquals($expectedView,$actualView);
     }
 

--- a/test/unit/mongo/MongoTripodViewsTest.php
+++ b/test/unit/mongo/MongoTripodViewsTest.php
@@ -1,14 +1,14 @@
 <?php
 
 require_once 'MongoTripodTestBase.php';
-require_once 'src/mongo/Tripod.class.php';
+require_once 'src/mongo/Driver.class.php';
 require_once 'src/mongo/delegates/Views.class.php';
 
-use \Tripod\Mongo\Views;
+use \Tripod\Mongo\Composites\Views;
 
 class MongoTripodViewsTest extends MongoTripodTestBase {
     /**
-     * @var \Tripod\Mongo\Views
+     * @var \Tripod\Mongo\Composites\Views
      */
     protected $tripodViews = null;
 
@@ -21,9 +21,9 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         $this->tripodTransactionLog->purgeAllTransactions();
 
         // Stub ouf 'addToElastic' search to prevent writes into Elastic Search happening by default.
-        /** @var \Tripod\Mongo\Tripod|PHPUnit_Framework_MockObject_MockObject $this->tripod */
+        /** @var \Tripod\Mongo\Driver|PHPUnit_Framework_MockObject_MockObject $this->tripod */
         $this->tripod = $this->getMock(
-            '\Tripod\Mongo\Tripod',
+            '\Tripod\Mongo\Driver',
             array('addToSearchIndexQueue'),
             array('CBD_testing','tripod_php_testing',
                 array(
@@ -37,7 +37,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         $this->getTripodCollection($this->tripod)->drop();
         $this->tripod->setTransactionLog($this->tripodTransactionLog);
 
-        $this->tripodViews = new \Tripod\Mongo\Views(
+        $this->tripodViews = new \Tripod\Mongo\Composites\Views(
             $this->tripod->getStoreName(),
             $this->getTripodCollection($this->tripod),
             'http://talisaspire.com/'
@@ -109,7 +109,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
     public function testGenerateViewWithTTL()
     {
         $expiryDate = new MongoDate(time()+300);
-        $mockTripodViews = $this->getMock('\Tripod\Mongo\Views', array('getExpirySecFromNow'), $this->viewsConstParams);
+        $mockTripodViews = $this->getMock('\Tripod\Mongo\Composites\Views', array('getExpirySecFromNow'), $this->viewsConstParams);
         $mockTripodViews->expects($this->once())->method('getExpirySecFromNow')->with(300)->will($this->returnValue((time()+300)));
 
         $mockTripodViews->getViewForResource("http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA","v_resource_full_ttl");
@@ -186,13 +186,13 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
     public function testTTLViewIsRegeneratedOnFetch()
     {
         // make mock return expiry date in past...
-        $mockTripodViews = $this->getMock('\Tripod\Mongo\Views', array('getExpirySecFromNow'), $this->viewsConstParams);
+        $mockTripodViews = $this->getMock('\Tripod\Mongo\Composites\Views', array('getExpirySecFromNow'), $this->viewsConstParams);
         $mockTripodViews->expects($this->once())->method('getExpirySecFromNow')->with(300)->will($this->returnValue((time()-300)));
 
         $mockTripodViews->generateView("v_resource_full_ttl","http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA");
 
         // now mock out generate views and check it's called...
-        $mockTripodViews2 = $this->getMock('\Tripod\Mongo\Views', array('generateView'), $this->viewsConstParams);
+        $mockTripodViews2 = $this->getMock('\Tripod\Mongo\Composites\Views', array('generateView'), $this->viewsConstParams);
         $mockTripodViews2->expects($this->once())->method('generateView')->with('v_resource_full_ttl','http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA');
 
         $mockTripodViews2->getViewForResource('http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA','v_resource_full_ttl');
@@ -202,9 +202,9 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
     {
         $expiryDate = new MongoDate(time()+300);
         /**
-         * @var $mockTripodViews \Tripod\Mongo\Views
+         * @var $mockTripodViews \Tripod\Mongo\Composites\Views
          */
-        $mockTripodViews = $this->getMock('\Tripod\Mongo\Views', array('getExpirySecFromNow'), $this->viewsConstParams);
+        $mockTripodViews = $this->getMock('\Tripod\Mongo\Composites\Views', array('getExpirySecFromNow'), $this->viewsConstParams);
         $mockTripodViews->expects($this->once())->method('getExpirySecFromNow')->with(300)->will($this->returnValue((time()+300)));
 
         $mockTripodViews->getViewForResource("http://talisaspire.com/works/4d101f63c10a6","v_counts");
@@ -269,8 +269,8 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
 
         // use a mock heron-in to make sure generateView is not called again for different combinations of qname/full uri
 
-        /* @var $mockTripodViews \Tripod\Mongo\Views */
-        $mockTripodViews = $this->getMock('\Tripod\Mongo\Views', array('generateView'), $this->viewsConstParams);
+        /* @var $mockTripodViews \Tripod\Mongo\Composites\Views */
+        $mockTripodViews = $this->getMock('\Tripod\Mongo\Composites\Views', array('generateView'), $this->viewsConstParams);
         $mockTripodViews->expects($this->never())->method('generateView');
 
         $g3 = $mockTripodViews->getViewForResource("http://basedata.com/b/2","v_work_see_also","http://basedata.com/b/DefaultGraph");
@@ -283,15 +283,15 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
 
     public function testGenerateViewsForResourcesOfTypeWithNamespace()
     {
-        /* @var $mockTripodViews \Tripod\Mongo\Views */
-        $mockTripodViews = $this->getMock('\Tripod\Mongo\Views', array('generateView'), $this->viewsConstParams);
+        /* @var $mockTripodViews \Tripod\Mongo\Composites\Views */
+        $mockTripodViews = $this->getMock('\Tripod\Mongo\Composites\Views', array('generateView'), $this->viewsConstParams);
         $mockTripodViews->expects($this->atLeastOnce())->method('generateView')->will($this->returnValue(array("ok"=>true)));
 
         // spec is namespaced, acorn:Work, can it resolve?
         $mockTripodViews->generateViewsForResourcesOfType("http://talisaspire.com/schema#Work");
 
-        /* @var $mockTripodViews \Tripod\Mongo\Views */
-        $mockTripodViews = $this->getMock('\Tripod\Mongo\Views', array('generateView'), $this->viewsConstParams);
+        /* @var $mockTripodViews \Tripod\Mongo\Composites\Views */
+        $mockTripodViews = $this->getMock('\Tripod\Mongo\Composites\Views', array('generateView'), $this->viewsConstParams);
         $mockTripodViews->expects($this->atLeastOnce())->method('generateView')->will($this->returnValue(array("ok"=>true)));
 
         // spec is fully qualified, http://talisaspire.com/shema#Work2, can it resolve?
@@ -348,7 +348,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
 
         /* @var $mockTripodViews|PHPUnit_Framework_MockObject_MockObject Views */
         $mockTripodViews = $this->getMock(
-            '\Tripod\Mongo\Views',
+            '\Tripod\Mongo\Composites\Views',
             array('generateView','fetchGraph', 'getConfigInstance'),
             array('tripod_php_testing',$mockColl,$context)
         );
@@ -405,9 +405,9 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         $mockConfig->loadConfig(\Tripod\Mongo\Config::getConfig());
 
 
-        /* @var $mockTripodViews \Tripod\Mongo\Views */
+        /* @var $mockTripodViews \Tripod\Mongo\Composites\Views */
         $mockTripodViews = $this->getMock(
-            '\Tripod\Mongo\Views',
+            '\Tripod\Mongo\Composites\Views',
             array('generateView','fetchGraph','getConfigInstance'),
             array('tripod_php_testing',$mockColl,$context)
         );
@@ -451,7 +451,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         $originalGraph->add_literal_triple($uri2, $labeller->qname_to_uri('dct:subject'), 'Things grouped by no specific criteria');
 
         $originalGraph->add_resource_triple($uri1, $labeller->qname_to_uri('dct:isVersionOf'), $uri2);
-        $tripod = new \Tripod\Mongo\Tripod('CBD_testing', 'tripod_php_testing', array('defaultContext'=>$context));
+        $tripod = new \Tripod\Mongo\Driver('CBD_testing', 'tripod_php_testing', array('defaultContext'=>$context));
         $tripod->saveChanges(new \Tripod\ExtendedGraph(), $originalGraph);
 
         $collections = \Tripod\Mongo\Config::getInstance()->getCollectionsForViews('tripod_php_testing', array('v_resource_full', 'v_resource_full_ttl', 'v_resource_to_single_source'));
@@ -467,9 +467,9 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             )
         );
 
-        /** @var \Tripod\Mongo\Tripod|PHPUnit_Framework_MockObject_MockObject $mockTripod */
+        /** @var \Tripod\Mongo\Driver|PHPUnit_Framework_MockObject_MockObject $mockTripod */
         $mockTripod = $this->getMock(
-            '\Tripod\Mongo\Tripod',
+            '\Tripod\Mongo\Driver',
             array(
                 'getDataUpdater', 'getComposite'
             ),
@@ -505,7 +505,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             )
         );
 
-        $mockViews = $this->getMock('\Tripod\Mongo\Views',
+        $mockViews = $this->getMock('\Tripod\Mongo\Composites\Views',
             array('generateViewsForResourcesOfType'),
             array(
                 'tripod_php_testing',
@@ -545,9 +545,9 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
 
         // Walk through the processSyncOperations process manually for views
 
-        /** @var \Tripod\Mongo\Views $view */
+        /** @var \Tripod\Mongo\Composites\Views $view */
         $view = $mockTripod->getComposite(OP_VIEWS);
-        $this->assertInstanceOf('\Tripod\Mongo\Views', $view);
+        $this->assertInstanceOf('\Tripod\Mongo\Composites\Views', $view);
 
         $expectedImpactedSubjects = array(
             new \Tripod\Mongo\ImpactedSubject(
@@ -600,7 +600,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         $originalGraph->add_literal_triple($uri2, $labeller->qname_to_uri('dct:subject'), 'Things grouped by no specific criteria');
 
         $originalGraph->add_resource_triple($uri1, $labeller->qname_to_uri('dct:isVersionOf'), $uri2);
-        $tripod = new \Tripod\Mongo\Tripod('CBD_testing', 'tripod_php_testing', array('defaultContext'=>$context));
+        $tripod = new \Tripod\Mongo\Driver('CBD_testing', 'tripod_php_testing', array('defaultContext'=>$context));
         $tripod->saveChanges(new \Tripod\ExtendedGraph(), $originalGraph);
 
         $collections = \Tripod\Mongo\Config::getInstance()->getCollectionsForViews('tripod_php_testing', array('v_resource_full', 'v_resource_full_ttl', 'v_resource_to_single_source'));
@@ -616,9 +616,9 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             )
         );
 
-        /** @var \Tripod\Mongo\Tripod|PHPUnit_Framework_MockObject_MockObject $mockTripod */
+        /** @var \Tripod\Mongo\Driver|PHPUnit_Framework_MockObject_MockObject $mockTripod */
         $mockTripod = $this->getMock(
-            '\Tripod\Mongo\Tripod',
+            '\Tripod\Mongo\Driver',
             array(
                 'getDataUpdater', 'getComposite'
             ),
@@ -654,7 +654,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             )
         );
 
-        $mockViews = $this->getMock('\Tripod\Mongo\Views',
+        $mockViews = $this->getMock('\Tripod\Mongo\Composites\Views',
             array('generateView'),
             array(
                 'tripod_php_testing',
@@ -712,9 +712,9 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
 
         // Walk through the processSyncOperations process manually for views
 
-        /** @var \Tripod\Mongo\Views $view */
+        /** @var \Tripod\Mongo\Composites\Views $view */
         $view = $mockTripod->getComposite(OP_VIEWS);
-        $this->assertInstanceOf('\Tripod\Mongo\Views', $view);
+        $this->assertInstanceOf('\Tripod\Mongo\Composites\Views', $view);
 
         $expectedImpactedSubjects = array(
             new \Tripod\Mongo\ImpactedSubject(
@@ -768,7 +768,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         $originalGraph->add_literal_triple($uri2, $labeller->qname_to_uri('dct:subject'), 'Things grouped by no specific criteria');
 
         $originalGraph->add_resource_triple($uri1, $labeller->qname_to_uri('dct:isVersionOf'), $uri2);
-        $tripod = new \Tripod\Mongo\Tripod('CBD_testing', 'tripod_php_testing', array('defaultContext'=>$context));
+        $tripod = new \Tripod\Mongo\Driver('CBD_testing', 'tripod_php_testing', array('defaultContext'=>$context));
         $tripod->saveChanges(new \Tripod\ExtendedGraph(), $originalGraph);
 
         $collections = \Tripod\Mongo\Config::getInstance()->getCollectionsForViews('tripod_php_testing', array('v_resource_full', 'v_resource_full_ttl', 'v_resource_to_single_source'));
@@ -782,9 +782,9 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             $labeller->uri_to_alias($uri2)=>array('dct:subject')
         );
 
-        /** @var \Tripod\Mongo\Tripod|PHPUnit_Framework_MockObject_MockObject $mockTripod */
+        /** @var \Tripod\Mongo\Driver|PHPUnit_Framework_MockObject_MockObject $mockTripod */
         $mockTripod = $this->getMock(
-            '\Tripod\Mongo\Tripod',
+            '\Tripod\Mongo\Driver',
             array(
                 'getDataUpdater', 'getComposite'
             ),
@@ -820,7 +820,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             )
         );
 
-        $mockViews = $this->getMock('\Tripod\Mongo\Views',
+        $mockViews = $this->getMock('\Tripod\Mongo\Composites\Views',
             array('generateView'),
             array(
                 'tripod_php_testing',
@@ -880,9 +880,9 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
 
         // Walk through the processSyncOperations process manually for views
 
-        /** @var \Tripod\Mongo\Views $view */
+        /** @var \Tripod\Mongo\Composites\Views $view */
         $view = $mockTripod->getComposite(OP_VIEWS);
-        $this->assertInstanceOf('\Tripod\Mongo\Views', $view);
+        $this->assertInstanceOf('\Tripod\Mongo\Composites\Views', $view);
 
         $expectedImpactedSubjects = array(
             new \Tripod\Mongo\ImpactedSubject(
@@ -935,7 +935,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         $originalGraph->add_literal_triple($uri2, $labeller->qname_to_uri('dct:subject'), 'Things grouped by no specific criteria');
 
         $originalGraph->add_resource_triple($uri1, $labeller->qname_to_uri('dct:isVersionOf'), $uri2);
-        $tripod = new \Tripod\Mongo\Tripod('CBD_testing', 'tripod_php_testing', array('defaultContext'=>$context));
+        $tripod = new \Tripod\Mongo\Driver('CBD_testing', 'tripod_php_testing', array('defaultContext'=>$context));
         $tripod->saveChanges(new \Tripod\ExtendedGraph(), $originalGraph);
 
         $collections = \Tripod\Mongo\Config::getInstance()->getCollectionsForViews('tripod_php_testing', array('v_resource_full', 'v_resource_full_ttl', 'v_resource_to_single_source'));
@@ -949,9 +949,9 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             $labeller->uri_to_alias($uri1)=>array('dct:title')
         );
 
-        /** @var \Tripod\Mongo\Tripod|PHPUnit_Framework_MockObject_MockObject $mockTripod */
+        /** @var \Tripod\Mongo\Driver|PHPUnit_Framework_MockObject_MockObject $mockTripod */
         $mockTripod = $this->getMock(
-            '\Tripod\Mongo\Tripod',
+            '\Tripod\Mongo\Driver',
             array(
                 'getDataUpdater', 'getComposite'
             ),
@@ -987,7 +987,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             )
         );
 
-        $mockViews = $this->getMock('\Tripod\Mongo\Views',
+        $mockViews = $this->getMock('\Tripod\Mongo\Composites\Views',
             array('generateView'),
             array(
                 'tripod_php_testing',
@@ -1046,9 +1046,9 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
 
         // Walk through the processSyncOperations process manually for views
 
-        /** @var \Tripod\Mongo\Views $view */
+        /** @var \Tripod\Mongo\Composites\Views $view */
         $view = $mockTripod->getComposite(OP_VIEWS);
-        $this->assertInstanceOf('\Tripod\Mongo\Views', $view);
+        $this->assertInstanceOf('\Tripod\Mongo\Composites\Views', $view);
 
         $expectedImpactedSubjects = array(
             new \Tripod\Mongo\ImpactedSubject(
@@ -1106,9 +1106,9 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             $labeller->uri_to_alias($uri1)=>array('dct:subject')
         );
 
-        /** @var \Tripod\Mongo\Tripod|PHPUnit_Framework_MockObject_MockObject $mockTripod */
+        /** @var \Tripod\Mongo\Driver|PHPUnit_Framework_MockObject_MockObject $mockTripod */
         $mockTripod = $this->getMock(
-            '\Tripod\Mongo\Tripod',
+            '\Tripod\Mongo\Driver',
             array(
                 'getDataUpdater', 'getComposite'
             ),
@@ -1144,7 +1144,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             )
         );
 
-        $mockViews = $this->getMock('\Tripod\Mongo\Views',
+        $mockViews = $this->getMock('\Tripod\Mongo\Composites\Views',
             array('generateViewsForResourcesOfType'),
             array(
                 'tripod_php_testing',
@@ -1193,9 +1193,9 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
 
         $mockTripod->saveChanges(new \Tripod\ExtendedGraph(), $originalGraph);
 
-        /** @var \Tripod\Mongo\Views $view */
+        /** @var \Tripod\Mongo\Composites\Views $view */
         $view = $mockTripod->getComposite(OP_VIEWS);
-        $this->assertInstanceOf('\Tripod\Mongo\Views', $view);
+        $this->assertInstanceOf('\Tripod\Mongo\Composites\Views', $view);
 
         $impactedSubjects = $view->getImpactedSubjects($originalSubjectsAndPredicatesOfChange, $context);
 
@@ -1207,9 +1207,9 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         $mockTripod->saveChanges($originalGraph, $newGraph);
 
 
-        /** @var \Tripod\Mongo\Views $view */
+        /** @var \Tripod\Mongo\Composites\Views $view */
         $view = $mockTripod->getComposite(OP_VIEWS);
-        $this->assertInstanceOf('\Tripod\Mongo\Views', $view);
+        $this->assertInstanceOf('\Tripod\Mongo\Composites\Views', $view);
 
         $impactedSubjects = $view->getImpactedSubjects($updatedSubjectsAndPredicatesOfChange, $context);
 
@@ -1223,7 +1223,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
      */
     public function testSavingMultipleNewEntitiesResultsInOneImpactedSubject()
     {
-        $tripod = $this->getMockBuilder('\Tripod\Mongo\Tripod')
+        $tripod = $this->getMockBuilder('\Tripod\Mongo\Driver')
             ->setMethods(array('getDataUpdater'))
             ->setConstructorArgs(
                 array(
@@ -1291,7 +1291,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         );
         $tripod->saveChanges(new \Tripod\Mongo\MongoGraph(), $g);
 
-        /** @var \Tripod\Mongo\Views $views */
+        /** @var \Tripod\Mongo\Composites\Views $views */
         $views = $tripod->getComposite(OP_VIEWS);
 
         $expectedImpactedSubjects = array(

--- a/test/unit/mongo/TriplesUtilTest.php
+++ b/test/unit/mongo/TriplesUtilTest.php
@@ -12,7 +12,7 @@ class TriplesUtilTest extends MongoTripodTestBase
 
     public function testGetTArrayAbout()
     {
-        $tu = new TriplesUtil();
+        $tu = new \Tripod\Mongo\TriplesUtil();
         $triples = array();
 
         $triples[] = "<http://serials.talisaspire.com/issn/0893-0465> <http://xmlns.com/foaf/0.1/page> <http://www.ingentaconnect.com/content/bpl/ciso> . ";

--- a/test/unit/mongo/TriplesUtilTest.php
+++ b/test/unit/mongo/TriplesUtilTest.php
@@ -1,6 +1,6 @@
 <?php
 require_once 'MongoTripodTestBase.php';
-require_once 'src/mongo/MongoTripodConfig.class.php';
+require_once 'src/mongo/Config.class.php';
 require_once 'src/mongo/util/TriplesUtil.class.php';
 
 class TriplesUtilTest extends MongoTripodTestBase

--- a/test/unit/mongo/data/config.json
+++ b/test/unit/mongo/data/config.json
@@ -168,7 +168,7 @@
                 }
             ],
             "search_config": {
-                "search_provider": "MongoSearchProvider",
+                "search_provider": "\\Tripod\\Mongo\\MongoSearchProvider",
                 "search_specifications": [
                     {
                         "_id": "i_search_list",

--- a/test/unit/mongo/data/configQueueOperations.json
+++ b/test/unit/mongo/data/configQueueOperations.json
@@ -55,7 +55,7 @@
                 }
             ],
             "search_config":{
-                "search_provider":"MongoSearchProvider",
+                "search_provider":"\\Tripod\\Mongo\\MongoSearchProvider",
                 "search_specifications":[
                     {
                         "_id":"i_search_resource",


### PR DESCRIPTION
This branch introduces namespaces to Tripod.

Feel free to argue about which classes should go in which namespaces and how they should be named.

The way I've divided them up currently (although this is totally open for discussion) is:

` Tripod `
* ~~` ITripod `~~ ` IDriver `
* ` ITripodStat `
* ` ChangeSet `
* ` ExtendedGraph `
* ` Labeller `
* ` Timer `
* ~~` ITripodSearchProvider ` (perhaps could just be ` iSearchProvider `, thoughts?)~~ ` ISearchProvider ` (formerly ` iTripodSearchProvider `)

` Tripod\Mongo ` (btw, it will take *forever* to get used to this inversion)
* ~~` Tripod `~~ ` Driver ` (formerly ` MongoTripod `)
* ~~` TripodBase `~~ ` DriverBase ` (formerly ` MongoTripodBase `)
* ` MongoGraph `
* ` Labeller ` (formerly ` MongoTripodLabeller `)
* ` ImpactedSubject ` (in current master, this is ` ModifiedSubject `, but that concept has been changed in this feature)
* ` Config ` (formerly ` MongoTripodConfig `)
* ` TriplesUtil `
* ` IndexUtils `
* ` NQuadSerializer ` (formerly ` MongoTripodNQuadSerializer `)
* ` MongoSearchProvider ` (this wasn't renamed because this is defining a Mongo-based search provider)
* ` Updates ` (formerly ` MongoTripodUpdates `)
* ` TransactionLog ` (formerly ` MongoTransactionLog ` - this might have been a mistake, as it's probably more like ` MongoSearchProvider `)
* ` SearchDocuments ` (formerly ` MongoTripodSearchDocuments `)

` Tripod\Mongo\Composites `
* ` IComposite ` (views, tables, and search are now defined as *composites*, this is an interface common among all)
* ` CompositeBase `
* ` Views ` (formerly ` MongoTripodViews `.  ~~Do the composites need their own part of the namespace? I feel that might be overkill~~)
* ` Tables ` (formerly ` MongoTripodTables `)
* ` SearchIndexer ` (formerly ` MongoTripodSearchIndexer `)

` Tripod\Mongo\Jobs `
* ` ApplyOperation ` (this is the background job to generate the composites - ~~the jobs could arguably have their own ` Tripod\Mongo\Jobs ` namespace. Discuss~~ moved into their own package)
* ` DiscoverImpactedSubjects ` (same as above)
* ` JobBase ` (same)

` Tripod\Exceptions `
* ` Exception ` (formerly ` TripodException `)
* ` CardinalityException ` (formerly ` TripodCardinalityException `)
* ` ConfigException ` (now it's own file, previously was bundled with ` MongoTripodConfig ` as  ` MongoTripodConfigException `)
* ` LabellerException ` (formerly ` TripodLabellerException `)
* ` SearchException ` (formerly ` TripodSearchException `)
* ` ViewException ` (formerly ` TripodViewException ` - is this MongoTripod-specific?)
* ` TimerException `

Where class names changed, if they had any associated getter methods, these would have changed, as well.  This was kind of a big undertaking, so there may be some that were missed, so feel free to point any out that you might run across.

Also, as I was going through the classes that were imported from legacy libraries (e.g. ` ExtendedGraph `), I cleaned things up a bit, adding docblocks, removing unused (or broken) methods, etc.
