### PR TITLE
90% Handle Mongo 2.6's stricter enforcement of index key sizes.

### DIFF
--- a/src/mongo/delegates/Tables.class.php
+++ b/src/mongo/delegates/Tables.class.php
@@ -617,7 +617,7 @@ class Tables extends CompositeBase
         {
             $collection->save($generatedRow);
         } catch (\Exception $e) {
-            // We only trunacte and retry the save if the \MongoCursorException contains this text.
+            // We only truncate and retry the save if the \Exception contains this text.
             if (strpos($e->getMessage(),"Btree::insert: key too large to index") !== FALSE)
             {
                 $this->truncateFields($collection, $generatedRow);

--- a/test/unit/mongo/MongoTripodConfigTest.php
+++ b/test/unit/mongo/MongoTripodConfigTest.php
@@ -969,7 +969,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
     public function testGetAllTypesInSpecifications()
     {
         $types = $this->tripodConfig->getAllTypesInSpecifications("tripod_php_testing");
-        $this->assertEquals(11, count($types), "There should be 10 types based on the configured view, table and search specifications in config.json");
+        $this->assertEquals(11, count($types), "There should be 11 types based on the configured view, table and search specifications in config.json");
         $expectedValues = array(
             "acorn:Resource",
             "acorn:ResourceForTruncating",

--- a/test/unit/mongo/MongoTripodConfigTest.php
+++ b/test/unit/mongo/MongoTripodConfigTest.php
@@ -969,9 +969,10 @@ class MongoTripodConfigTest extends MongoTripodTestBase
     public function testGetAllTypesInSpecifications()
     {
         $types = $this->tripodConfig->getAllTypesInSpecifications("tripod_php_testing");
-        $this->assertEquals(10, count($types), "There should be 10 types based on the configured view, table and search specifications in config.json");
+        $this->assertEquals(11, count($types), "There should be 10 types based on the configured view, table and search specifications in config.json");
         $expectedValues = array(
             "acorn:Resource",
+            "acorn:ResourceForTruncating",
             "acorn:Work",
             "http://talisaspire.com/schema#Work2",
             "acorn:Work2",
@@ -1326,7 +1327,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $transactionColletion = $transactionMongo->selectCollection($newConfig['transaction_log']['database'], $newConfig['transaction_log']['collection']);
         $transactionCount = $transactionColletion->count();
         $transactionExampleDocument = $transactionColletion->findOne();
-        $this->assertEquals(19, $transactionCount);
+        $this->assertEquals(20, $transactionCount);
         $this->assertContains('transaction_', $transactionExampleDocument["_id"]);
     }
 

--- a/test/unit/mongo/MongoTripodDriverTest.php
+++ b/test/unit/mongo/MongoTripodDriverTest.php
@@ -218,7 +218,7 @@ class MongoTripodDriverTest extends MongoTripodTestBase
     public function testGetCount()
     {
         $count = $this->tripod->getCount(array("rdf:type.".VALUE_URI=>"bibo:Book"));
-        $this->assertEquals(5,$count);
+        $this->assertEquals(6,$count);
     }
 
     public function testTripodSaveChangesRemovesLiteralTriple()
@@ -1670,14 +1670,14 @@ class MongoTripodDriverTest extends MongoTripodTestBase
         $table = 't_distinct';
         $this->tripod->generateTableRows($table);
         $rows = $this->tripod->getTableRows($table, array(), array(), 0, 0);
-        $this->assertEquals(7, $rows['head']['count']);
+        $this->assertEquals(8, $rows['head']['count']);
         $results = $this->tripod->getDistinctTableColumnValues($table, "value.title");
 
         $this->assertArrayHasKey('head', $results);
         $this->assertArrayHasKey('count', $results['head']);
-        $this->assertEquals(3, $results['head']['count']);
+        $this->assertEquals(4, $results['head']['count']);
         $this->assertArrayHasKey('results', $results);
-        $this->assertEquals(3, count($results['results']));
+        $this->assertEquals(4, count($results['results']));
         $this->assertContains('Physics 3rd Edition: Physics for Engineers and Scientists', $results['results']);
         $this->assertContains('A document title', $results['results']);
         $this->assertContains('Another document title', $results['results']);
@@ -1696,9 +1696,9 @@ class MongoTripodDriverTest extends MongoTripodTestBase
         $results = $this->tripod->getDistinctTableColumnValues($table, "value.type");
         $this->assertArrayHasKey('head', $results);
         $this->assertArrayHasKey('count', $results['head']);
-        $this->assertEquals(4, $results['head']['count']);
+        $this->assertEquals(5, $results['head']['count']);
         $this->assertArrayHasKey('results', $results);
-        $this->assertEquals(4, count($results['results']));
+        $this->assertEquals(5, count($results['results']));
         $this->assertContains('acorn:Resource', $results['results']);
         $this->assertContains('acorn:Work', $results['results']);
         $this->assertContains('bibo:Book', $results['results']);

--- a/test/unit/mongo/MongoTripodNQuadSerializerTest.php
+++ b/test/unit/mongo/MongoTripodNQuadSerializerTest.php
@@ -93,6 +93,32 @@ class MongoTripodNQuadSerializerTest extends MongoTripodTestBase
 <http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA-2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> <http://talisaspire.com/> .
 <http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA-2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://talisaspire.com/schema#Resource> <http://talisaspire.com/> .
 <http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA-2> <http://www.w3.org/2002/07/owl#sameAs> <http://talisaspire.com/isbn/9780393929690> <http://talisaspire.com/> .
+<http://talisaspire.com/resources/indexKeyTooLarge> <http://purl.org/dc/terms/isVersionOf> <http://talisaspire.com/works/4d101f63c10a6> <http://talisaspire.com/> .
+<http://talisaspire.com/resources/indexKeyTooLarge> <http://purl.org/dc/terms/source> <http://life.ac.uk/resources/836E7CAD-63D2-63A0-B1CB-AA6A7E54A5C9> <http://talisaspire.com/> .
+<http://talisaspire.com/resources/indexKeyTooLarge> <http://purl.org/dc/terms/source> <http://life.ac.uk/resources/BFBC6A06-A8B0-DED8-53AA-8E80DB44CC53> <http://talisaspire.com/> .
+<http://talisaspire.com/resources/indexKeyTooLarge> <http://purl.org/dc/terms/subject> <http://talisaspire.com/disciplines/physics> <http://talisaspire.com/> .
+<http://talisaspire.com/resources/indexKeyTooLarge> <http://purl.org/ontology/bibo/isbn13> \"1234567890123\" <http://talisaspire.com/> .
+<http://talisaspire.com/resources/indexKeyTooLarge> <http://talisaspire.com/schema#bookmarkReferences> <http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA/bookmarks> <http://talisaspire.com/> .
+<http://talisaspire.com/resources/indexKeyTooLarge> <http://talisaspire.com/schema#foo> \"wibble\" <http://talisaspire.com/> .
+<http://talisaspire.com/resources/indexKeyTooLarge> <http://talisaspire.com/schema#jacsUri> <http://jacs3.dataincubator.org/f300> <http://talisaspire.com/> .
+<http://talisaspire.com/resources/indexKeyTooLarge> <http://talisaspire.com/schema#jacsUri> <http://jacs3.dataincubator.org/f340> <http://talisaspire.com/> .
+<http://talisaspire.com/resources/indexKeyTooLarge> <http://talisaspire.com/schema#listReferences> <http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA/lists> <http://talisaspire.com/> .
+<http://talisaspire.com/resources/indexKeyTooLarge> <http://talisaspire.com/schema#openLibraryUri> <http://openlibrary.org/books/OL10157958M> <http://talisaspire.com/> .
+<http://talisaspire.com/resources/indexKeyTooLarge> <http://talisaspire.com/schema#preferredMetadata> <http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA/metadata> <http://talisaspire.com/> .
+<http://talisaspire.com/resources/indexKeyTooLarge> <http://talisaspire.com/searchTerms/schema#author> \"Ohanian\" <http://talisaspire.com/> .
+<http://talisaspire.com/resources/indexKeyTooLarge> <http://talisaspire.com/searchTerms/schema#discipline> \"physics\" <http://talisaspire.com/> .
+<http://talisaspire.com/resources/indexKeyTooLarge> <http://talisaspire.com/searchTerms/schema#isbn> \"1234567890\" <http://talisaspire.com/> .
+<http://talisaspire.com/resources/indexKeyTooLarge> <http://talisaspire.com/searchTerms/schema#openLibrarySubject> \"Engineering: general\" <http://talisaspire.com/> .
+<http://talisaspire.com/resources/indexKeyTooLarge> <http://talisaspire.com/searchTerms/schema#openLibrarySubject> \"PHYSICS\" <http://talisaspire.com/> .
+<http://talisaspire.com/resources/indexKeyTooLarge> <http://talisaspire.com/searchTerms/schema#openLibrarySubject> \"Science\" <http://talisaspire.com/> .
+<http://talisaspire.com/resources/indexKeyTooLarge> <http://talisaspire.com/searchTerms/schema#title> \"Mahommah Gardo Baquaqua. Biography of Mahommah G. Baquaqua, a Native of Zoogoo, in the Interior of Africa. (A Convert to Christianity,) With a Description of That Part of the World; Including the Manners and Customs of the Inhabitants, Their Religious Notions, Form of Government, Laws, Appearance of the Country, Buildings, Agriculture, Manufactures, Shepherds and Herdsmen, Domestic Animals, Marriage Ceremonials, Funeral Services, Styles of Dress, Trade and Commerce, Modes of Warfare, System of Slavery, &amp;c., &amp;c. Mahommah&#039;s Early Life, His Education, His Capture and Slavery in Western Africa and Brazil, His Escape to the United States, from Thence to Hayti, (the City of Port Au Prince,) His Reception by the Baptist Missionary There, The Rev. W. L. Judd; His Conversion to Christianity, Baptism, and Return to This Country, His Views, Objects and Aim. Written and Revised from His Own Words, by Samuel Moore, Esq., Late Publisher of the &quot;North of England Shipping Gazette,&quot; Author of Several Popular Works, and Editor of Sundry Reform Papers.\" <http://talisaspire.com/> .
+<http://talisaspire.com/resources/indexKeyTooLarge> <http://talisaspire.com/searchTerms/schema#topic> \"engineering: general\" <http://talisaspire.com/> .
+<http://talisaspire.com/resources/indexKeyTooLarge> <http://talisaspire.com/searchTerms/schema#topic> \"physics\" <http://talisaspire.com/> .
+<http://talisaspire.com/resources/indexKeyTooLarge> <http://talisaspire.com/searchTerms/schema#topic> \"science\" <http://talisaspire.com/> .
+<http://talisaspire.com/resources/indexKeyTooLarge> <http://talisaspire.com/searchTerms/schema#usedAt> \"0071\" <http://talisaspire.com/> .
+<http://talisaspire.com/resources/indexKeyTooLarge> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/ontology/bibo/Book> <http://talisaspire.com/> .
+<http://talisaspire.com/resources/indexKeyTooLarge> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://talisaspire.com/schema#ResourceForTruncating> <http://talisaspire.com/> .
+<http://talisaspire.com/resources/indexKeyTooLarge> <http://www.w3.org/2002/07/owl#sameAs> <http://talisaspire.com/isbn/9780393929690> <http://talisaspire.com/> .
 <http://jacs3.dataincubator.org/f300> <http://purl.org/dc/terms/title> \"First title\" <http://talisaspire.com/> .
 <http://jacs3.dataincubator.org/f300> <http://purl.org/dc/terms/title> \"Second title\" <http://talisaspire.com/> .
 <http://jacs3.dataincubator.org/f340> <http://purl.org/dc/terms/title> \"First title\" <http://talisaspire.com/> .

--- a/test/unit/mongo/MongoTripodTablesTest.php
+++ b/test/unit/mongo/MongoTripodTablesTest.php
@@ -758,14 +758,14 @@ class MongoTripodTablesTest extends MongoTripodTestBase
         $table = 't_distinct';
         $this->generateTableRows($table);
         $rows = $this->tripodTables->getTableRows($table, array(), array(), 0, 0);
-        $this->assertEquals(7, $rows['head']['count']);
+        $this->assertEquals(8, $rows['head']['count']);
         $results = $this->tripodTables->distinct($table, "value.title");
 
         $this->assertArrayHasKey('head', $results);
         $this->assertArrayHasKey('count', $results['head']);
-        $this->assertEquals(3, $results['head']['count']);
+        $this->assertEquals(4, $results['head']['count']);
         $this->assertArrayHasKey('results', $results);
-        $this->assertEquals(3, count($results['results']));
+        $this->assertEquals(4, count($results['results']));
         $this->assertContains('Physics 3rd Edition: Physics for Engineers and Scientists', $results['results']);
         $this->assertContains('A document title', $results['results']);
         $this->assertContains('Another document title', $results['results']);
@@ -784,9 +784,9 @@ class MongoTripodTablesTest extends MongoTripodTestBase
         $results = $this->tripodTables->distinct($table, "value.type");
         $this->assertArrayHasKey('head', $results);
         $this->assertArrayHasKey('count', $results['head']);
-        $this->assertEquals(4, $results['head']['count']);
+        $this->assertEquals(5, $results['head']['count']);
         $this->assertArrayHasKey('results', $results);
-        $this->assertEquals(4, count($results['results']));
+        $this->assertEquals(5, count($results['results']));
         $this->assertContains('acorn:Resource', $results['results']);
         $this->assertContains('acorn:Work', $results['results']);
         $this->assertContains('bibo:Book', $results['results']);

--- a/test/unit/mongo/MongoTripodTablesTest.php
+++ b/test/unit/mongo/MongoTripodTablesTest.php
@@ -641,6 +641,31 @@ class MongoTripodTablesTest extends MongoTripodTestBase
     }
 
     /**
+     * Test table rows are tuncated if they are too large to index
+     * @access public
+     * @return void
+     */
+    public function testGenerateTableRowsTruncatesFieldsTooLargeToIndex()
+    {
+        $fullTitle = "Mahommah Gardo Baquaqua. Biography of Mahommah G. Baquaqua, a Native of Zoogoo, in the Interior of Africa. (A Convert to Christianity,) With a Description of That Part of the World; Including the Manners and Customs of the Inhabitants, Their Religious Notions, Form of Government, Laws, Appearance of the Country, Buildings, Agriculture, Manufactures, Shepherds and Herdsmen, Domestic Animals, Marriage Ceremonials, Funeral Services, Styles of Dress, Trade and Commerce, Modes of Warfare, System of Slavery, &amp;c., &amp;c. Mahommah&#039;s Early Life, His Education, His Capture and Slavery in Western Africa and Brazil, His Escape to the United States, from Thence to Hayti, (the City of Port Au Prince,) His Reception by the Baptist Missionary There, The Rev. W. L. Judd; His Conversion to Christianity, Baptism, and Return to This Country, His Views, Objects and Aim. Written and Revised from His Own Words, by Samuel Moore, Esq., Late Publisher of the &quot;North of England Shipping Gazette,&quot; Author of Several Popular Works, and Editor of Sundry Reform Papers.";
+        $truncatedTitle = substr($fullTitle,0,1011); // 1011 = 1024 - index name "value_title_1"
+        $fullTitleLength = strlen($fullTitle);
+        $truncatedTitleLength = strLen($truncatedTitle);
+
+        $rows = $this->generateTableRows("t_truncation");
+
+        // When using Mongo 2.4 and below, the string will not have been truncated.
+        // Due to stricter index key enforcement in Mongo 2.6 and above, the string will have been truncated.
+        // Allow the test to pass for either version of Mongo
+        $actualLength = strlen($rows['results'][0]['title']);
+        $this->assertTrue($actualLength === $fullTitleLength || $actualLength === $truncatedTitleLength, "Title is an unexpected length");
+
+        // Assert that the title starts with the truncated title.
+        // This will be the case for both Mongo 2.4 and Mongo 2.6
+        $this->assertTrue(strpos($rows['results'][0]['title'], $truncatedTitle) === 0, "Unexpected title");
+    }
+
+    /**
      * Test that link modifier is derived from the joined resource id, rather than base
      * @access public
      * @return void

--- a/test/unit/mongo/data/config.json
+++ b/test/unit/mongo/data/config.json
@@ -336,9 +336,6 @@
                     "ensureIndexes": [
                         {
                             "value.isbn": 1
-                        },
-                        {
-                            "value.title": 1
                         }
                     ],
                     "fields": [

--- a/test/unit/mongo/data/config.json
+++ b/test/unit/mongo/data/config.json
@@ -336,6 +336,9 @@
                     "ensureIndexes": [
                         {
                             "value.isbn": 1
+                        },
+                        {
+                            "value.title": 1
                         }
                     ],
                     "fields": [
@@ -346,6 +349,43 @@
                         {
                             "fieldName": "isbn",
                             "predicates": ["bibo:isbn13"]
+                        }
+                    ],
+                    "joins": {
+                        "dct:isVersionOf": {
+                            "fields": [
+                                {
+                                    "fieldName": "isbn13",
+                                    "predicates": ["bibo:isbn13"]
+                                }
+                            ]
+                        }
+                    }
+                },
+                {
+                    "_id": "t_truncation",
+                    "type": "acorn:ResourceForTruncating",
+                    "from": "CBD_testing",
+                    "ensureIndexes": [
+                        {
+                            "value.isbn": 1
+                        },
+                        {
+                            "value.title": 1
+                        }
+                    ],
+                    "fields": [
+                        {
+                            "fieldName": "type",
+                            "predicates": ["rdf:type"]
+                        },
+                        {
+                            "fieldName": "isbn",
+                            "predicates": ["bibo:isbn13"]
+                        },
+                        {
+                            "fieldName": "title",
+                            "predicates": ["searchterms:title"]
                         }
                     ],
                     "joins": {

--- a/test/unit/mongo/data/resources.json
+++ b/test/unit/mongo/data/resources.json
@@ -247,6 +247,117 @@
     },
     {
         "_id": {
+            "r":"http://talisaspire.com/resources/indexKeyTooLarge",
+            "c":"http://talisaspire.com/"
+        },
+        "_version": 0,
+        "dct:isVersionOf":
+        {
+            "u":"http://talisaspire.com/works/4d101f63c10a6"
+        },
+        "dct:source":[
+            {
+                "u":"http://life.ac.uk/resources/836E7CAD-63D2-63A0-B1CB-AA6A7E54A5C9"
+            },
+            {
+                "u":"http://life.ac.uk/resources/BFBC6A06-A8B0-DED8-53AA-8E80DB44CC53"
+            }
+        ],
+        "dct:subject":
+        {
+            "u":"http://talisaspire.com/disciplines/physics"
+        },
+        "bibo:isbn13":
+        {
+            "l":"1234567890123"
+        },
+        "acorn:bookmarkReferences":
+        {
+            "u":"http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA/bookmarks"
+        },
+        "acorn:foo":
+        {
+            "l":"wibble"
+        },
+        "acorn:jacsUri":[
+            {
+                "u":"http://jacs3.dataincubator.org/f300"
+            },
+            {
+                "u":"http://jacs3.dataincubator.org/f340"
+            }
+        ],
+        "acorn:listReferences":
+        {
+            "u":"http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA/lists"
+        },
+        "acorn:openLibraryUri":
+        {
+            "u":"http://openlibrary.org/books/OL10157958M"
+        },
+        "acorn:preferredMetadata":
+        {
+            "u":"http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA/metadata"
+        },
+        "searchterms:author":
+        {
+            "l":"Ohanian"
+        },
+        "searchterms:discipline":
+        {
+            "l":"physics"
+        },
+        "searchterms:isbn":
+        {
+            "l":"1234567890"
+        },
+        "searchterms:openLibrarySubject":[
+            {
+                "l":"Engineering: general"
+            },
+            {
+                "l":"PHYSICS"
+            },
+            {
+                "l":"Science"
+            }
+        ],
+        "searchterms:title":[
+
+            {
+                "l":"Mahommah Gardo Baquaqua. Biography of Mahommah G. Baquaqua, a Native of Zoogoo, in the Interior of Africa. (A Convert to Christianity,) With a Description of That Part of the World; Including the Manners and Customs of the Inhabitants, Their Religious Notions, Form of Government, Laws, Appearance of the Country, Buildings, Agriculture, Manufactures, Shepherds and Herdsmen, Domestic Animals, Marriage Ceremonials, Funeral Services, Styles of Dress, Trade and Commerce, Modes of Warfare, System of Slavery, &amp;c., &amp;c. Mahommah&#039;s Early Life, His Education, His Capture and Slavery in Western Africa and Brazil, His Escape to the United States, from Thence to Hayti, (the City of Port Au Prince,) His Reception by the Baptist Missionary There, The Rev. W. L. Judd; His Conversion to Christianity, Baptism, and Return to This Country, His Views, Objects and Aim. Written and Revised from His Own Words, by Samuel Moore, Esq., Late Publisher of the &quot;North of England Shipping Gazette,&quot; Author of Several Popular Works, and Editor of Sundry Reform Papers."
+            }
+        ],
+        "searchterms:topic":[
+            {
+                "l":"engineering: general"
+            },
+            {
+                "l":"physics"
+            },
+            {
+                "l":"science"
+            }
+        ],
+        "searchterms:usedAt":
+        {
+            "l":"0071"
+        },
+        "rdf:type":[
+            {
+                "u":"http://purl.org/ontology/bibo/Book"
+            },
+            {
+                "u":"http://talisaspire.com/schema#ResourceForTruncating"
+            }
+        ],
+        "owl:sameAs":
+        {
+            "u":"http://talisaspire.com/isbn/9780393929690"
+        }
+    },
+    {
+        "_id": {
             "r" : "http://jacs3.dataincubator.org/f300",
             "c":"http://talisaspire.com/"
         },


### PR DESCRIPTION
Mongo 2.6 has introduced stricter enforcement of the maximum
index key size. By default an index key > 1024 bytes now throws
an exception. This pull requests changes Table Row generation
to capture this error when thrown. The key is then truncated
and the save retried.