### PR TITLE
Removed socketTimout from ensureIndex to prevent upgrade clash 

### DIFF
--- a/src/mongo/delegates/SearchDocuments.class.php
+++ b/src/mongo/delegates/SearchDocuments.class.php
@@ -117,8 +117,7 @@ class SearchDocuments extends DriverBase
             ->ensureIndex(
                 array('_id.type'=>1),
                 array(
-                    'background'=>1,
-                    "socketTimeoutMS"=>\Tripod\Mongo\Config::getInstance()->getMongoCursorTimeout()
+                    'background'=>1
                 )
             );
 
@@ -128,8 +127,7 @@ class SearchDocuments extends DriverBase
             ->ensureIndex(
                 array('_impactIndex'=>1),
                 array(
-                    'background'=>1,
-                    "socketTimeoutMS"=>\Tripod\Mongo\Config::getInstance()->getMongoCursorTimeout()
+                    'background'=>1
                 )
             );
 

--- a/src/mongo/delegates/Tables.class.php
+++ b/src/mongo/delegates/Tables.class.php
@@ -486,8 +486,7 @@ class Tables extends CompositeBase
                 '_id.type'=>1
             ),
             array(
-                'background'=>1,
-                "socketTimeoutMS"=>\Tripod\Mongo\Config::getInstance()->getMongoCursorTimeout()
+                'background'=>1
             )
         );
 
@@ -496,8 +495,7 @@ class Tables extends CompositeBase
                 '_id.type'=>1
             ),
             array(
-                'background'=>1,
-                "socketTimeoutMS"=>\Tripod\Mongo\Config::getInstance()->getMongoCursorTimeout()
+                'background'=>1
             )
         );
 
@@ -506,8 +504,7 @@ class Tables extends CompositeBase
                 'value.'._IMPACT_INDEX=>1
             ),
             array(
-                'background'=>1,
-                "socketTimeoutMS"=>\Tripod\Mongo\Config::getInstance()->getMongoCursorTimeout()
+                'background'=>1
             )
         );
 
@@ -519,8 +516,7 @@ class Tables extends CompositeBase
                 $collection->ensureIndex(
                     $ensureIndex,
                     array(
-                        'background'=>1,
-                        "socketTimeoutMS"=>\Tripod\Mongo\Config::getInstance()->getMongoCursorTimeout()
+                        'background'=>1
                     )
                 );
             }

--- a/src/mongo/delegates/Views.class.php
+++ b/src/mongo/delegates/Views.class.php
@@ -410,8 +410,7 @@ class Views extends CompositeBase
                     '_id.type'=>1
                 ),
                 array(
-                    'background'=>1,
-                    "socketTimeoutMS"=>\Tripod\Mongo\Config::getInstance()->getMongoCursorTimeout()
+                    'background'=>1
                 )
             );
 
@@ -420,8 +419,7 @@ class Views extends CompositeBase
                     '_id.type'=>1
                 ),
                 array(
-                    'background'=>1,
-                    "socketTimeoutMS"=>\Tripod\Mongo\Config::getInstance()->getMongoCursorTimeout()
+                    'background'=>1
                 )
             );
 
@@ -430,8 +428,7 @@ class Views extends CompositeBase
                     'value.'._IMPACT_INDEX=>1
                 ),
                 array(
-                    'background'=>1,
-                    "socketTimeoutMS"=>\Tripod\Mongo\Config::getInstance()->getMongoCursorTimeout()
+                    'background'=>1
                 )
             );
 
@@ -443,8 +440,7 @@ class Views extends CompositeBase
                     $collection->ensureIndex(
                         $ensureIndex,
                         array(
-                            'background'=>1,
-                            "socketTimeoutMS"=>\Tripod\Mongo\Config::getInstance()->getMongoCursorTimeout()
+                            'background'=>1
                         )
                     );
                 }


### PR DESCRIPTION
The mongo PECL driver seems to dislike socketTimeoutMS preventing us from upgrading an existing DB to the latest version of tripod. This pull removes the socketTimeoutMS option from the Composites.