### PR TITLE
50%: Only return spec fields in composite generation

### DIFF
--- a/src/mongo/Config.class.php
+++ b/src/mongo/Config.class.php
@@ -91,7 +91,7 @@ class Config
      *
      * @var array
      */
-    protected $specPredicates;
+    protected $specPredicates = array("_stores"=>array());
 
     /**
      * @var array
@@ -788,25 +788,19 @@ class Config
      */
     protected function getDefinedPredicatesInSpecs($storename)
     {
-        $predicates = array();
-        $specs = array_merge($this->getTableSpecifications($storename), $this->getSearchDocumentSpecifications($storename));
-        foreach($specs as $spec)
+        if(!isset($this->specPredicates["_stores"][$storename]))
         {
-            if(!isset($spec[_ID_KEY]))
-            {
-                continue;
-            }
-            if(isset($this->specPredicates[$spec[_ID_KEY]]))
-            {
-                $predicates[$spec[_ID_KEY]] = $this->specPredicates[$spec[_ID_KEY]];
-            }
-            else
-            {
-                $predicates[$spec[_ID_KEY]] = array_unique($this->getDefinedPredicatesInSpecBlock($spec, true));
-            }
-        }
 
-        return $predicates;
+            $this->specPredicates["_stores"][$storename] = array();
+
+            $specs = array_merge($this->getTableSpecifications($storename), $this->getSearchDocumentSpecifications($storename));
+            foreach($specs as $spec)
+            {
+                $this->specPredicates["_stores"][$storename][$spec[_ID_KEY]] = array_unique($this->getDefinedPredicatesInSpecBlock($spec, true));
+            }
+
+        }
+        return $this->specPredicates["_stores"][$storename];
     }
 
     /**
@@ -815,7 +809,7 @@ class Config
      * @param bool $recursive
      * @return array
      */
-    public function getDefinedPredicatesInSpecBlock(array $block, $recursive=false)
+    protected function getDefinedPredicatesInSpecBlock(array $block, $recursive=false)
     {
         $specBlockKey = crc32(json_encode($block));
         if(isset($this->specPredicates[$specBlockKey]))
@@ -1048,13 +1042,13 @@ class Config
      */
     public function getDefinedPredicatesInSpec($storename, $specId)
     {
-        if(!isset($this->specPredicates[$storename]))
+        if(!isset($this->specPredicates["_stores"][$storename]))
         {
-            $this->specPredicates[$storename] = $this->getDefinedPredicatesInSpecs($storename);
+            $this->getDefinedPredicatesInSpecs($storename);
         }
-        if(isset($this->specPredicates[$storename][$specId]))
+        if(isset($this->specPredicates["_stores"][$storename][$specId]))
         {
-            return $this->specPredicates[$storename][$specId];
+            return $this->specPredicates["_stores"][$storename][$specId];
         }
         return array();
     }

--- a/src/mongo/base/CompositeBase.class.php
+++ b/src/mongo/base/CompositeBase.class.php
@@ -165,7 +165,7 @@ abstract class CompositeBase extends \Tripod\Mongo\DriverBase implements \Tripod
         if(!empty($intersectingTypes))
         {
             // Views should always invalidate
-            if($this instanceof \Tripod\Mongo\Views)
+            if($this instanceof \Tripod\Mongo\Composites\Views)
             {
                 return true;
             }

--- a/src/mongo/delegates/SearchDocuments.class.php
+++ b/src/mongo/delegates/SearchDocuments.class.php
@@ -97,7 +97,8 @@ class SearchDocuments extends DriverBase
             'c'=>$this->labeller->uri_to_alias($context)
         );
 
-        $sourceDocument = Config::getInstance()->getCollectionForCBD($this->storeName, $from)->findOne(array('_id'=>$_id));
+        $fields = $this->getConfigInstance()->getFieldsDefinedInSpecBlock($searchSpec);
+        $sourceDocument = Config::getInstance()->getCollectionForCBD($this->storeName, $from)->findOne(array('_id'=>$_id), $fields);
 
         if(empty($sourceDocument)){
             $this->debugLog("Source document not found for $resource, cannot proceed");
@@ -206,7 +207,9 @@ class SearchDocuments extends DriverBase
                     : $config->getCollectionForCBD($this->storeName, $from)
                 );
 
-                $cursor = $collection->find(array('_id'=>array('$in'=>$joinUris)));
+                $fields = $this->getConfigInstance()->getFieldsDefinedInSpecBlock($rules);
+
+                $cursor = $collection->find(array('_id'=>array('$in'=>$joinUris)), $fields);
                 // add to impact index
                 $this->addIdToImpactIndex($joinUris, $target);
                 foreach($cursor as $linkMatch)

--- a/src/mongo/delegates/SearchDocuments.class.php
+++ b/src/mongo/delegates/SearchDocuments.class.php
@@ -97,7 +97,8 @@ class SearchDocuments extends DriverBase
             'c'=>$this->labeller->uri_to_alias($context)
         );
 
