### PR TITLE
90%: All queues (manually sent or defined in specs) should be namespaced

### DIFF
--- a/src/mongo/jobs/ApplyOperation.class.php
+++ b/src/mongo/jobs/ApplyOperation.class.php
@@ -57,6 +57,10 @@ class ApplyOperation extends JobBase {
         {
             $queueName = \Tripod\Mongo\Config::getApplyQueueName();
         }
+        elseif(strpos($queueName, \Tripod\Mongo\Config::getApplyQueueName()) === false)
+        {
+            $queueName = \Tripod\Mongo\Config::getApplyQueueName() . '::' . $queueName;
+        }
 
         $data = array(
             self::SUBJECTS_KEY=>array_map(function(\Tripod\Mongo\ImpactedSubject $subject) { return $subject->toArray(); }, $subjects),

--- a/src/mongo/jobs/DiscoverImpactedSubjects.class.php
+++ b/src/mongo/jobs/DiscoverImpactedSubjects.class.php
@@ -144,6 +144,10 @@ class DiscoverImpactedSubjects extends JobBase {
         {
             $queueName = Config::getDiscoverQueueName();
         }
+        elseif(strpos($queueName, \Tripod\Mongo\Config::getDiscoverQueueName()) === false)
+        {
+            $queueName = \Tripod\Mongo\Config::getDiscoverQueueName() . '::' . $queueName;
+        }
         $this->submitJob($queueName,get_class($this),$data);
     }
 

--- a/test/unit/mongo/ApplyOperationTest.php
+++ b/test/unit/mongo/ApplyOperationTest.php
@@ -273,7 +273,7 @@ class ApplyOperationTest extends MongoTripodTestBase
             ->setMockClassName('MockApplyOperation')
             ->getMock();
 
-        $queueName = 'TRIPOD_TESTING_QUEUE_' . uniqid();
+        $queueName = \Tripod\Mongo\Config::getApplyQueueName() . '::TRIPOD_TESTING_QUEUE_' . uniqid();
 
         $applyOperation->expects($this->once())
             ->method('submitJob')

--- a/test/unit/mongo/DiscoverImpactedSubjectsTest.php
+++ b/test/unit/mongo/DiscoverImpactedSubjectsTest.php
@@ -250,7 +250,7 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
             'contextAlias'=>'http://talisaspire.com/'
         );
 
-        $queueName = 'TRIPOD_TESTING_QUEUE_' . uniqid();
+        $queueName = \Tripod\Mongo\Config::getDiscoverQueueName() . '::TRIPOD_TESTING_QUEUE_' . uniqid();
 
         /** @var \Tripod\Mongo\Jobs\DiscoverImpactedSubjects|PHPUnit_Framework_MockObject_MockObject $discoverImpactedSubjects */
         $discoverImpactedSubjects = $this->getMockBuilder('\Tripod\Mongo\Jobs\DiscoverImpactedSubjects')


### PR DESCRIPTION
This change ensures that all operations queued through ` ApplyOperation->createJob() ` or DiscoverImpactedSubjects->createJob() ` either use the default queue names or are namespaced under the default queue name.

For example, if a specification contains the ‘queue’ attribute ‘wibble’, it will be placed either in:

` tripod::{$APP_ENV}::apply::wibble `
or
` tripod::apply::wibble `

(depending whether or not $APP_ENV is set)

If you manually set a queue on Tripod init:

```php
$tripod = new \Tripod\Mongo\Driver(‘CBD_foo’, ‘foo’, array(OP_ASYNC=>array(OP_QUEUE=>’foobar’));
```

operations would be sent to:

` tripod::$APP_ENV::discover::foobar `
` tripod::$APP_ENV::apply::foobar `

or 

` tripod::discover::foobar `
` tripod::apply::foobar `

if $APP_ENV isn’t set.