### PR TITLE
90%: Fix queue stats

### DIFF
--- a/src/classes/StatsD.class.php
+++ b/src/classes/StatsD.class.php
@@ -26,7 +26,7 @@ class StatsD implements ITripodStat
     {
         $this->host = $host;
         $this->port = $port;
-        $this->prefix = $prefix;
+        $this->setPrefix($prefix);
     }
 
     /**
@@ -153,10 +153,18 @@ class StatsD implements ITripodStat
 
     /**
      * @param string $prefix
+     * @throws \InvalidArgumentException
      */
     public function setPrefix($prefix)
     {
-        $this->prefix = $prefix;
+        if($this->isValidPathValue($prefix))
+        {
+            $this->prefix = $prefix;
+        }
+        else
+        {
+            throw new \InvalidArgumentException('Invalid prefix supplied');
+        }
     }
 
     /**
@@ -192,9 +200,15 @@ class StatsD implements ITripodStat
     }
 
     /**
+     * This method combines the by database and aggregate stats to send to StatsD.  The return will look something list:
+     * {
+     *  "{prefix}.tripod.group_by_db.{storeName}.{stat}"=>"1|c",
+     *  "{prefix}.tripod.{stat}"=>"1|c"
+     * }
+     *
      * @param string $operation
      * @param string|array $value
-     * @return array
+     * @return array An associative array of the grouped_by_database and aggregate stats
      */
     protected function generateStatData($operation, $value)
     {
@@ -216,10 +230,18 @@ class StatsD implements ITripodStat
 
     /**
      * @param string $pivotValue
+     * @throws \InvalidArgumentException
      */
     public function setPivotValue($pivotValue)
     {
-        $this->pivotValue = $pivotValue;
+        if($this->isValidPathValue($pivotValue))
+        {
+            $this->pivotValue = $pivotValue;
+        }
+        else
+        {
+            throw new \InvalidArgumentException('Invalid pivot value supplied');
+        }
     }
 
     /**
@@ -253,5 +275,15 @@ class StatsD implements ITripodStat
     protected function getAggregateStatPath()
     {
         return (empty($this->prefix) ? STAT_CLASS : $this->prefix . '.' . STAT_CLASS);
+    }
+
+    /**
+     * StatsD paths cannot start with, end with, or have more than one consecutive '.'
+     * @param $value
+     * @return bool
+     */
+    protected function isValidPathValue($value)
+    {
+        return (preg_match("/(^\.)|(\.\.+)|(\.$)/", $value) === 0);
     }
 }

--- a/src/classes/StatsD.class.php
+++ b/src/classes/StatsD.class.php
@@ -228,7 +228,7 @@ class StatsD implements ITripodStat
      */
     protected function getStatsPaths()
     {
-        return(array_values(array_filter($this->getStoreStatPath(), $this->getAggregateStatPath())));
+        return(array_values(array_filter(array($this->getStoreStatPath(), $this->getAggregateStatPath()))));
     }
 
     /**

--- a/src/classes/StatsD.class.php
+++ b/src/classes/StatsD.class.php
@@ -61,9 +61,8 @@ class StatsD implements ITripodStat
      */
     public function gauge($operation, $value)
     {
-        $key = (empty($this->prefix)) ? $operation : "{$this->prefix}.$operation";
         $this->send(
-            array($key=>$value."|g")
+            $this->generateStatData($operation, $value.'|g')
         );
     }
 

--- a/src/mongo/MongoTripodConstants.php
+++ b/src/mongo/MongoTripodConstants.php
@@ -89,7 +89,8 @@ define('MONGO_CONNECTION_ERROR','MONGO_CONNECTION_ERROR');
 
 define('SUBJECT_COUNT', 'subject_count');
 
-define('STAT_PREFIX', 'tripod.group_by_db.');
+define('STAT_CLASS', 'tripod');
+define('STAT_PIVOT_FIELD', 'group_by_db');
 
 //Audit types, statuses
 define('AUDIT_TYPE_REMOVE_INERT_LOCKS', 'REMOVE_INERT_LOCKS');

--- a/src/mongo/base/DriverBase.class.php
+++ b/src/mongo/base/DriverBase.class.php
@@ -89,14 +89,9 @@ abstract class DriverBase
     public function setStat(\Tripod\ITripodStat $stat)
     {
         // TODO: how do we decouple this and still allow StatsD to know which db we're using?
-        if($stat instanceof \Tripod\StatsD && strpos($stat->getPrefix(), STAT_PREFIX) === false)
+        if($stat instanceof \Tripod\StatsD)
         {
-            $prefix = STAT_PREFIX.$this->storeName;
-            if (!is_null($stat->getPrefix()))
-            {
-                $prefix = "{$stat->getPrefix()}.$prefix";
-            }
-            $stat->setPrefix($prefix);
+            $stat->setPivotValue($this->getStoreName());
         }
         $this->stat = $stat;
     }