-        $fields = $this->getConfigInstance()->getFieldsDefinedInSpecBlock($searchSpec);
+        $fields = $this->getConfigInstance()->getMongoFieldsForSpecBlock($searchSpec);
+
         $sourceDocument = Config::getInstance()->getCollectionForCBD($this->storeName, $from)->findOne(array('_id'=>$_id), $fields);
 
         if(empty($sourceDocument)){
@@ -207,7 +208,7 @@ class SearchDocuments extends DriverBase
                     : $config->getCollectionForCBD($this->storeName, $from)
                 );
 
-                $fields = $this->getConfigInstance()->getFieldsDefinedInSpecBlock($rules);
+                $fields = $this->getConfigInstance()->getMongoFieldsForSpecBlock($rules);
 
                 $cursor = $collection->find(array('_id'=>array('$in'=>$joinUris)), $fields);
                 // add to impact index

--- a/src/mongo/delegates/Tables.class.php
+++ b/src/mongo/delegates/Tables.class.php
@@ -514,7 +514,8 @@ class Tables extends CompositeBase
             $filter["_id"] = array(_ID_RESOURCE=>$this->labeller->uri_to_alias($resource),_ID_CONTEXT=>$contextAlias);
         }
 
-        $fields = $this->getConfigInstance()->getFieldsDefinedInSpecBlock($tableSpec);
+        $fields = $this->getConfigInstance()->getMongoFieldsForSpecBlock($tableSpec);
+
         $docs = $this->config->getCollectionForCBD($this->storeName, $from)->find($filter, $fields);
         foreach ($docs as $doc)
         {
@@ -530,7 +531,7 @@ class Tables extends CompositeBase
 
                 $this->submitJob($queueName, 'ApplyOperation', array(
                     "subject"=>$subject->toArray(),
-                    "tripodConfig"=>MongoTripodConfig::getConfig()
+                    "tripodConfig"=>\Tripod\Mongo\Config::getConfig()
                 ));
             }
             else
@@ -1165,7 +1166,8 @@ class Tables extends CompositeBase
                     : $this->config->getCollectionForCBD($this->storeName, $from)
                 );
 
-                $fields = $this->getConfigInstance()->getFieldsDefinedInSpecBlock($ruleset);
+                $fields = $this->getConfigInstance()->getMongoFieldsForSpecBlock($ruleset);
+
                 $cursor = $collection->find(array('_id'=>array('$in'=>$joinUris)), $fields);
 
                 $this->addIdToImpactIndex($joinUris, $dest);

--- a/src/mongo/delegates/Tables.class.php
+++ b/src/mongo/delegates/Tables.class.php
@@ -514,7 +514,8 @@ class Tables extends CompositeBase
             $filter["_id"] = array(_ID_RESOURCE=>$this->labeller->uri_to_alias($resource),_ID_CONTEXT=>$contextAlias);
         }
 
