### PR TITLE
90% - Prevent null values being added to ExtendedGraph

### DIFF
--- a/src/classes/ExtendedGraph.class.php
+++ b/src/classes/ExtendedGraph.class.php
@@ -174,6 +174,7 @@ class ExtendedGraph
      * @param string $s
      * @param string $p
      * @param array $o_info
+     * @throws Exceptions\Exception
      * @return bool
      */
     private function _add_triple($s, $p, Array $o_info) {
@@ -186,19 +187,19 @@ class ExtendedGraph
         if(!$this->isValidResourceValue($p)){
             throw new \Tripod\Exceptions\Exception("The predicate is invalid");
         }
-            if (!isset($this->_index[$s])) {
-                $this->_index[$s] = array();
-                $this->_index[$s][$p] = array($o_info);
+        if (!isset($this->_index[$s])) {
+            $this->_index[$s] = array();
+            $this->_index[$s][$p] = array($o_info);
+            return true;
+        } elseif (!isset($this->_index[$s][$p])) {
+            $this->_index[$s][$p] = array($o_info);
+            return true;
+        } else {
+            if (!in_array($o_info, $this->_index[$s][$p])) {
+                $this->_index[$s][$p][] = $o_info;
                 return true;
-            } elseif (!isset($this->_index[$s][$p])) {
-                $this->_index[$s][$p] = array($o_info);
-                return true;
-            } else {
-                if (!in_array($o_info, $this->_index[$s][$p])) {
-                    $this->_index[$s][$p][] = $o_info;
-                    return true;
-                }
             }
+        }
         return false;
     }
 

--- a/src/classes/ExtendedGraph.class.php
+++ b/src/classes/ExtendedGraph.class.php
@@ -193,13 +193,10 @@ class ExtendedGraph
     /**
      * Check if a triple value is valid.
      *
-     * Currently null values are not valid,
-     * although this may expand to include any non-strings
-     *
      * @return bool
      */
     protected function isValidTripleValue($value){
-        if(!is_string($value) && !is_int($value) && !is_array($value) && !is_float($value) && !is_bool($value)){
+        if(!is_scalar($value) && !is_array($value)){
             return false;
         }
         return true;

--- a/src/classes/ExtendedGraph.class.php
+++ b/src/classes/ExtendedGraph.class.php
@@ -177,6 +177,10 @@ class ExtendedGraph
      * @return bool
      */
     private function _add_triple($s, $p, Array $o_info) {
+        // Make sure the subject is not an empty string
+        if($s === ""){
+            throw new \Tripod\Exceptions\Exception("The subject cannot be an empty string");
+        }
         // The value $o should already have been validated by this point
         // It's validation differs depending on whether it is a literal or resource
         // So just check the subject and predicate here...

--- a/src/classes/ExtendedGraph.class.php
+++ b/src/classes/ExtendedGraph.class.php
@@ -141,7 +141,7 @@ class ExtendedGraph
      * @return boolean true if the triple was new, false if it already existed in the graph
      */
     public function add_resource_triple($s, $p, $o) {
-        if($this->isValidTripleValue($s) && $this->isValidTripleValue($p) && $this->isValidTripleValue($o)) {
+        if($this->isValidResourceValue($o)) {
             return $this->_add_triple($s, $p, array('type' => strpos($o, '_:') === 0 ? 'bnode' : 'uri', 'value' => $o));
         }
         return false;
@@ -157,7 +157,7 @@ class ExtendedGraph
      * @return boolean true if the triple was new, false if it already existed in the graph
      */
     public function add_literal_triple($s, $p, $o, $lang = null, $dt = null) {
-        if($this->isValidTripleValue($s) && $this->isValidTripleValue($p) && $this->isValidLiteralValue($o)) {
+        if($this->isValidLiteralValue($o)) {
             $o_info = array('type' => 'literal', 'value' => $o);
             if ($lang != null) {
                 $o_info['lang'] = $lang;
@@ -177,14 +177,15 @@ class ExtendedGraph
      * @return bool
      */
     private function _add_triple($s, $p, Array $o_info) {
-        // Make sure the subject is not an empty string
-        if($s === ""){
-            throw new \Tripod\Exceptions\Exception("The subject cannot be an empty string");
-        }
         // The value $o should already have been validated by this point
         // It's validation differs depending on whether it is a literal or resource
         // So just check the subject and predicate here...
-        if($this->isValidTripleValue($s) && $this->isValidTripleValue($p)) {
+        if(!$this->isValidResourceValue($s)){
+            throw new \Tripod\Exceptions\Exception("The subject is invalid");
+        }
+        if(!$this->isValidResourceValue($p)){
+            throw new \Tripod\Exceptions\Exception("The predicate is invalid");
+        }
             if (!isset($this->_index[$s])) {
                 $this->_index[$s] = array();
                 $this->_index[$s][$p] = array($o_info);
@@ -198,7 +199,6 @@ class ExtendedGraph
                     return true;
                 }
             }
-        }
         return false;
     }
 
@@ -210,6 +210,7 @@ class ExtendedGraph
      * but accepting scalars so we can handle legacy data
      * which was not type-checked.
      *
+     * @param string $value
      * @return bool
      */
     protected function isValidLiteralValue($value){
@@ -222,10 +223,11 @@ class ExtendedGraph
     /**
      * Check if a triple value is valid.
      *
+     * @param string $value
      * @return bool
      */
-    protected function isValidTripleValue($value){
-        if(!is_string($value)){
+    protected function isValidResourceValue($value){
+        if(!is_string($value) || empty($value)){
             return false;
         }
         return true;

--- a/src/classes/ExtendedGraph.class.php
+++ b/src/classes/ExtendedGraph.class.php
@@ -141,7 +141,7 @@ class ExtendedGraph
      * @return boolean true if the triple was new, false if it already existed in the graph
      */
     public function add_resource_triple($s, $p, $o) {
-        if($this->isValidResourceValue($o)) {
+        if($this->isValidResource($o)) {
             return $this->_add_triple($s, $p, array('type' => strpos($o, '_:') === 0 ? 'bnode' : 'uri', 'value' => $o));
         }
         return false;
@@ -157,7 +157,7 @@ class ExtendedGraph
      * @return boolean true if the triple was new, false if it already existed in the graph
      */
     public function add_literal_triple($s, $p, $o, $lang = null, $dt = null) {
-        if($this->isValidLiteralValue($o)) {
+        if($this->isValidLiteral($o)) {
             $o_info = array('type' => 'literal', 'value' => $o);
             if ($lang != null) {
                 $o_info['lang'] = $lang;
@@ -181,10 +181,10 @@ class ExtendedGraph
         // The value $o should already have been validated by this point
         // It's validation differs depending on whether it is a literal or resource
         // So just check the subject and predicate here...
-        if(!$this->isValidResourceValue($s)){
+        if(!$this->isValidResource($s)){
             throw new \Tripod\Exceptions\Exception("The subject is invalid");
         }
-        if(!$this->isValidResourceValue($p)){
+        if(!$this->isValidResource($p)){
             throw new \Tripod\Exceptions\Exception("The predicate is invalid");
         }
         if (!isset($this->_index[$s])) {
@@ -214,7 +214,7 @@ class ExtendedGraph
      * @param string $value
      * @return bool
      */
-    protected function isValidLiteralValue($value){
+    protected function isValidLiteral($value){
         if(!is_scalar($value)){
             return false;
         }
@@ -227,7 +227,7 @@ class ExtendedGraph
      * @param string $value
      * @return bool
      */
-    protected function isValidResourceValue($value){
+    protected function isValidResource($value){
         if(!is_string($value) || empty($value)){
             return false;
         }

--- a/src/classes/ExtendedGraph.class.php
+++ b/src/classes/ExtendedGraph.class.php
@@ -141,7 +141,7 @@ class ExtendedGraph
      * @return boolean true if the triple was new, false if it already existed in the graph
      */
     public function add_resource_triple($s, $p, $o) {
-        if($this->isValidResourceValue($o)) {
+        if($this->isValidTripleValue($s) && $this->isValidTripleValue($p) && $this->isValidTripleValue($o)) {
             return $this->_add_triple($s, $p, array('type' => strpos($o, '_:') === 0 ? 'bnode' : 'uri', 'value' => $o));
         }
         return false;
@@ -157,7 +157,7 @@ class ExtendedGraph
      * @return boolean true if the triple was new, false if it already existed in the graph
      */
     public function add_literal_triple($s, $p, $o, $lang = null, $dt = null) {
-        if($this->isValidLiteralValue($o)) {
+        if($this->isValidTripleValue($s) && $this->isValidTripleValue($p) && $this->isValidLiteralValue($o)) {
             $o_info = array('type' => 'literal', 'value' => $o);
             if ($lang != null) {
                 $o_info['lang'] = $lang;
@@ -177,17 +177,22 @@ class ExtendedGraph
      * @return bool
      */
     private function _add_triple($s, $p, Array $o_info) {
-        if (!isset($this->_index[$s])) {
-            $this->_index[$s] = array();
-            $this->_index[$s][$p] = array($o_info);
-            return true;
-        } elseif (!isset($this->_index[$s][$p])) {
-            $this->_index[$s][$p] = array($o_info);
-            return true;
-        } else {
-            if (!in_array($o_info, $this->_index[$s][$p])) {
-                $this->_index[$s][$p][] = $o_info;
+        // The value $o should already have been validated by this point
+        // It's validation differs depending on whether it is a literal or resource
+        // So just check the subject and predicate here...
+        if($this->isValidTripleValue($s) && $this->isValidTripleValue($p)) {
+            if (!isset($this->_index[$s])) {
+                $this->_index[$s] = array();
+                $this->_index[$s][$p] = array($o_info);
                 return true;
+            } elseif (!isset($this->_index[$s][$p])) {
+                $this->_index[$s][$p] = array($o_info);
+                return true;
+            } else {
+                if (!in_array($o_info, $this->_index[$s][$p])) {
+                    $this->_index[$s][$p][] = $o_info;
+                    return true;
+                }
             }
         }
         return false;
@@ -215,7 +220,7 @@ class ExtendedGraph
      *
      * @return bool
      */
-    protected function isValidResourceValue($value){
+    protected function isValidTripleValue($value){
         if(!is_string($value)){
             return false;
         }

--- a/src/classes/ExtendedGraph.class.php
+++ b/src/classes/ExtendedGraph.class.php
@@ -171,7 +171,7 @@ class ExtendedGraph
      * @return bool
      */
     private function _add_triple($s, $p, Array $o_info) {
-        if($this->isValueValid($o_info['value'])) {
+        if($this->isValidTripleValue($o_info['value'])) {
             if (!isset($this->_index[$s])) {
                 $this->_index[$s] = array();
                 $this->_index[$s][$p] = array($o_info);
@@ -198,7 +198,7 @@ class ExtendedGraph
      *
      * @return bool
      */
-    protected function isValueValid($value){
+    protected function isValidTripleValue($value){
         if(!is_string($value) && !is_int($value) && !is_array($value) && !is_float($value) && !is_bool($value)){
             return false;
         }

--- a/src/classes/ExtendedGraph.class.php
+++ b/src/classes/ExtendedGraph.class.php
@@ -171,22 +171,38 @@ class ExtendedGraph
      * @return bool
      */
     private function _add_triple($s, $p, Array $o_info) {
-        if (!isset($this->_index[$s])) {
-            $this->_index[$s] = array();
-            $this->_index[$s][$p] = array( $o_info );
-            return true;
-        }
-        elseif (!isset($this->_index[$s][$p])) {
-            $this->_index[$s][$p] = array( $o_info);
-            return true;
-        }
-        else {
-            if ( ! in_array( $o_info, $this->_index[$s][$p] ) ) {
-                $this->_index[$s][$p][] = $o_info;
+        if($this->isValueValid($o_info['value'])) {
+            if (!isset($this->_index[$s])) {
+                $this->_index[$s] = array();
+                $this->_index[$s][$p] = array($o_info);
                 return true;
+            } elseif (!isset($this->_index[$s][$p])) {
+                $this->_index[$s][$p] = array($o_info);
+                return true;
+            } else {
+                if (!in_array($o_info, $this->_index[$s][$p])) {
+                    $this->_index[$s][$p][] = $o_info;
+                    return true;
+                }
             }
         }
         return false;
+    }
+
+
+    /**
+     * Check if a triple value is valid.
+     *
+     * Currently null values are not valid,
+     * although this may expand to include any non-strings
+     *
+     * @return bool
+     */
+    protected function isValueValid($value){
+        if($value === null){
+            return false;
+        }
+        return true;
     }
 
     /**

--- a/src/classes/ExtendedGraph.class.php
+++ b/src/classes/ExtendedGraph.class.php
@@ -199,7 +199,7 @@ class ExtendedGraph
      * @return bool
      */
     protected function isValueValid($value){
-        if($value === null){
+        if(!is_string($value) && !is_int($value) && !is_array($value) && !is_float($value) && !is_bool($value)){
             return false;
         }
         return true;

--- a/src/mongo/MongoGraph.class.php
+++ b/src/mongo/MongoGraph.class.php
@@ -153,7 +153,7 @@ class MongoGraph extends \Tripod\ExtendedGraph {
         if (array_key_exists(VALUE_LITERAL,$mongoValueObject))
         {
             // only allow valid values
-            if($this->isValidTripleValue($mongoValueObject[VALUE_LITERAL])){
+            if($this->isValidLiteralValue($mongoValueObject[VALUE_LITERAL])){
                 // single value literal
                 $simpleGraphValueObject[] = array(
                     'type'=>'literal',
@@ -163,7 +163,7 @@ class MongoGraph extends \Tripod\ExtendedGraph {
         else if (array_key_exists(VALUE_URI,$mongoValueObject))
         {
             // only allow valid values
-            if($this->isValidTripleValue($mongoValueObject[VALUE_URI])) {
+            if($this->isValidResourceValue($mongoValueObject[VALUE_URI])) {
                 // single value uri
                 $simpleGraphValueObject[] = array(
                     'type' => 'uri',
@@ -177,12 +177,21 @@ class MongoGraph extends \Tripod\ExtendedGraph {
             {
                 foreach ($kvp as $type=>$value)
                 {
-                    // Only add valid values
-                    if(!$this->isValidTripleValue($value)){
-                        continue;
+                    // Make sure the value is valid
+                    if($type==VALUE_LITERAL){
+                        if(!$this->isValidLiteralValue($value)){
+                            continue;
+                        }
+                        $valueTypeLabel = 'literal';
+                    }
+                    else{
+                        if(!$this->isValidResourceValue($value)){
+                            continue;
+                        }
+                        $valueTypeLabel = 'uri';
                     }
                     $simpleGraphValueObject[] = array(
-                        'type'=>($type==VALUE_LITERAL) ? 'literal' : 'uri',
+                        'type'=>$valueTypeLabel,
                         'value'=>($type==VALUE_URI) ? $this->_labeller->qname_to_alias($value) : $value);
                 }
             }

--- a/src/mongo/MongoGraph.class.php
+++ b/src/mongo/MongoGraph.class.php
@@ -143,6 +143,9 @@ class MongoGraph extends \Tripod\ExtendedGraph {
                 if(!isset($value['r']) || !$this->isValidTripleValue($value['r'])){
                     return;
                 }
+                if($value['r'] === ""){
+                    throw new \Tripod\Exceptions\Exception("The subject cannot be an empty string");
+                }
             }
         }
         $_i[$this->_labeller->qname_to_alias($tarray["_id"][_ID_RESOURCE])] = $predObjects;

--- a/src/mongo/MongoGraph.class.php
+++ b/src/mongo/MongoGraph.class.php
@@ -153,7 +153,7 @@ class MongoGraph extends \Tripod\ExtendedGraph {
         if (array_key_exists(VALUE_LITERAL,$mongoValueObject))
         {
             // only allow valid values
-            if($this->isValueValid($mongoValueObject[VALUE_LITERAL])){
+            if($this->isValidTripleValue($mongoValueObject[VALUE_LITERAL])){
                 // single value literal
                 $simpleGraphValueObject[] = array(
                     'type'=>'literal',
@@ -163,7 +163,7 @@ class MongoGraph extends \Tripod\ExtendedGraph {
         else if (array_key_exists(VALUE_URI,$mongoValueObject))
         {
             // only allow valid values
-            if($this->isValueValid($mongoValueObject[VALUE_URI])) {
+            if($this->isValidTripleValue($mongoValueObject[VALUE_URI])) {
                 // single value uri
                 $simpleGraphValueObject[] = array(
                     'type' => 'uri',
@@ -178,7 +178,7 @@ class MongoGraph extends \Tripod\ExtendedGraph {
                 foreach ($kvp as $type=>$value)
                 {
                     // Only add valid values
-                    if(!$this->isValueValid($value)){
+                    if(!$this->isValidTripleValue($value)){
                         continue;
                     }
                     $simpleGraphValueObject[] = array(

--- a/src/mongo/MongoGraph.class.php
+++ b/src/mongo/MongoGraph.class.php
@@ -138,7 +138,7 @@ class MongoGraph extends \Tripod\ExtendedGraph {
             }
             else if($key == "_id"){
                 // If the subject is invalid then throw an exception
-                if(!isset($value['r']) || !$this->isValidResourceValue($value['r'])){
+                if(!isset($value['r']) || !$this->isValidResource($value['r'])){
                     throw new \Tripod\Exceptions\Exception("The subject cannot be an empty string");
                 }
             }
@@ -160,7 +160,7 @@ class MongoGraph extends \Tripod\ExtendedGraph {
         if (array_key_exists(VALUE_LITERAL,$mongoValueObject))
         {
             // only allow valid values
-            if($this->isValidLiteralValue($mongoValueObject[VALUE_LITERAL])){
+            if($this->isValidLiteral($mongoValueObject[VALUE_LITERAL])){
                 // single value literal
                 $simpleGraphValueObject[] = array(
                     'type'=>'literal',
@@ -170,7 +170,7 @@ class MongoGraph extends \Tripod\ExtendedGraph {
         else if (array_key_exists(VALUE_URI,$mongoValueObject))
         {
             // only allow valid values
-            if($this->isValidResourceValue($mongoValueObject[VALUE_URI])) {
+            if($this->isValidResource($mongoValueObject[VALUE_URI])) {
                 // single value uri
                 $simpleGraphValueObject[] = array(
                     'type' => 'uri',
@@ -186,13 +186,13 @@ class MongoGraph extends \Tripod\ExtendedGraph {
                 {
                     // Make sure the value is valid
                     if($type==VALUE_LITERAL){
-                        if(!$this->isValidLiteralValue($value)){
+                        if(!$this->isValidLiteral($value)){
                             continue;
                         }
                         $valueTypeLabel = 'literal';
                     }
                     else{
-                        if(!$this->isValidResourceValue($value)){
+                        if(!$this->isValidResource($value)){
                             continue;
                         }
                         $valueTypeLabel = 'uri';

--- a/src/mongo/MongoGraph.class.php
+++ b/src/mongo/MongoGraph.class.php
@@ -128,11 +128,20 @@ class MongoGraph extends \Tripod\ExtendedGraph {
         {
             if($key[0] != '_')
             {
-                $predicate = $this->qname_to_uri($key);
-                $graphValueObject = $this->toGraphValueObject($value);
-                // Only add if valid values have been found
-                if($graphValueObject !== false) {
-                    $predObjects[$predicate] = $graphValueObject;
+                // Make sure the predicate is valid
+                if($this->isValidTripleValue($key)){
+                    $predicate = $this->qname_to_uri($key);
+                    $graphValueObject = $this->toGraphValueObject($value);
+                    // Only add if valid values have been found
+                    if ($graphValueObject !== false) {
+                        $predObjects[$predicate] = $graphValueObject;
+                    }
+                }
+            }
+            else if($key == "_id"){
+                // If the subject is not valid then return
+                if(!isset($value['r']) || !$this->isValidTripleValue($value['r'])){
+                    return;
                 }
             }
         }
@@ -163,7 +172,7 @@ class MongoGraph extends \Tripod\ExtendedGraph {
         else if (array_key_exists(VALUE_URI,$mongoValueObject))
         {
             // only allow valid values
-            if($this->isValidResourceValue($mongoValueObject[VALUE_URI])) {
+            if($this->isValidTripleValue($mongoValueObject[VALUE_URI])) {
                 // single value uri
                 $simpleGraphValueObject[] = array(
                     'type' => 'uri',
@@ -185,7 +194,7 @@ class MongoGraph extends \Tripod\ExtendedGraph {
                         $valueTypeLabel = 'literal';
                     }
                     else{
-                        if(!$this->isValidResourceValue($value)){
+                        if(!$this->isValidTripleValue($value)){
                             continue;
                         }
                         $valueTypeLabel = 'uri';

--- a/src/mongo/MongoGraph.class.php
+++ b/src/mongo/MongoGraph.class.php
@@ -144,7 +144,7 @@ class MongoGraph extends \Tripod\ExtendedGraph {
      * Convert from Tripod value object format (comapct) to ExtendedGraph format (verbose)
      *
      * @param array $mongoValueObject
-     * @return array| false an array of values or false if the value is not valid
+     * @return array|bool an array of values or false if the value is not valid
      */
     private function toGraphValueObject($mongoValueObject)
     {

--- a/test/unit/ExtendedGraphTest.php
+++ b/test/unit/ExtendedGraphTest.php
@@ -64,6 +64,56 @@ class ExtendedGraphTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    /**
+     * @dataProvider addInvalidSubjectToLiteralResultsInNoTriple_Provider
+     */
+    public function testAddInvalidSubjectToLiteralResultsInNoTriple($value)
+    {
+        $graph = new ExtendedGraph();
+
+        $addResult = $graph->add_resource_triple($value, 'http://some/predicate', 'http://someplace.com');
+        $this->assertFalse($addResult, 'The triple should not have been added for this value');
+
+        $graph->get_triple_count();
+        $this->assertEquals(0, $graph->get_triple_count(), 'The triple should not have been added for this value');
+    }
+    public function addInvalidSubjectToLiteralResultsInNoTriple_Provider(){
+        return array(
+            array(1),
+            array(1.2),
+            array(true),
+            array(array()),
+            array(null),
+            array(new stdClass()),
+            array(function(){})
+        );
+    }
+
+    /**
+     * @dataProvider addInvalidSubjectToLiteralResultsInNoTriple_Provider
+     */
+    public function testAddInvalidPredicateToLiteralResultsInNoTriple($value)
+    {
+        $graph = new ExtendedGraph();
+
+        $addResult = $graph->add_resource_triple('http://some/subject/1', $value, 'http://someplace.com');
+        $this->assertFalse($addResult, 'The triple should not have been added for this value');
+
+        $graph->get_triple_count();
+        $this->assertEquals(0, $graph->get_triple_count(), 'The triple should not have been added for this value');
+    }
+    public function addInvalidPredicateToLiteralResultsInNoTriple_Provider(){
+        return array(
+            array(1),
+            array(1.2),
+            array(true),
+            array(array()),
+            array(null),
+            array(new stdClass()),
+            array(function(){})
+        );
+    }
+
     public function testAddValidValueToResourceResultsInTriple()
     {
         $value = 'A String';
@@ -90,6 +140,56 @@ class ExtendedGraphTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($hasPropertyResult, 'The triple should not have been added for this value');
     }
     public function addInvalidValueToResourceResultsInNoTriple_Provider(){
+        return array(
+            array(1),
+            array(1.2),
+            array(true),
+            array(array()),
+            array(null),
+            array(new stdClass()),
+            array(function(){})
+        );
+    }
+
+    /**
+     * @dataProvider addInvalidSubjectToResourceResultsInNoTriple_Provider
+     */
+    public function testAddInvalidSubjectToResourceResultsInNoTriple($value)
+    {
+        $graph = new ExtendedGraph();
+
+        $addResult = $graph->add_resource_triple($value, 'http://some/predicate', 'http://someplace.com');
+        $this->assertFalse($addResult, 'The triple should not have been added for this value');
+
+        $graph->get_triple_count();
+        $this->assertEquals(0, $graph->get_triple_count(), 'The triple should not have been added for this value');
+    }
+    public function addInvalidSubjectToResourceResultsInNoTriple_Provider(){
+        return array(
+            array(1),
+            array(1.2),
+            array(true),
+            array(array()),
+            array(null),
+            array(new stdClass()),
+            array(function(){})
+        );
+    }
+
+    /**
+     * @dataProvider addInvalidSubjectToLiteralResultsInNoTriple_Provider
+     */
+    public function testAddInvalidPredicateToResourceResultsInNoTriple($value)
+    {
+        $graph = new ExtendedGraph();
+
+        $addResult = $graph->add_resource_triple('http://some/subject/1', $value, 'http://someplace.com');
+        $this->assertFalse($addResult, 'The triple should not have been added for this value');
+
+        $graph->get_triple_count();
+        $this->assertEquals(0, $graph->get_triple_count(), 'The triple should not have been added for this value');
+    }
+    public function addInvalidPredicateToResourceResultsInNoTriple_Provider(){
         return array(
             array(1),
             array(1.2),

--- a/test/unit/ExtendedGraphTest.php
+++ b/test/unit/ExtendedGraphTest.php
@@ -67,18 +67,16 @@ class ExtendedGraphTest extends PHPUnit_Framework_TestCase
     /**
      * @dataProvider addInvalidSubjectToLiteralResultsInNoTriple_Provider
      */
-    public function testAddInvalidSubjectToLiteralResultsInNoTriple($value)
+    public function testAddInvalidSubjectToLiteralThrowsException($value)
     {
+        $this->setExpectedException('\Tripod\Exceptions\Exception');
+
         $graph = new ExtendedGraph();
-
-        $addResult = $graph->add_resource_triple($value, 'http://some/predicate', 'http://someplace.com');
-        $this->assertFalse($addResult, 'The triple should not have been added for this value');
-
-        $graph->get_triple_count();
-        $this->assertEquals(0, $graph->get_triple_count(), 'The triple should not have been added for this value');
+        $graph->add_resource_triple($value, 'http://some/predicate', 'http://someplace.com');
     }
     public function addInvalidSubjectToLiteralResultsInNoTriple_Provider(){
         return array(
+            array(""),
             array(1),
             array(1.2),
             array(true),
@@ -89,28 +87,19 @@ class ExtendedGraphTest extends PHPUnit_Framework_TestCase
         );
     }
 
-    public function testAddEmptySubjectToLiteralThrowsException()
-    {
-        $this->setExpectedException('\Tripod\Exceptions\Exception');
-        $graph = new ExtendedGraph();
-        $graph->add_literal_triple("", 'http://some/predicate', 'http://someplace.com');
-    }
-
     /**
      * @dataProvider addInvalidSubjectToLiteralResultsInNoTriple_Provider
      */
-    public function testAddInvalidPredicateToLiteralResultsInNoTriple($value)
+    public function testAddInvalidPredicateToLiteralThrowsException($value)
     {
+        $this->setExpectedException('\Tripod\Exceptions\Exception');
+
         $graph = new ExtendedGraph();
-
-        $addResult = $graph->add_resource_triple('http://some/subject/1', $value, 'http://someplace.com');
-        $this->assertFalse($addResult, 'The triple should not have been added for this value');
-
-        $graph->get_triple_count();
-        $this->assertEquals(0, $graph->get_triple_count(), 'The triple should not have been added for this value');
+        $graph->add_resource_triple('http://some/subject/1', $value, 'http://someplace.com');
     }
     public function addInvalidPredicateToLiteralResultsInNoTriple_Provider(){
         return array(
+            array(""),
             array(1),
             array(1.2),
             array(true),
@@ -161,18 +150,16 @@ class ExtendedGraphTest extends PHPUnit_Framework_TestCase
     /**
      * @dataProvider addInvalidSubjectToResourceResultsInNoTriple_Provider
      */
-    public function testAddInvalidSubjectToResourceResultsInNoTriple($value)
+    public function testAddInvalidSubjectToResourceThrowsException($value)
     {
+        $this->setExpectedException('\Tripod\Exceptions\Exception');
+
         $graph = new ExtendedGraph();
-
-        $addResult = $graph->add_resource_triple($value, 'http://some/predicate', 'http://someplace.com');
-        $this->assertFalse($addResult, 'The triple should not have been added for this value');
-
-        $graph->get_triple_count();
-        $this->assertEquals(0, $graph->get_triple_count(), 'The triple should not have been added for this value');
+        $graph->add_resource_triple($value, 'http://some/predicate', 'http://someplace.com');
     }
     public function addInvalidSubjectToResourceResultsInNoTriple_Provider(){
         return array(
+            array(""),
             array(1),
             array(1.2),
             array(true),
@@ -183,28 +170,19 @@ class ExtendedGraphTest extends PHPUnit_Framework_TestCase
         );
     }
 
-    public function testAddEmptySubjectToResourceThrowsException()
-    {
-        $this->setExpectedException('\Tripod\Exceptions\Exception');
-        $graph = new ExtendedGraph();
-        $graph->add_resource_triple("", 'http://some/predicate', 'http://someplace.com');
-    }
-
     /**
      * @dataProvider addInvalidSubjectToLiteralResultsInNoTriple_Provider
      */
-    public function testAddInvalidPredicateToResourceResultsInNoTriple($value)
+    public function testAddInvalidPredicateToResourceThrowsException($value)
     {
+        $this->setExpectedException('\Tripod\Exceptions\Exception');
+
         $graph = new ExtendedGraph();
-
-        $addResult = $graph->add_resource_triple('http://some/subject/1', $value, 'http://someplace.com');
-        $this->assertFalse($addResult, 'The triple should not have been added for this value');
-
-        $graph->get_triple_count();
-        $this->assertEquals(0, $graph->get_triple_count(), 'The triple should not have been added for this value');
+        $graph->add_resource_triple('http://some/subject/1', $value, 'http://someplace.com');
     }
     public function addInvalidPredicateToResourceResultsInNoTriple_Provider(){
         return array(
+            array(""),
             array(1),
             array(1.2),
             array(true),

--- a/test/unit/ExtendedGraphTest.php
+++ b/test/unit/ExtendedGraphTest.php
@@ -23,28 +23,51 @@ class ExtendedGraphTest extends PHPUnit_Framework_TestCase
         echo "\nTest: {$className}->{$testName}\n";
     }
 
-    public function testAddNullToLiteralResultsInNoTriple()
+    /**
+     * @dataProvider addInvalidValueToLiteralResultsInNoTriple_Provider
+     */
+    public function testAddInvalidValueToLiteralResultsInNoTriple($value)
     {
         $graph = new ExtendedGraph();
-        $graph->add_literal_triple('http://some/subject/1', 'http://some/predicate', null);
+        $graph->add_literal_triple('http://some/subject/1', 'http://some/predicate', $value);
 
         $result = $graph->subject_has_property('http://some/subject/1', 'http://some/predicate');
         $this->assertFalse($result);
     }
+    public function addInvalidValueToLiteralResultsInNoTriple_Provider(){
+        return array(
+            array(null),
+            array(new stdClass()),
+            array(function(){})
+        );
+    }
 
-    public function testAddNullToResourceResultsInNoTriple()
+    /**
+     * @dataProvider addInvalidValueToResourceResultsInNoTriple_Provider
+     */
+    public function testAddInvalidValueToResourceResultsInNoTriple($value)
     {
         $graph = new ExtendedGraph();
-        $graph->add_resource_triple('http://some/subject/1', 'http://some/predicate', null);
+        $graph->add_resource_triple('http://some/subject/1', 'http://some/predicate', $value);
 
         $result = $graph->subject_has_property('http://some/subject/1', 'http://some/predicate');
         $this->assertFalse($result);
     }
+    public function addInvalidValueToResourceResultsInNoTriple_Provider(){
+        return array(
+            array(null),
+            array(new stdClass()),
+            array(function(){})
+        );
+    }
 
-    public function testAddGraphWithNullValueDoesNotAddNullTriple()
+    /**
+     * @dataProvider addGraphWithInvalidValueDoesNotAddNullTriple_Provider
+     */
+    public function testAddGraphWithInvalidValueDoesNotAddNullTriple($value)
     {
         $graph = new ExtendedGraph();
-        $graph->add_resource_triple('http://some/subject/1', 'http://some/predicate', null);
+        $graph->add_resource_triple('http://some/subject/1', 'http://some/predicate', $value);
         $graph->add_resource_triple('http://some/subject/1', 'http://some/other/predicate', 'triple');
 
         $nullTriple = $graph->subject_has_property('http://some/subject/1', 'http://some/predicate');
@@ -52,6 +75,13 @@ class ExtendedGraphTest extends PHPUnit_Framework_TestCase
 
         $this->assertFalse($nullTriple);
         $this->assertTrue($stringTriple);
+    }
+    public function addGraphWithInvalidValueDoesNotAddNullTriple_Provider(){
+        return array(
+            array(null),
+            array(new stdClass()),
+            array(function(){})
+        );
     }
 
     public function testRemoveProperties()

--- a/test/unit/ExtendedGraphTest.php
+++ b/test/unit/ExtendedGraphTest.php
@@ -29,10 +29,11 @@ class ExtendedGraphTest extends PHPUnit_Framework_TestCase
     public function testAddInvalidValueToLiteralResultsInNoTriple($value)
     {
         $graph = new ExtendedGraph();
-        $graph->add_literal_triple('http://some/subject/1', 'http://some/predicate', $value);
+        $addResult = $graph->add_literal_triple('http://some/subject/1', 'http://some/predicate', $value);
+        $this->assertFalse($addResult, 'The triple should not have been added for this value');
 
-        $result = $graph->subject_has_property('http://some/subject/1', 'http://some/predicate');
-        $this->assertFalse($result);
+        $hasPropertyResult = $graph->subject_has_property('http://some/subject/1', 'http://some/predicate');
+        $this->assertFalse($hasPropertyResult, 'The triple should not have been added for this value');
     }
     public function addInvalidValueToLiteralResultsInNoTriple_Provider(){
         return array(
@@ -48,36 +49,19 @@ class ExtendedGraphTest extends PHPUnit_Framework_TestCase
     public function testAddInvalidValueToResourceResultsInNoTriple($value)
     {
         $graph = new ExtendedGraph();
-        $graph->add_resource_triple('http://some/subject/1', 'http://some/predicate', $value);
 
-        $result = $graph->subject_has_property('http://some/subject/1', 'http://some/predicate');
-        $this->assertFalse($result);
+        $addResult = $graph->add_resource_triple('http://some/subject/1', 'http://some/predicate', $value);
+        $this->assertFalse($addResult, 'The triple should not have been added for this value');
+
+        $hasPropertyResult = $graph->subject_has_property('http://some/subject/1', 'http://some/predicate');
+        $this->assertFalse($hasPropertyResult, 'The triple should not have been added for this value');
     }
     public function addInvalidValueToResourceResultsInNoTriple_Provider(){
         return array(
-            array(null),
-            array(new stdClass()),
-            array(function(){})
-        );
-    }
-
-    /**
-     * @dataProvider addGraphWithInvalidValueDoesNotAddNullTriple_Provider
-     */
-    public function testAddGraphWithInvalidValueDoesNotAddNullTriple($value)
-    {
-        $graph = new ExtendedGraph();
-        $graph->add_resource_triple('http://some/subject/1', 'http://some/predicate', $value);
-        $graph->add_resource_triple('http://some/subject/1', 'http://some/other/predicate', 'triple');
-
-        $nullTriple = $graph->subject_has_property('http://some/subject/1', 'http://some/predicate');
-        $stringTriple = $graph->subject_has_property('http://some/subject/1', 'http://some/other/predicate');
-
-        $this->assertFalse($nullTriple);
-        $this->assertTrue($stringTriple);
-    }
-    public function addGraphWithInvalidValueDoesNotAddNullTriple_Provider(){
-        return array(
+            array(1),
+            array(1.2),
+            array(true),
+            array(array()),
             array(null),
             array(new stdClass()),
             array(function(){})

--- a/test/unit/ExtendedGraphTest.php
+++ b/test/unit/ExtendedGraphTest.php
@@ -89,6 +89,13 @@ class ExtendedGraphTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    public function testAddEmptySubjectToLiteralThrowsException()
+    {
+        $this->setExpectedException('\Tripod\Exceptions\Exception');
+        $graph = new ExtendedGraph();
+        $graph->add_literal_triple("", 'http://some/predicate', 'http://someplace.com');
+    }
+
     /**
      * @dataProvider addInvalidSubjectToLiteralResultsInNoTriple_Provider
      */
@@ -174,6 +181,13 @@ class ExtendedGraphTest extends PHPUnit_Framework_TestCase
             array(new stdClass()),
             array(function(){})
         );
+    }
+
+    public function testAddEmptySubjectToResourceThrowsException()
+    {
+        $this->setExpectedException('\Tripod\Exceptions\Exception');
+        $graph = new ExtendedGraph();
+        $graph->add_resource_triple("", 'http://some/predicate', 'http://someplace.com');
     }
 
     /**

--- a/test/unit/ExtendedGraphTest.php
+++ b/test/unit/ExtendedGraphTest.php
@@ -23,6 +23,37 @@ class ExtendedGraphTest extends PHPUnit_Framework_TestCase
         echo "\nTest: {$className}->{$testName}\n";
     }
 
+    public function testAddNullToLiteralResultsInNoTriple()
+    {
+        $graph = new ExtendedGraph();
+        $graph->add_literal_triple('http://some/subject/1', 'http://some/predicate', null);
+
+        $result = $graph->subject_has_property('http://some/subject/1', 'http://some/predicate');
+        $this->assertFalse($result);
+    }
+
+    public function testAddNullToResourceResultsInNoTriple()
+    {
+        $graph = new ExtendedGraph();
+        $graph->add_resource_triple('http://some/subject/1', 'http://some/predicate', null);
+
+        $result = $graph->subject_has_property('http://some/subject/1', 'http://some/predicate');
+        $this->assertFalse($result);
+    }
+
+    public function testAddGraphWithNullValueDoesNotAddNullTriple()
+    {
+        $graph = new ExtendedGraph();
+        $graph->add_resource_triple('http://some/subject/1', 'http://some/predicate', null);
+        $graph->add_resource_triple('http://some/subject/1', 'http://some/other/predicate', 'triple');
+
+        $nullTriple = $graph->subject_has_property('http://some/subject/1', 'http://some/predicate');
+        $stringTriple = $graph->subject_has_property('http://some/subject/1', 'http://some/other/predicate');
+
+        $this->assertFalse($nullTriple);
+        $this->assertTrue($stringTriple);
+    }
+
     public function testRemoveProperties()
     {
         $graph = new ExtendedGraph();

--- a/test/unit/ExtendedGraphTest.php
+++ b/test/unit/ExtendedGraphTest.php
@@ -24,6 +24,27 @@ class ExtendedGraphTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @dataProvider addValidValueToLiteralResultsInTriple_Provider
+     */
+    public function testAddValidValueToLiteralResultsInTriple($value)
+    {
+        $graph = new ExtendedGraph();
+        $addResult = $graph->add_literal_triple('http://some/subject/1', 'http://some/predicate', $value);
+        $this->assertTrue($addResult, 'The triple should have been added for this value');
+
+        $hasPropertyResult = $graph->subject_has_property('http://some/subject/1', 'http://some/predicate');
+        $this->assertTrue($hasPropertyResult, 'The triple should have been added for this value');
+    }
+    public function addValidValueToLiteralResultsInTriple_Provider(){
+        return array(
+            array('String'),
+            array(1),
+            array(1.2),
+            array(true)
+        );
+    }
+
+    /**
      * @dataProvider addInvalidValueToLiteralResultsInNoTriple_Provider
      */
     public function testAddInvalidValueToLiteralResultsInNoTriple($value)
@@ -42,6 +63,18 @@ class ExtendedGraphTest extends PHPUnit_Framework_TestCase
             array(function(){})
         );
     }
+
+    public function testAddValidValueToResourceResultsInTriple()
+    {
+        $value = 'A String';
+        $graph = new ExtendedGraph();
+        $addResult = $graph->add_resource_triple('http://some/subject/1', 'http://some/predicate', $value);
+        $this->assertTrue($addResult, 'The triple should have been added for this value');
+
+        $hasPropertyResult = $graph->subject_has_property('http://some/subject/1', 'http://some/predicate');
+        $this->assertTrue($hasPropertyResult, 'The triple should have been added for this value');
+    }
+
 
     /**
      * @dataProvider addInvalidValueToResourceResultsInNoTriple_Provider

--- a/test/unit/mongo/MongoGraphTest.php
+++ b/test/unit/mongo/MongoGraphTest.php
@@ -103,6 +103,42 @@ class MongoGraphTest extends MongoTripodTestBase
     }
 
     /**
+     * @dataProvider addTripodArrayContainingValidLiteralValues_Provider
+     */
+    public function testAddTripodArrayContainingValidLiteralValues($value)
+    {
+        $doc = array(
+            "_id"=>array("r"=>"http://talisaspire.com/works/4d101f63c10a6-2", "c"=>"http://talisaspire.com/works/4d101f63c10a6-2"),
+            "_version"=>0,
+            "rdf:type"=>array(
+                array("l"=>$value),
+                array("l"=>"a Value"),
+            ),
+            "bibo:isbn13"=>array("l"=>"9211234567890"),
+            "bibo:isbn10"=>array("l"=>$value)
+        );
+
+        $expected = new \Tripod\Mongo\MongoGraph();
+        $expected->add_literal_triple("http://talisaspire.com/works/4d101f63c10a6-2", $expected->qname_to_uri("bibo:isbn13"),"9211234567890");
+        $expected->add_literal_triple("http://talisaspire.com/works/4d101f63c10a6-2", $expected->qname_to_uri("bibo:isbn10"),$value);
+        $expected->add_literal_triple("http://talisaspire.com/works/4d101f63c10a6-2", $expected->qname_to_uri("rdf:type"),$value);
+        $expected->add_literal_triple("http://talisaspire.com/works/4d101f63c10a6-2", $expected->qname_to_uri("rdf:type"),"a Value");
+
+        $g = new \Tripod\Mongo\MongoGraph();
+        $g->add_tripod_array($doc);
+
+        $this->assertEquals($expected, $g);
+    }
+    public function addTripodArrayContainingValidLiteralValues_Provider(){
+        return array(
+            array('A String'),
+            array(1),
+            array(1.2),
+            array(true)
+        );
+    }
+
+    /**
      * @dataProvider addTripodArrayContainingInvalidLiteralValues_Provider
      */
     public function testAddTripodArrayContainingInvalidLiteralValues($value)
@@ -133,6 +169,33 @@ class MongoGraphTest extends MongoTripodTestBase
             array(new stdClass()),
             array(function(){})
         );
+    }
+
+
+    public function testAddTripodArrayContainingValidResourceValues()
+    {
+        $value = 'A String';
+        $doc = array(
+            "_id"=>array("r"=>"http://talisaspire.com/works/4d101f63c10a6-2", "c"=>"http://talisaspire.com/works/4d101f63c10a6-2"),
+            "_version"=>0,
+            "dct:subject"=>array("u"=>"http://talisaspire.com/disciplines/physics"),
+            "dct:publisher"=>array("u"=>$value),
+            "rdf:type"=>array(
+                array("u"=>$value),
+                array("u"=>"http://talisaspire.com/schema#Work")
+            ),
+        );
+
+        $expected = new \Tripod\Mongo\MongoGraph();
+        $expected->add_resource_triple("http://talisaspire.com/works/4d101f63c10a6-2", $expected->qname_to_uri("dct:subject"),"http://talisaspire.com/disciplines/physics");
+        $expected->add_resource_triple("http://talisaspire.com/works/4d101f63c10a6-2", $expected->qname_to_uri("dct:publisher"),$value);
+        $expected->add_resource_triple("http://talisaspire.com/works/4d101f63c10a6-2", $expected->qname_to_uri("rdf:type"),$value);
+        $expected->add_resource_triple("http://talisaspire.com/works/4d101f63c10a6-2", $expected->qname_to_uri("rdf:type"),"http://talisaspire.com/schema#Work");
+
+        $g = new \Tripod\Mongo\MongoGraph();
+        $g->add_tripod_array($doc);
+
+        $this->assertEquals($expected, $g);
     }
 
     /**

--- a/test/unit/mongo/MongoGraphTest.php
+++ b/test/unit/mongo/MongoGraphTest.php
@@ -176,6 +176,7 @@ class MongoGraphTest extends MongoTripodTestBase
      */
     public function testAddTripodArrayContainingInvalidPredicates($value)
     {
+        $this->setExpectedException('\Tripod\Exceptions\LabellerException');
         $doc = array(
             "_id"=>array("r"=>"http://talisaspire.com/works/4d101f63c10a6-2", "c"=>"http://talisaspire.com/works/4d101f63c10a6-2"),
             "_version"=>0,
@@ -192,8 +193,6 @@ class MongoGraphTest extends MongoTripodTestBase
 
         $g = new \Tripod\Mongo\MongoGraph();
         $g->add_tripod_array($doc);
-
-        $this->assertEquals($expected, $g);
     }
     public function addTripodArrayContainingInvalidPredicates_Provider(){
         return array(
@@ -204,10 +203,38 @@ class MongoGraphTest extends MongoTripodTestBase
     }
 
     /**
+     *
+     * We are expecting the labeller
+     *
+     */
+    public function testAddTripodArrayContainingEmptyPredicate()
+    {
+        // An Uninitialized string offset should occur if an empty predicate is passed.
+        $this->setExpectedException("PHPUnit_Framework_Error");
+        $doc = array(
+            "_id"=>array("r"=>"http://talisaspire.com/works/4d101f63c10a6-2", "c"=>"http://talisaspire.com/works/4d101f63c10a6-2"),
+            "_version"=>0,
+            "rdf:type"=>array(
+                array("l"=>"a Value"),
+            ),
+            "bibo:isbn13"=>array("l"=>"9211234567890"),
+            ""=>array("l"=>"9211234567890")
+        );
+
+        $expected = new \Tripod\Mongo\MongoGraph();
+        $expected->add_literal_triple("http://talisaspire.com/works/4d101f63c10a6-2", $expected->qname_to_uri("bibo:isbn13"),"9211234567890");
+        $expected->add_literal_triple("http://talisaspire.com/works/4d101f63c10a6-2", $expected->qname_to_uri("rdf:type"),"a Value");
+
+        $g = new \Tripod\Mongo\MongoGraph();
+        $g->add_tripod_array($doc);
+    }
+
+    /**
      * @dataProvider addTripodArrayContainingInvalidSubject_Provider
      */
     public function testAddTripodArrayContainingInvalidSubject($value)
     {
+        $this->setExpectedException('\Tripod\Exceptions\Exception');
         $doc = array(
             "_id"=>array("r"=>$value, "c"=>"http://talisaspire.com/works/4d101f63c10a6-2"),
             "_version"=>0,
@@ -219,32 +246,15 @@ class MongoGraphTest extends MongoTripodTestBase
 
         $g = new \Tripod\Mongo\MongoGraph();
         $g->add_tripod_array($doc);
-        $this->assertEquals(0, $g->get_triple_count());
     }
     public function addTripodArrayContainingInvalidSubject_Provider(){
         return array(
+            array(""),
             array(1),
             array(1.2),
             array(true),
         );
     }
-
-    public function testAddTripodArrayContainingEmptySubject()
-    {
-        $this->setExpectedException('\Tripod\Exceptions\Exception');
-        $doc = array(
-            "_id"=>array("r"=>"", "c"=>"http://talisaspire.com/works/4d101f63c10a6-2"),
-            "_version"=>0,
-            "rdf:type"=>array(
-                array("l"=>"a Value"),
-            ),
-            "bibo:isbn13"=>array("l"=>"9211234567890"),
-        );
-
-        $g = new \Tripod\Mongo\MongoGraph();
-        $g->add_tripod_array($doc);
-    }
-
 
     public function testAddTripodArrayContainingValidResourceValues()
     {

--- a/test/unit/mongo/MongoGraphTest.php
+++ b/test/unit/mongo/MongoGraphTest.php
@@ -102,33 +102,74 @@ class MongoGraphTest extends MongoTripodTestBase
         $this->assertEquals($expected, $g);
     }
 
-    public function testAddTripodArrayContainingNullValues()
+    /**
+     * @dataProvider addTripodArrayContainingInvalidLiteralValues_Provider
+     */
+    public function testAddTripodArrayContainingInvalidLiteralValues($value)
+    {
+        $doc = array(
+            "_id"=>array("r"=>"http://talisaspire.com/works/4d101f63c10a6-2", "c"=>"http://talisaspire.com/works/4d101f63c10a6-2"),
+            "_version"=>0,
+            "rdf:type"=>array(
+                array("l"=>$value),
+                array("l"=>"a Value"),
+            ),
+            "bibo:isbn13"=>array("l"=>"9211234567890"),
+            "bibo:isbn10"=>array("l"=>$value)
+        );
+
+        $expected = new \Tripod\Mongo\MongoGraph();
+        $expected->add_literal_triple("http://talisaspire.com/works/4d101f63c10a6-2", $expected->qname_to_uri("bibo:isbn13"),"9211234567890");
+        $expected->add_literal_triple("http://talisaspire.com/works/4d101f63c10a6-2", $expected->qname_to_uri("rdf:type"),"a Value");
+
+        $g = new \Tripod\Mongo\MongoGraph();
+        $g->add_tripod_array($doc);
+
+        $this->assertEquals($expected, $g);
+    }
+    public function addTripodArrayContainingInvalidLiteralValues_Provider(){
+        return array(
+            array(null),
+            array(new stdClass()),
+            array(function(){})
+        );
+    }
+
+    /**
+     * @dataProvider addTripodArrayContainingInvalidResourceValues_Provider
+     */
+    public function testAddTripodArrayContainingInvalidResourceValues($value)
     {
         $doc = array(
             "_id"=>array("r"=>"http://talisaspire.com/works/4d101f63c10a6-2", "c"=>"http://talisaspire.com/works/4d101f63c10a6-2"),
             "_version"=>0,
             "dct:subject"=>array("u"=>"http://talisaspire.com/disciplines/physics"),
-            "dct:publisher"=>array("u"=>null),
+            "dct:publisher"=>array("u"=>$value),
             "rdf:type"=>array(
-                array("u"=>null),
-                array("l"=>null),
-                array("l"=>"a Value"),
+                array("u"=>$value),
                 array("u"=>"http://talisaspire.com/schema#Work")
             ),
-            "bibo:isbn13"=>array("l"=>"9211234567890"),
-            "bibo:isbn10"=>array("l"=>null)
         );
 
         $expected = new \Tripod\Mongo\MongoGraph();
-        $expected->add_literal_triple("http://talisaspire.com/works/4d101f63c10a6-2", $expected->qname_to_uri("bibo:isbn13"),"9211234567890");
         $expected->add_resource_triple("http://talisaspire.com/works/4d101f63c10a6-2", $expected->qname_to_uri("dct:subject"),"http://talisaspire.com/disciplines/physics");
-        $expected->add_literal_triple("http://talisaspire.com/works/4d101f63c10a6-2", $expected->qname_to_uri("rdf:type"),"a Value");
         $expected->add_resource_triple("http://talisaspire.com/works/4d101f63c10a6-2", $expected->qname_to_uri("rdf:type"),"http://talisaspire.com/schema#Work");
 
         $g = new \Tripod\Mongo\MongoGraph();
         $g->add_tripod_array($doc);
 
         $this->assertEquals($expected, $g);
+    }
+    public function addTripodArrayContainingInvalidResourceValues_Provider(){
+        return array(
+            array(1),
+            array(1.2),
+            array(true),
+            array(array()),
+            array(null),
+            array(new stdClass()),
+            array(function(){})
+        );
     }
 
     public function testAddTripodArrayWhenAddingViews()

--- a/test/unit/mongo/MongoGraphTest.php
+++ b/test/unit/mongo/MongoGraphTest.php
@@ -102,6 +102,35 @@ class MongoGraphTest extends MongoTripodTestBase
         $this->assertEquals($expected, $g);
     }
 
+    public function testAddTripodArrayContainingNullValues()
+    {
+        $doc = array(
+            "_id"=>array("r"=>"http://talisaspire.com/works/4d101f63c10a6-2", "c"=>"http://talisaspire.com/works/4d101f63c10a6-2"),
+            "_version"=>0,
+            "dct:subject"=>array("u"=>"http://talisaspire.com/disciplines/physics"),
+            "dct:publisher"=>array("u"=>null),
+            "rdf:type"=>array(
+                array("u"=>null),
+                array("l"=>null),
+                array("l"=>"a Value"),
+                array("u"=>"http://talisaspire.com/schema#Work")
+            ),
+            "bibo:isbn13"=>array("l"=>"9211234567890"),
+            "bibo:isbn10"=>array("l"=>null)
+        );
+
+        $expected = new \Tripod\Mongo\MongoGraph();
+        $expected->add_literal_triple("http://talisaspire.com/works/4d101f63c10a6-2", $expected->qname_to_uri("bibo:isbn13"),"9211234567890");
+        $expected->add_resource_triple("http://talisaspire.com/works/4d101f63c10a6-2", $expected->qname_to_uri("dct:subject"),"http://talisaspire.com/disciplines/physics");
+        $expected->add_literal_triple("http://talisaspire.com/works/4d101f63c10a6-2", $expected->qname_to_uri("rdf:type"),"a Value");
+        $expected->add_resource_triple("http://talisaspire.com/works/4d101f63c10a6-2", $expected->qname_to_uri("rdf:type"),"http://talisaspire.com/schema#Work");
+
+        $g = new \Tripod\Mongo\MongoGraph();
+        $g->add_tripod_array($doc);
+
+        $this->assertEquals($expected, $g);
+    }
+
     public function testAddTripodArrayWhenAddingViews()
     {
         // view contains 4 subgraphs

--- a/test/unit/mongo/MongoGraphTest.php
+++ b/test/unit/mongo/MongoGraphTest.php
@@ -229,6 +229,22 @@ class MongoGraphTest extends MongoTripodTestBase
         );
     }
 
+    public function testAddTripodArrayContainingEmptySubject()
+    {
+        $this->setExpectedException('\Tripod\Exceptions\Exception');
+        $doc = array(
+            "_id"=>array("r"=>"", "c"=>"http://talisaspire.com/works/4d101f63c10a6-2"),
+            "_version"=>0,
+            "rdf:type"=>array(
+                array("l"=>"a Value"),
+            ),
+            "bibo:isbn13"=>array("l"=>"9211234567890"),
+        );
+
+        $g = new \Tripod\Mongo\MongoGraph();
+        $g->add_tripod_array($doc);
+    }
+
 
     public function testAddTripodArrayContainingValidResourceValues()
     {

--- a/test/unit/mongo/MongoGraphTest.php
+++ b/test/unit/mongo/MongoGraphTest.php
@@ -171,6 +171,64 @@ class MongoGraphTest extends MongoTripodTestBase
         );
     }
 
+    /**
+     * @dataProvider addTripodArrayContainingInvalidPredicates_Provider
+     */
+    public function testAddTripodArrayContainingInvalidPredicates($value)
+    {
+        $doc = array(
+            "_id"=>array("r"=>"http://talisaspire.com/works/4d101f63c10a6-2", "c"=>"http://talisaspire.com/works/4d101f63c10a6-2"),
+            "_version"=>0,
+            "rdf:type"=>array(
+                array("l"=>"a Value"),
+            ),
+            "bibo:isbn13"=>array("l"=>"9211234567890"),
+            $value=>array("l"=>"9211234567890")
+        );
+
+        $expected = new \Tripod\Mongo\MongoGraph();
+        $expected->add_literal_triple("http://talisaspire.com/works/4d101f63c10a6-2", $expected->qname_to_uri("bibo:isbn13"),"9211234567890");
+        $expected->add_literal_triple("http://talisaspire.com/works/4d101f63c10a6-2", $expected->qname_to_uri("rdf:type"),"a Value");
+
+        $g = new \Tripod\Mongo\MongoGraph();
+        $g->add_tripod_array($doc);
+
+        $this->assertEquals($expected, $g);
+    }
+    public function addTripodArrayContainingInvalidPredicates_Provider(){
+        return array(
+            array(1),
+            array(1.2),
+            array(true),
+        );
+    }
+
+    /**
+     * @dataProvider addTripodArrayContainingInvalidSubject_Provider
+     */
+    public function testAddTripodArrayContainingInvalidSubject($value)
+    {
+        $doc = array(
+            "_id"=>array("r"=>$value, "c"=>"http://talisaspire.com/works/4d101f63c10a6-2"),
+            "_version"=>0,
+            "rdf:type"=>array(
+                array("l"=>"a Value"),
+            ),
+            "bibo:isbn13"=>array("l"=>"9211234567890"),
+        );
+
+        $g = new \Tripod\Mongo\MongoGraph();
+        $g->add_tripod_array($doc);
+        $this->assertEquals(0, $g->get_triple_count());
+    }
+    public function addTripodArrayContainingInvalidSubject_Provider(){
+        return array(
+            array(1),
+            array(1.2),
+            array(true),
+        );
+    }
+
 
     public function testAddTripodArrayContainingValidResourceValues()
     {


### PR DESCRIPTION
To address issue https://github.com/talis/tripod-php/issues/81

This will ensure that subjects, predicates, and resource values are always strings.  Literal values can be any scalar - we would like to enforce strings for literal values too, but doing so may break legacy databases which use non-strings as values.