### PR TITLE
90%: Apply operation multiple subjects

### DIFF
--- a/scripts/mongo/createSearchDocuments.php
+++ b/scripts/mongo/createSearchDocuments.php
@@ -81,10 +81,6 @@ require_once $tripodBasePath . '/src/tripod.inc.php';
 function generateSearchDocuments($id, $specId, $storeName, $stat = null, $queue = null)
 {
     $spec = \Tripod\Mongo\Config::getInstance()->getSearchDocumentSpecification($storeName, $specId);
-    if(empty($spec)) // Older version of Tripod being used?
-    {
-        $spec = \Tripod\Mongo\Config::getInstance()->getSearchDocumentSpecification($specId);
-    }
     if (array_key_exists("from",$spec))
     {
         MongoCursor::$timeout = -1;

--- a/scripts/mongo/createSearchDocuments.php
+++ b/scripts/mongo/createSearchDocuments.php
@@ -142,7 +142,7 @@ if(isset($options['a']) || isset($options['async']))
     }
     else
     {
-        $queue = MongoTripodConfig::getInstance()->getApplyQueueName();
+        $queue = \Tripod\Mongo\Config::getInstance()->getApplyQueueName();
     }
 }
 

--- a/scripts/mongo/createTables.php
+++ b/scripts/mongo/createTables.php
@@ -82,10 +82,6 @@ require_once $tripodBasePath . '/src/tripod.inc.php';
 function generateTables($id, $tableId, $storeName, $stat = null, $queue = null)
 {
     $tableSpec = \Tripod\Mongo\Config::getInstance()->getTableSpecification($storeName, $tableId);
-    if(empty($tableSpec)) // Older version of Tripod being used?
-    {
-        $tableSpec = \Tripod\Mongo\Config::getInstance()->getTableSpecification($tableId);
-    }
     if (array_key_exists("from",$tableSpec))
     {
         MongoCursor::$timeout = -1;

--- a/scripts/mongo/createViews.php
+++ b/scripts/mongo/createViews.php
@@ -81,11 +81,6 @@ require_once $tripodBasePath . '/src/tripod.inc.php';
 function generateViews($id, $viewId, $storeName, $stat, $queue)
 {
     $viewSpec = \Tripod\Mongo\Config::getInstance()->getViewSpecification($storeName, $viewId);
-    if(empty($viewSpec)) // Older version of Tripod being used?
-    {
-        $viewSpec = \Tripod\Mongo\Config::getInstance()->getViewSpecification($viewId);
-    }
-    echo $viewId;
     if (array_key_exists("from",$viewSpec))
     {
         MongoCursor::$timeout = -1;

--- a/scripts/mongo/createViews.php
+++ b/scripts/mongo/createViews.php
@@ -142,7 +142,7 @@ if(isset($options['a']) || isset($options['async']))
     }
     else
     {
-        $queue = MongoTripodConfig::getInstance()->getApplyQueueName();
+        $queue = \Tripod\Mongo\Config::getInstance()->getApplyQueueName();
     }
 }
 

--- a/src/mongo/delegates/SearchIndexer.class.php
+++ b/src/mongo/delegates/SearchIndexer.class.php
@@ -214,7 +214,7 @@ class SearchIndexer extends CompositeBase
                     array($searchDocumentType)
                 );
 
-                $this->getApplyOperation()->createJob($subject, $queueName);
+                $this->getApplyOperation()->createJob(array($subject), $queueName);
             }
             else
             {

--- a/src/mongo/delegates/Tables.class.php
+++ b/src/mongo/delegates/Tables.class.php
@@ -526,7 +526,7 @@ class Tables extends CompositeBase
                     $from,
                     array($tableType)
                 );
-                $this->getApplyOperation()->createJob($subject, $queueName);
+                $this->getApplyOperation()->createJob(array($subject), $queueName);
             }
             else
             {

--- a/src/mongo/delegates/Views.class.php
+++ b/src/mongo/delegates/Views.class.php
@@ -444,7 +444,7 @@ class Views extends CompositeBase
                         array($viewId)
                     );
 
