### PR TITLE
30% - Throw an exception if a resque job is not created sucessfully

### DIFF
--- a/src/exceptions/AsyncJobException.class.php
+++ b/src/exceptions/AsyncJobException.class.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tripod\Exceptions;
+
+require_once TRIPOD_DIR . '/exceptions/Exception.class.php';
+
+/**
+ * @codeCoverageIgnore
+ */
+class AsyncJobException extends Exception {
+
+    /**
+     * @param string $message
+     */
+    public function __construct($message)
+    {
+        parent::__construct("Async Job Exception: $message");
+    }
+}

--- a/src/mongo/base/JobBase.class.php
+++ b/src/mongo/base/JobBase.class.php
@@ -1,6 +1,9 @@
 <?php
 
 namespace Tripod\Mongo\Jobs;
+use Tripod\Exceptions\AsyncJobException;
+use Tripod\Exceptions\Exception;
+
 /**
  * Todo: How to inject correct stat class... :-S
  */
@@ -76,10 +79,15 @@ abstract class JobBase extends \Tripod\Mongo\DriverBase
      * @param string $queueName
      * @param string $class
      * @param array $data
+     * @throws AsyncJobException
      */
     protected function submitJob($queueName, $class, Array $data)
     {
-        \Resque::enqueue($queueName, $class, $data);
+        $id = \Resque::enqueue($queueName, $class, $data, true);
+        $status = new \Resque_Job_Status($id);
+        if($status->get() === false){
+            throw new AsyncJobException("Resque Job - $id - was not successfully created");
+        }
     }
 }
 


### PR DESCRIPTION
Currently if resque fails to create a job it will fail silently and tripod will continue regardless.  We are waiting for https://github.com/chrisboulton/php-resque/pull/229 to be merged into the php-resque master to resolve this properly, but in the meantime here is a workaround where we test the status of the job immediately after creation to check that it does not return false.