@@ -111,11 +106,6 @@ abstract class DriverBase
         if($stat)
         {
             $statConfig = $stat->getConfig();
-            // Remove any prefix that we've added
-            if(isset($statConfig['config']['prefix']) && strpos($statConfig['config']['prefix'], STAT_PREFIX) !== false)
-            {
-                $statConfig['config']['prefix'] = preg_replace("/\.?".STAT_PREFIX.$this->storeName."/", '', $statConfig['config']['prefix']);
-            }
         }
         else
         {

--- a/src/mongo/base/JobBase.class.php
+++ b/src/mongo/base/JobBase.class.php
@@ -147,9 +147,8 @@ abstract class JobBase extends \Tripod\Mongo\DriverBase
      */
     public function getStat()
     {
-        if(!isset($this->statsConfig) && isset($this->args['statsConfig']))
+        if((!isset($this->statsConfig) || empty($this->statsConfig)) && isset($this->args['statsConfig']))
         {
-
             $this->statsConfig = $this->args['statsConfig'];
         }
         return parent::getStat();

--- a/test/unit/mongo/MongoTripodDriverTest.php
+++ b/test/unit/mongo/MongoTripodDriverTest.php
@@ -2097,14 +2097,14 @@ class MongoTripodDriverTest extends MongoTripodTestBase
 
         $this->assertEquals('example.com', $stat->getHost());
         $this->assertEquals(1234, $stat->getPort());
-        $this->assertEquals('somePrefix.tripod.group_by_db.tripod_php_testing', $stat->getPrefix());
+        $this->assertEquals('somePrefix', $stat->getPrefix());
 
         $config = $stat->getConfig();
         $this->assertEquals(
             array(
                 'host'=>'example.com',
                 'port'=>1234,
-                'prefix'=>'somePrefix.tripod.group_by_db.tripod_php_testing'
+                'prefix'=>'somePrefix'
             ),
             $config['config']
         );

--- a/test/unit/mongo/MongoTripodDriverTest.php
+++ b/test/unit/mongo/MongoTripodDriverTest.php
@@ -1988,7 +1988,8 @@ class MongoTripodDriverTest extends MongoTripodTestBase
     }
 
     public function testStatsD() {
-        $mockStatsD = $this->getMock('\Tripod\StatsD', array('send'), array("localhost","2012","myapp.tripod.group_by_db.tripod_php_testing"));
+        $mockStatsD = $this->getMock('\Tripod\StatsD', array('send'), array("localhost","2012","myapp"));
+        $mockStatsD->setPivotValue('tripod_php_testing');
 
         /* @var $mockTripod \Tripod\Mongo\Driver PHPUnit_Framework_MockObject_MockObject */
         $mockTripod = $this->getMock('\Tripod\Mongo\Driver', array('getStat'), array('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/',"statsDHost"=>"localhost","statsDPort"=>"2012","statsDPrefix"=>"myapp")));
@@ -1998,7 +1999,12 @@ class MongoTripodDriverTest extends MongoTripodTestBase
 
         $mockStatsD->expects($this->once())
             ->method("send")
-            ->with(array("myapp.tripod.group_by_db.tripod_php_testing.MONGO_GET_ETAG"=>"1|c"));
+            ->with(
+                array(
+                    "myapp.tripod.MONGO_GET_ETAG"=>"1|c",
+                    "myapp.tripod.group_by_db.tripod_php_testing.MONGO_GET_ETAG"=>"1|c"
+                )
+            );
 
         $mockTripod->getETag("http://foo");
     }

--- a/test/unit/mongo/MongoTripodStatTest.php
+++ b/test/unit/mongo/MongoTripodStatTest.php
@@ -58,10 +58,31 @@ class MongoTripodStatTest extends MongoTripodTestBase
         $stat->expects($this->once())
             ->method('send')
             ->with(
-                array('FOO.BAR'=>"1|c"),
+                array(STAT_CLASS.'.FOO.BAR'=>"1|c"),
                 1
             );
 