-                    $this->getApplyOperation()->createJob($subject, $queueName);
+                    $this->getApplyOperation()->createJob(array($subject), $queueName);
                 }
                 else
                 {

--- a/src/mongo/jobs/ApplyOperation.class.php
+++ b/src/mongo/jobs/ApplyOperation.class.php
@@ -56,13 +56,8 @@ class ApplyOperation extends JobBase {
             $queueName = \Tripod\Mongo\Config::getApplyQueueName();
         }
 
-        $subjectArray = array();
-        foreach($subjects as $subject)
-        {
-            $subjectArray[] = $subject->toArray();
-        }
         $data = array(
-            "subjects"=>$subjectArray,
+            "subjects"=>array_map(function(\Tripod\Mongo\ImpactedSubject $subject) { return $subject->toArray(); }, $subjects),
             "tripodConfig"=>\Tripod\Mongo\Config::getConfig()
         );
 

--- a/src/mongo/jobs/ApplyOperation.class.php
+++ b/src/mongo/jobs/ApplyOperation.class.php
@@ -56,8 +56,13 @@ class ApplyOperation extends JobBase {
             $queueName = \Tripod\Mongo\Config::getApplyQueueName();
         }
 
+        $subjectArray = array();
+        foreach($subjects as $subject)
+        {
+            $subjectArray[] = $subject->toArray();
+        }
         $data = array(
-            "subjects"=>array_walk($subjects, function(\Tripod\Mongo\ImpactedSubject $subject) { return $subject->toArray(); }),
+            "subjects"=>$subjectArray,
             "tripodConfig"=>\Tripod\Mongo\Config::getConfig()
         );
 

--- a/src/mongo/jobs/ApplyOperation.class.php
+++ b/src/mongo/jobs/ApplyOperation.class.php
@@ -25,9 +25,12 @@ class ApplyOperation extends JobBase {
             // set the config to what is received
             \Tripod\Mongo\Config::setConfig($this->args["tripodConfig"]);
 
-            $subject = $this->createImpactedSubject($this->args['subject']);
+            foreach($this->args['subjects'] as $subject)
+            {
+                $impactedSubject = $this->createImpactedSubject($subject);
+                $impactedSubject->update();
+            }
 
-            $subject->update();
 
             $timer->stop();
             // stat time taken to process item, from time it was created (queued)
@@ -43,17 +46,18 @@ class ApplyOperation extends JobBase {
     }
 
     /**
-     * @param \Tripod\Mongo\ImpactedSubject $subject
+     * @param \Tripod\Mongo\ImpactedSubject[] $subjects
      * @param string|null $queueName
      */
-    public function createJob(\Tripod\Mongo\ImpactedSubject $subject, $queueName=null)
+    public function createJob(Array $subjects, $queueName=null)
     {
         if(!$queueName)
         {
             $queueName = \Tripod\Mongo\Config::getApplyQueueName();
         }
+
         $data = array(
-            "subject"=>$subject->toArray(),
+            "subjects"=>array_walk($subjects, function(\Tripod\Mongo\ImpactedSubject $subject) { return $subject->toArray(); }),
             "tripodConfig"=>\Tripod\Mongo\Config::getConfig()
         );
 
@@ -82,6 +86,6 @@ class ApplyOperation extends JobBase {
      */
     protected function getMandatoryArgs()
     {
-        return array("tripodConfig","subject");
+        return array("tripodConfig","subjects");
     }
 }

--- a/src/mongo/jobs/DiscoverImpactedSubjects.class.php
+++ b/src/mongo/jobs/DiscoverImpactedSubjects.class.php
@@ -41,7 +41,6 @@ class DiscoverImpactedSubjects extends JobBase {
             $tripod = $this->getTripod($this->args["storeName"],$this->args["podName"]);
 
             $operations = $this->args['operations'];
-            $modifiedSubjects = array();
 
             $subjectsAndPredicatesOfChange = $this->args['changes'];
 
@@ -49,7 +48,7 @@ class DiscoverImpactedSubjects extends JobBase {
             {
                 /** @var \Tripod\Mongo\Composites\IComposite $composite */
                 $composite = $tripod->getComposite($op);
-                $modifiedSubjects = array_merge($modifiedSubjects,$composite->getImpactedSubjects($subjectsAndPredicatesOfChange,$this->args['contextAlias']));
+                $modifiedSubjects = $composite->getImpactedSubjects($subjectsAndPredicatesOfChange,$this->args['contextAlias']);
                 if(!empty($modifiedSubjects)){
                     /* @var $subject \Tripod\Mongo\ImpactedSubject */
                     foreach ($modifiedSubjects as $subject) {

--- a/src/mongo/jobs/DiscoverImpactedSubjects.class.php
+++ b/src/mongo/jobs/DiscoverImpactedSubjects.class.php
@@ -47,72 +47,72 @@ class DiscoverImpactedSubjects extends JobBase {
 
             foreach($operations as $op)
             {
+                /** @var \Tripod\Mongo\Composites\IComposite $composite */
                 $composite = $tripod->getComposite($op);
                 $modifiedSubjects = array_merge($modifiedSubjects,$composite->getImpactedSubjects($subjectsAndPredicatesOfChange,$this->args['contextAlias']));
-            }
-
-            if(!empty($modifiedSubjects)){
-                /* @var $subject \Tripod\Mongo\ImpactedSubject */
-                foreach ($modifiedSubjects as $subject) {
-                    if(isset($this->args['queue']) || count($subject->getSpecTypes()) == 0)
-                    {
-                        $queueName = (isset($this->args['queue']) ? $this->args['queue'] : Config::getApplyQueueName());
-                        $this->addSubjectToQueue($subject, $queueName);
-                    }
-                    else
-                    {
-                        $specsGroupedByQueue = array();
-                        foreach($subject->getSpecTypes() as $specType)
+                if(!empty($modifiedSubjects)){
+                    /* @var $subject \Tripod\Mongo\ImpactedSubject */
+                    foreach ($modifiedSubjects as $subject) {
+                        if(isset($this->args['queue']) || count($subject->getSpecTypes()) == 0)
                         {
-                            $spec = null;
-                            switch($subject->getOperation())
+                            $queueName = (isset($this->args['queue']) ? $this->args['queue'] : Config::getApplyQueueName());
+                            $this->addSubjectToQueue($subject, $queueName);
+                        }
+                        else
+                        {
+                            $specsGroupedByQueue = array();
+                            foreach($subject->getSpecTypes() as $specType)
                             {
-                                case OP_VIEWS:
-                                    $spec = Config::getInstance()->getViewSpecification($this->args["storeName"], $specType);
-                                    break;
-                                case OP_TABLES:
-                                    $spec = Config::getInstance()->getTableSpecification($this->args["storeName"], $specType);
-                                    break;
-                                case OP_SEARCH:
-                                    $spec = Config::getInstance()->getSearchDocumentSpecification($this->args["storeName"], $specType);
-                                    break;
-                            }
-                            if(!$spec || !isset($spec['queue']))
-                            {
-                                if(!$spec)
+                                $spec = null;
+                                switch($subject->getOperation())
                                 {
-                                    $spec = array();
+                                    case OP_VIEWS:
+                                        $spec = Config::getInstance()->getViewSpecification($this->args["storeName"], $specType);
+                                        break;
+                                    case OP_TABLES:
+                                        $spec = Config::getInstance()->getTableSpecification($this->args["storeName"], $specType);
+                                        break;
+                                    case OP_SEARCH:
+                                        $spec = Config::getInstance()->getSearchDocumentSpecification($this->args["storeName"], $specType);
+                                        break;
                                 }
-                                $spec['queue'] = Config::getApplyQueueName();
+                                if(!$spec || !isset($spec['queue']))
+                                {
+                                    if(!$spec)
+                                    {
+                                        $spec = array();
+                                    }
+                                    $spec['queue'] = Config::getApplyQueueName();
+                                }
+                                if(!isset($specsGroupedByQueue[$spec['queue']]))
+                                {
+                                    $specsGroupedByQueue[$spec['queue']] = array();
+                                }
+                                $specsGroupedByQueue[$spec['queue']][] = $specType;
                             }
-                            if(!isset($specsGroupedByQueue[$spec['queue']]))
+
+                            foreach($specsGroupedByQueue as $queueName=>$specs)
                             {
-                                $specsGroupedByQueue[$spec['queue']] = array();
+                                $queuedSubject = new \Tripod\Mongo\ImpactedSubject(
+                                    $subject->getResourceId(),
+                                    $subject->getOperation(),
+                                    $subject->getStoreName(),
+                                    $subject->getPodName(),
+                                    $specs
+                                );
+
+                                $this->addSubjectToQueue($queuedSubject, $queueName);
                             }
-                            $specsGroupedByQueue[$spec['queue']][] = $specType;
-                        }
-
-                        foreach($specsGroupedByQueue as $queueName=>$specs)
-                        {
-                            $queuedSubject = new \Tripod\Mongo\ImpactedSubject(
-                                $subject->getResourceId(),
-                                $subject->getOperation(),
-                                $subject->getStoreName(),
-                                $subject->getPodName(),
-                                $specs
-                            );
-
-                            $this->addSubjectToQueue($queuedSubject, $queueName);
                         }
                     }
-                }
-                if(!empty($this->subjectsGroupedByQueue))
-                {
-                    foreach($this->subjectsGroupedByQueue as $queueName=>$subjects)
+                    if(!empty($this->subjectsGroupedByQueue))
                     {
-                        $this->getApplyOperation()->createJob($subjects, $queueName);
+                        foreach($this->subjectsGroupedByQueue as $queueName=>$subjects)
+                        {
+                            $this->getApplyOperation()->createJob($subjects, $queueName);
+                        }
+                        $this->subjectsGroupedByQueue = array();
                     }
-                    $this->subjectsGroupedByQueue = array();
                 }
             }
 

--- a/test/unit/mongo/ApplyOperationTest.php
+++ b/test/unit/mongo/ApplyOperationTest.php
@@ -22,10 +22,10 @@ class ApplyOperationTest extends MongoTripodTestBase
     public function testMandatoryArgSubject()
     {
         $this->setArgs();
-        unset($this->args['subject']);
+        unset($this->args['subjects']);
         $job = new \Tripod\Mongo\Jobs\ApplyOperation();
         $job->args = $this->args;
-        $this->setExpectedException('Exception', "Argument subject was not present in supplied job args for job Tripod\Mongo\Jobs\ApplyOperation");
+        $this->setExpectedException('Exception', "Argument subjects was not present in supplied job args for job Tripod\Mongo\Jobs\ApplyOperation");
         $job->perform();
     }
 
@@ -231,7 +231,7 @@ class ApplyOperationTest extends MongoTripodTestBase
         );
 
         $jobData = array(
-            'subject'=>$impactedSubject->toArray(),
+            'subjects'=>array($impactedSubject->toArray()),
             'tripodConfig'=>\Tripod\Mongo\Config::getConfig(),
         );
 
@@ -249,7 +249,7 @@ class ApplyOperationTest extends MongoTripodTestBase
                 $jobData
             );
 
-        $applyOperation->createJob($impactedSubject);
+        $applyOperation->createJob(array($impactedSubject));
     }
 
     public function testCreateJobSpecifyQueue()
@@ -263,7 +263,7 @@ class ApplyOperationTest extends MongoTripodTestBase
         );
 
         $jobData = array(
-            'subject'=>$impactedSubject->toArray(),
+            'subjects'=>array($impactedSubject->toArray()),
             'tripodConfig'=>\Tripod\Mongo\Config::getConfig(),
         );
 
@@ -283,7 +283,7 @@ class ApplyOperationTest extends MongoTripodTestBase
                 $jobData
             );
 
-        $applyOperation->createJob($impactedSubject, $queueName);
+        $applyOperation->createJob(array($impactedSubject), $queueName);
     }
 
     protected function setArgs()
@@ -300,7 +300,7 @@ class ApplyOperationTest extends MongoTripodTestBase
 
         $this->args = array(
             'tripodConfig'=>\Tripod\Mongo\Config::getConfig(),
-            'subject'=>$subject->toArray()
+            'subjects'=>array($subject->toArray())
         );
     }
 }

--- a/test/unit/mongo/DiscoverImpactedSubjectsTest.php
+++ b/test/unit/mongo/DiscoverImpactedSubjectsTest.php
@@ -173,11 +173,11 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
             ->method('createJob')
             ->withConsecutive(
                 array(
-                    $viewSubject,
+                    array($viewSubject),
                     \Tripod\Mongo\Config::getApplyQueueName()
                 ),
                 array(
-                    $tableSubject,
+                   array($tableSubject),
                     \Tripod\Mongo\Config::getApplyQueueName()
                 )
             );
@@ -365,11 +365,11 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
             ->method('createJob')
             ->withConsecutive(
                 array(
-                    $viewSubject,
+                    array($viewSubject),
                     $args['queue']
                 ),
                 array(
-                    $tableSubject,
+                    array($tableSubject),
                     $args['queue']
                 )
             );
@@ -556,15 +556,15 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
             ->method('createJob')
             ->withConsecutive(
                 array(
-                    $queuedTable1,
+                    array($queuedTable1),
                     \Tripod\Mongo\Config::getApplyQueueName()
                 ),
                 array(
-                    $queuedTable2,
+                    array($queuedTable2),
                     "counts_and_other_non_essentials"
                 ),
                 array(
-                    $queuedTable3,
+                    array($queuedTable3),
                     "MOST_IMPORTANT_QUEUE_EVER"
                 )
             );
@@ -720,7 +720,7 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
             ->method('createJob')
             ->withConsecutive(
                 array(
-                    $tableSubject,
+                    array($tableSubject),
                     $args['queue']
                 )
             );


### PR DESCRIPTION
This branch refactors ApplyOperation somewhat so that it works with an array of ImpactedSubjects rather than just one.  This produces a massive performance benefit by requiring fewer forked processes for every DiscoverImpactedSubjects job submitted.