### PR TITLE
90%: Treat tables, views, and search differently

### DIFF
--- a/src/mongo/delegates/MongoTripodSearchIndexer.class.php
+++ b/src/mongo/delegates/MongoTripodSearchIndexer.class.php
@@ -4,7 +4,9 @@
     require_once TRIPOD_DIR . 'mongo/providers/MongoSearchProvider.class.php';
     require_once TRIPOD_DIR . 'exceptions/TripodSearchException.class.php';
 
-
+/**
+ * Class MongoTripodSearchIndexer
+ */
 class MongoTripodSearchIndexer extends MongoTripodBase implements SplObserver
 {
     private $tripod = null;
@@ -18,6 +20,9 @@ class MongoTripodSearchIndexer extends MongoTripodBase implements SplObserver
      */
     private $configuredProvider = null;
 
+    /**
+     * @param MongoTripod $tripod
+     */
     public function __construct(MongoTripod $tripod)
     {
         $this->tripod = $tripod;

--- a/src/mongo/delegates/MongoTripodTables.class.php
+++ b/src/mongo/delegates/MongoTripodTables.class.php
@@ -337,8 +337,9 @@ class MongoTripodTables extends MongoTripodBase implements SplObserver
             return null;
         }
 
-        // ensure both the ID field and the impactIndex indexes are correctly set up
+        // ensure that the ID field, view type, and the impactIndex indexes are correctly set up
         $collection->ensureIndex(array('_id.r'=>1, '_id.c'=>1,'_id.type'=>1),array('background'=>1));
+        $collection->ensureIndex(array('_id.type'=>1),array('background'=>1));
         $collection->ensureIndex(array('value.'._IMPACT_INDEX=>1),array('background'=>1));
 
         // ensure any custom view indexes

--- a/src/mongo/delegates/MongoTripodViews.class.php
+++ b/src/mongo/delegates/MongoTripodViews.class.php
@@ -324,8 +324,9 @@ class MongoTripodViews extends MongoTripodBase implements SplObserver
                 throw new TripodViewException('Could not find any joins in view specification - usecase better served with select()');
             }
 
-            // ensure both the ID field and the impactIndex indexes are correctly set up
+            // ensure that the ID field, view type, and the impactIndex indexes are correctly set up
             $collection->ensureIndex(array('_id.r'=>1, '_id.c'=>1,'_id.type'=>1),array('background'=>1));
+            $collection->ensureIndex(array('_id.type'=>1),array('background'=>1));
             $collection->ensureIndex(array('value.'._IMPACT_INDEX=>1),array('background'=>1));
 
             // ensure any custom view indexes

--- a/src/mongo/util/IndexUtils.class.php
+++ b/src/mongo/util/IndexUtils.class.php
@@ -1,31 +1,37 @@
 <?php
 require_once(TRIPOD_DIR."mongo/MongoTripodConfig.class.php");
 
+/**
+ * Class IndexUtils
+ */
 class IndexUtils
 {
     /**
-     * Ensures the index for the given $dbName. As a consequence, sets the global
+     * Ensures the index for the given $storeName. As a consequence, sets the global
      * MongoCursor timeout to -1 for this thread, so use with caution from anything
      * other than a setup script
      * @param bool $reindex - force a reindex of existing data
-     * @param null $dbName - database name to ensure indexes for
+     * @param null $storeName - database name to ensure indexes for
      * @param bool $background - index in the background (default) or lock DB whilst indexing
      */
-    public function ensureIndexes($reindex=false,$dbName=null,$background=true)
+    public function ensureIndexes($reindex=false,$storeName=null,$background=true)
     {
         //MongoCursor::$timeout = -1; // set this otherwise you'll see timeout errors for large indexes
-
         $config = MongoTripodConfig::getInstance();
-        $dbs = ($dbName==null) ? $config->getDbs() : array($dbName);
-        foreach ($dbs as $dbName)
+        $dbs = ($storeName==null) ? $config->getDbs() : array($storeName);
+        foreach ($dbs as $storeName)
         {
-            $collections = MongoTripodConfig::getInstance()->getIndexesGroupedByCollection($dbName);
+            $collections = MongoTripodConfig::getInstance()->getIndexesGroupedByCollection($storeName);
             foreach ($collections as $collectionName=>$indexes)
             {
-
+                // Don't do this for composites, which could be anywhere
+                if(in_array($collectionName, array(TABLE_ROWS_COLLECTION,VIEWS_COLLECTION,SEARCH_INDEX_COLLECTION)))
+                {
+                    continue;
+                }
                 if ($reindex)
                 {
-                    $config->getCollectionForCBD($dbName, $collectionName)->deleteIndexes();
+                    $config->getCollectionForCBD($storeName, $collectionName)->deleteIndexes();
                 }
                 foreach ($indexes as $indexName=>$fields)
                 {
@@ -33,25 +39,51 @@ class IndexUtils
                     if (is_numeric($indexName))
                     {
                         // no name
-                        $config->getCollectionForCBD($dbName, $collectionName)->ensureIndex($fields,array("background"=>$background));
+                        $config->getCollectionForCBD($storeName, $collectionName)->ensureIndex($fields,array("background"=>$background));
                     }
                     else
                     {
-                        $config->getCollectionForCBD($dbName, $collectionName)->ensureIndex($fields,array('name'=>$indexName,"background"=>$background));
+                        $config->getCollectionForCBD($storeName, $collectionName)->ensureIndex($fields,array('name'=>$indexName,"background"=>$background));
                     }
                 }
             }
-            // finally, for views, make sure type is indexed
-            $dataSources = array();
-            foreach($config->getViewSpecifications($dbName) as $viewId=>$spec)
+
+            // Index views
+            foreach($config->getViewSpecifications($storeName) as $viewId=>$spec)
             {
-                $dataSources[] = $spec['to'];
+                $collection = MongoTripodConfig::getInstance()->getCollectionForView($storeName, $viewId);
+                if($collection)
+                {
+                    $indexes = array("_id.type"=>1);
+                    if(isset($spec['ensureIndexes']))
+                    {
+                        $indexes = array_merge($indexes, $spec['ensureIndexes']);
+                    }
+                    if ($reindex)
+                    {
+                        $collection->deleteIndexes();
+                    }
+                    $collection->ensureIndex($indexes, array("background"=>$background));
+                }
             }
-            foreach(array_unique($dataSources) as $dataSource)
+
+            // Index table rows
+            foreach($config->getTableSpecifications($storeName) as $tableId=>$spec)
             {
-                $config->getDatabase($dbName, $dataSource)
-                    ->selectCollection(VIEWS_COLLECTION)
-                    ->ensureIndex(array("_id.type"=>1),array("background"=>$background));
+                $collection = MongoTripodConfig::getInstance()->getCollectionForTable($storeName, $tableId);
+                if($collection)
+                {
+                    $indexes = array("_id.type"=>1);
+                    if(isset($spec['ensureIndexes']))
+                    {
+                        $indexes = array_merge($indexes, $spec['ensureIndexes']);
+                    }
+                    if ($reindex)
+                    {
+                        $collection->deleteIndexes();
+                    }
+                    $collection->ensureIndex($indexes, array("background"=>$background));
+                }
             }
         }
     }


### PR DESCRIPTION
I found when working on #56 that IndexUtils wasn't properly updated to deal with multiple datasources, which causes failures when it runs across tablespecs, viewspecs, and search document specs.

This branch excludes views, search, and table indexes from the regular index regeneration process and then specifically handles views and table rows (search indexes are done via some other mechanism).