+
+        $stat->increment('FOO.BAR');
+    }
+
+    public function testStatsDIncrementWithPivotValueNoPrefix()
+    {
+        $statConfig = $this->getStatsDConfig();
+
+        $stat = $this->getMockStat($statConfig['config']['host'], $statConfig['config']['port']);
+
+        $stat->expects($this->once())
+            ->method('send')
+            ->with(
+                array(
+                    STAT_CLASS.'.'.STAT_PIVOT_FIELD.'.wibble.FOO.BAR'=>'1|c',
+                    STAT_CLASS.'.FOO.BAR'=>"1|c"
+                ),
+                1
+            );
+
+        $stat->setPivotValue('wibble');
 
         $stat->increment('FOO.BAR');
     }
@@ -74,12 +95,31 @@ class MongoTripodStatTest extends MongoTripodTestBase
         $stat->expects($this->once())
             ->method('send')
             ->with(
-                array('somePrefix.FOO.BAR'=>"1|c"),
+                array('somePrefix.' . STAT_CLASS. '.FOO.BAR'=>"1|c"),
                 1
             );
 
 
         $stat->increment('FOO.BAR');
+    }
+
+    public function testStatsDIncrementWithPivotValueAndPrefix()
+    {
+        $statConfig = $this->getStatsDConfig();
+
+        $stat = $this->getMockStat($statConfig['config']['host'], $statConfig['config']['port'], $statConfig['config']['prefix']);
+        $stat->expects($this->once())
+            ->method('send')
+            ->with(
+                array(
+                    'somePrefix.' . STAT_CLASS . '.' . STAT_PIVOT_FIELD . '.wibble.FOO.BAR'=>"5|c",
+                    'somePrefix.' . STAT_CLASS.'.FOO.BAR'=>"5|c"
+                ),
+                1
+            );
+
+        $stat->setPivotValue('wibble');
+        $stat->increment('FOO.BAR', 5);
     }
 
     public function testStatsDTimerNoPrefix()
@@ -90,7 +130,7 @@ class MongoTripodStatTest extends MongoTripodTestBase
         $stat->expects($this->once())
             ->method('send')
             ->with(
-                array('FOO.BAR'=>array("1|c","1234|ms")),
+                array(STAT_CLASS . '.FOO.BAR'=>array("1|c","1234|ms")),
                 1
             );
 
@@ -98,6 +138,24 @@ class MongoTripodStatTest extends MongoTripodTestBase
         $stat->timer('FOO.BAR', 1234);
     }
 
+    public function testStatsDTimerWithPivotValueNoPrefix()
+    {
+        $statConfig = $this->getStatsDConfig();
+
+        $stat = $this->getMockStat($statConfig['config']['host'], $statConfig['config']['port']);
+        $stat->expects($this->once())
+            ->method('send')
+            ->with(
+                array(
+                    STAT_CLASS . '.' . STAT_PIVOT_FIELD . '.wibble.FOO.BAR'=>array("1|c","1234|ms"),
+                    STAT_CLASS . '.FOO.BAR'=>array("1|c","1234|ms")
+                ),
+                1
+            );
+
+        $stat->setPivotValue('wibble');
+        $stat->timer('FOO.BAR', 1234);
+    }
     public function testStatsDTimerWithPrefix()
     {
         $statConfig = $this->getStatsDConfig();
@@ -106,11 +164,30 @@ class MongoTripodStatTest extends MongoTripodTestBase
         $stat->expects($this->once())
             ->method('send')
             ->with(
-                array('somePrefix.FOO.BAR'=>array("1|c","4567|ms")),
+                array('somePrefix.' . STAT_CLASS. '.FOO.BAR'=>array("1|c","4567|ms")),
                 1
             );
 
 
+        $stat->timer('FOO.BAR',4567);
+    }
+
+    public function testStatsDTimerWithPrefixAndPivotValue()
+    {
+        $statConfig = $this->getStatsDConfig();
+
+        $stat = $this->getMockStat($statConfig['config']['host'], $statConfig['config']['port'], $statConfig['config']['prefix']);
+        $stat->expects($this->once())
+            ->method('send')
+            ->with(
+                array(
+                    'somePrefix.' . STAT_CLASS . '.' . STAT_PIVOT_FIELD . '.wibble.FOO.BAR'=>array("1|c","4567|ms"),
+                    'somePrefix.' . STAT_CLASS . '.FOO.BAR'=>array("1|c","4567|ms")
+                ),
+                1
+            );
+
+        $stat->setPivotValue('wibble');
         $stat->timer('FOO.BAR',4567);
     }
 
@@ -122,10 +199,29 @@ class MongoTripodStatTest extends MongoTripodTestBase
         $stat->expects($this->once())
             ->method('send')
             ->with(
-                array('FOO.BAR'=>"xyz|g"),
+                array(STAT_CLASS.'.FOO.BAR'=>"xyz|g"),
                 1
             );
 