-        $docs = $this->config->getCollectionForCBD($this->storeName, $from)->find($filter);
+        $fields = $this->getConfigInstance()->getFieldsDefinedInSpecBlock($tableSpec);
+        $docs = $this->config->getCollectionForCBD($this->storeName, $from)->find($filter, $fields);
         foreach ($docs as $doc)
         {
             if($queueName && !$resource)
@@ -1163,7 +1164,9 @@ class Tables extends CompositeBase
                     ? $this->config->getCollectionForCBD($this->storeName, $ruleset['from'])
                     : $this->config->getCollectionForCBD($this->storeName, $from)
                 );
-                $cursor = $collection->find(array('_id'=>array('$in'=>$joinUris)));
+
+                $fields = $this->getConfigInstance()->getFieldsDefinedInSpecBlock($ruleset);
+                $cursor = $collection->find(array('_id'=>array('$in'=>$joinUris)), $fields);
 
                 $this->addIdToImpactIndex($joinUris, $dest);
                 foreach($cursor as $linkMatch) {

--- a/src/mongo/delegates/Views.class.php
+++ b/src/mongo/delegates/Views.class.php
@@ -431,7 +431,8 @@ class Views extends CompositeBase
                 $filter["_id"] = array(_ID_RESOURCE=>$resourceAlias,_ID_CONTEXT=>$contextAlias);
             }
 
-            $docs = $this->config->getCollectionForCBD($this->storeName, $from)->find($filter);
+            $fields = $this->getConfigInstance()->getFieldsDefinedInSpecBlock($viewSpec);
+            $docs = $this->config->getCollectionForCBD($this->storeName, $from)->find($filter, $fields);
             foreach ($docs as $doc)
             {
                 if($queueName && !$resource)
@@ -542,7 +543,8 @@ class Views extends CompositeBase
                     ? $this->config->getCollectionForCBD($this->storeName, $ruleset['from'])
                     : $this->config->getCollectionForCBD($this->storeName, $from)
                 );
-                $cursor = $collection->find(array('_id'=>array('$in'=>$joinUris)));
+                $fields = $this->getConfigInstance()->getFieldsDefinedInSpecBlock($ruleset);
+                $cursor = $collection->find(array('_id'=>array('$in'=>$joinUris)), $fields);
                 foreach($cursor as $linkMatch) {
                     // if there is a condition, check it...
                     if (isset($ruleset['condition']))

--- a/src/mongo/delegates/Views.class.php
+++ b/src/mongo/delegates/Views.class.php
@@ -431,7 +431,8 @@ class Views extends CompositeBase
                 $filter["_id"] = array(_ID_RESOURCE=>$resourceAlias,_ID_CONTEXT=>$contextAlias);
             }
 
-            $fields = $this->getConfigInstance()->getFieldsDefinedInSpecBlock($viewSpec);
+            $fields = $this->getConfigInstance()->getMongoFieldsForSpecBlock($viewSpec);
+
             $docs = $this->config->getCollectionForCBD($this->storeName, $from)->find($filter, $fields);
             foreach ($docs as $doc)
             {
@@ -543,7 +544,8 @@ class Views extends CompositeBase
                     ? $this->config->getCollectionForCBD($this->storeName, $ruleset['from'])
                     : $this->config->getCollectionForCBD($this->storeName, $from)
                 );
-                $fields = $this->getConfigInstance()->getFieldsDefinedInSpecBlock($ruleset);
+                $fields = $this->getConfigInstance()->getMongoFieldsForSpecBlock($ruleset);
+
                 $cursor = $collection->find(array('_id'=>array('$in'=>$joinUris)), $fields);
                 foreach($cursor as $linkMatch) {
                     // if there is a condition, check it...
@@ -556,7 +558,6 @@ class Views extends CompositeBase
                         if ($buildImpactIndex && !isset($dest[_IMPACT_INDEX])) $dest[_IMPACT_INDEX] = array();
 
                         // add linkMatch if there isn't already a graph for it in the dest obj
-//                        $addItemToImpactIndex = true;
                         if ($buildImpactIndex)
                         {
                             $dest[_IMPACT_INDEX][] = $linkMatch['_id'];


### PR DESCRIPTION
This branch reduces the amount of data returned from Mongo so that it only returns the fields that are defined in the composite specification during the generation of the composites