+
+        $stat->gauge('FOO.BAR', 'xyz');
+    }
+
+    public function testStatsDGaugeWithPivotValueNoPrefix()
+    {
+        $statConfig = $this->getStatsDConfig();
+
+        $stat = $this->getMockStat($statConfig['config']['host'], $statConfig['config']['port']);
+        $stat->expects($this->once())
+            ->method('send')
+            ->with(
+                array(
+                    STAT_CLASS. '.' . STAT_PIVOT_FIELD .'.wibble.FOO.BAR'=>"xyz|g",
+                    STAT_CLASS.'.FOO.BAR'=>"xyz|g"
+                ),
+                1
+            );
+        $stat->setPivotValue('wibble');
 
         $stat->gauge('FOO.BAR', 'xyz');
     }
@@ -138,11 +234,30 @@ class MongoTripodStatTest extends MongoTripodTestBase
         $stat->expects($this->once())
             ->method('send')
             ->with(
-                array('somePrefix.FOO.BAR'=>"abc|g"),
+                array('somePrefix.' . STAT_CLASS . '.FOO.BAR'=>"abc|g"),
                 1
             );
 
 
+        $stat->gauge('FOO.BAR', 'abc');
+    }
+
+    public function testStatsDGaugeWithPrefixAndPivotValue()
+    {
+        $statConfig = $this->getStatsDConfig();
+
+        $stat = $this->getMockStat($statConfig['config']['host'], $statConfig['config']['port'], $statConfig['config']['prefix']);
+        $stat->expects($this->once())
+            ->method('send')
+            ->with(
+                array(
+                    'somePrefix.' . STAT_CLASS . '.' . STAT_PIVOT_FIELD . '.wibble.FOO.BAR'=>"abc|g",
+                    'somePrefix.' . STAT_CLASS . '.FOO.BAR'=>"abc|g"
+                ),
+                1
+            );
+
+        $stat->setPivotValue('wibble');
         $stat->gauge('FOO.BAR', 'abc');
     }
 }

--- a/test/unit/mongo/MongoTripodStatTest.php
+++ b/test/unit/mongo/MongoTripodStatTest.php
@@ -260,4 +260,49 @@ class MongoTripodStatTest extends MongoTripodTestBase
         $stat->setPivotValue('wibble');
         $stat->gauge('FOO.BAR', 'abc');
     }
+
+    public function testPrefixCannotStartWithDot()
+    {
+        $this->setExpectedException('InvalidArgumentException', 'Invalid prefix supplied');
+
+        $stat = new \Tripod\StatsD('foo.bar', 4567, '.some_prefix');
+    }
+
+    public function testPrefixCannotEndWithDot()
+    {
+        $this->setExpectedException('InvalidArgumentException', 'Invalid prefix supplied');
+
+        $stat = new \Tripod\StatsD('foo.bar', 4567, 'some_prefix.');
+    }
+
+    public function testPrefixCannotContainConsecutiveDot()
+    {
+        $this->setExpectedException('InvalidArgumentException', 'Invalid prefix supplied');
+
+        $stat = new \Tripod\StatsD('foo.bar', 4567, 'some..prefix');
+    }
+
+    public function testPivotValueCannotStartWithDot()
+    {
+        $this->setExpectedException('InvalidArgumentException', 'Invalid pivot value supplied');
+
+        $stat = new \Tripod\StatsD('foo.bar', 4567);
+        $stat->setPivotValue('.someValue');
+    }
+
+    public function testPivotValueCannotEndWithDot()
+    {
+        $this->setExpectedException('InvalidArgumentException', 'Invalid pivot value supplied');
+
+        $stat = new \Tripod\StatsD('foo.bar', 4567);
+        $stat->setPivotValue('someValue.');
+    }
+
+    public function testPivotValueCannotContainConsecutiveDot()
+    {
+        $this->setExpectedException('InvalidArgumentException', 'Invalid pivot value supplied');
+
+        $stat = new \Tripod\StatsD('foo.bar', 4567);
+        $stat->setPivotValue('some..value');
+    }
 }


### PR DESCRIPTION
This PR brings in 2 changes:
1. it fixes a bug where queue stats weren't actually getting sent: `JobBase->getStat()` was using `isset($this->statConfig)` to determine if there was already a config set, but since it defaults to an array, it also needed to check if it was empty
2. It rips out the faulty understanding of the stats prefix and hard codes both "by store" (database) and aggregate stats with each stats send