### PR TITLE
20% Outdated spec regeneration

### DIFF
--- a/src/mongo/Config.class.php
+++ b/src/mongo/Config.class.php
@@ -2064,6 +2064,48 @@ class Config
     }
 
     /**
+    * Creates a specification revision subdocument for a composite specification.
+    *
+    * @param \MongoCollection $specification - the composite specification
+    * @return array|null - the subdocument to add to the composite
+    **/
+    public static function getSpecRevisionSubDoc($specification) {
+        if(isset($specification) && isset($specification[_ID_KEY]) && isset($specification[_REVISION])) {
+            return array(
+                _SPEC_KEY => array(
+                    _SPEC_TYPE=> $specification[_ID_KEY],
+                    _SPEC_REVISION => $specification[_REVISION]
+                )
+            );
+        } else {
+            return null;
+        }
+    }
+
+    /**
+    * Ensures that specification revision is indexed for a composite collection.
+    *
+    * Note that spec revision is not required for all composite documents, so
+    * a sparse index is used to avoid indexing unrevisioned documents.
+    *
+    * @param \MongoCollection $compositeCollection - the composite collection
+    **/
+    public static function ensureIndexForSpecRevision($compositeCollection) {
+        if(isset($compositeCollection)) {
+            $compositeCollection->ensureIndex(
+                array(
+                    _SPEC_KEY.'.'._SPEC_TYPE => 1,
+                    _SPEC_KEY.'.'._SPEC_REVISION => 1
+                ),
+                array(
+                    'background' => 1,
+                    'sparse' => 1
+                )
+            );
+        }
+    }
+
+    /**
      * @return string
      */
     public static function getDiscoverQueueName()

--- a/src/mongo/Config.class.php
+++ b/src/mongo/Config.class.php
@@ -1795,6 +1795,18 @@ class Config
 
     /**
      * @param string $storeName
+     * @param Array $spec
+     * @param string $readPreference
+     * @throws \Tripod\Exceptions\ConfigException
+     * @return \MongoCollection
+     */
+    public function getFromCollectionForSpec($storeName, $spec, $readPreference = \MongoClient::RP_PRIMARY_PREFERRED)
+    {
+        return $this->getCollectionForCBD($storeName, $spec['from'], $readPreference);
+    }
+
+    /**
+     * @param string $storeName
      * @param string $viewId
      * @param string $readPreference
      * @throws \Tripod\Exceptions\ConfigException

--- a/src/mongo/Config.class.php
+++ b/src/mongo/Config.class.php
@@ -1806,6 +1806,32 @@ class Config
     }
 
     /**
+     * Gets the collection containing documents for a given composite type.
+     * @param string $compositeType
+     * @param string $storeName
+     * @param string $viewId
+     * @param string $readPreference
+     * @throws \Tripod\Exceptions\ConfigException
+     * @return \MongoCollection
+     */
+    public function getCollectionForCompositeType($compositeType, $storeName, $compositeId, $readPreference = \MongoClient::RP_PRIMARY_PREFERRED)
+    {
+        switch ($compositeType) {
+            case COMPOSITE_TYPE_VIEWS:
+                return $this->getCollectionForView($storeName, $compositeId, $readPreference);
+
+            case COMPOSITE_TYPE_TABLES:
+                return $this->getCollectionForTable($storeName, $compositeId, $readPreference);
+
+            case COMPOSITE_TYPE_SEARCH:
+                return $this->getCollectionForSearchDocument($storeName, $compositeId, $readPreference);
+
+            default:
+                throw new \Tripod\Exceptions\ConfigException("Undefined composite type '$compositeType' requested");
+        }
+    }
+
+    /**
      * @param string $storeName
      * @param string $viewId
      * @param string $readPreference

--- a/src/mongo/ICompositeRegen.php
+++ b/src/mongo/ICompositeRegen.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tripod\Mongo\Composites;
+
+/**
+ * Interface ICompositeRegen
+ * @package Tripod\Mongo\Composites
+ */
+interface ICompositeRegen
+{
+    /**
+     * Regenerate a specific composite document from its spec and root CBD
+     * @param $specification
+     * @param $compositeCollection
+     * @param $rootCbd
+     * @return void
+     */
+    public function regenerateOne($specification, $compositeCollection, $rootCbd);
+}

--- a/src/mongo/MongoTripodConstants.php
+++ b/src/mongo/MongoTripodConstants.php
@@ -7,6 +7,10 @@ define('VIEWS_COLLECTION', 'views');
 define('LOCKS_COLLECTION', 'locks');
 define('AUDIT_MANUAL_ROLLBACKS_COLLECTION','audit_manual_rollbacks');
 
+// Config specification keys
+define('CONFIG_KEY_SPEC_VIEWS', 'view_specifications');
+define('CONFIG_KEY_SPEC_TABLE_ROWS', 'table_specifications');
+
 // search
 define('SEARCH_INDEX_COLLECTION', 'search');
 define("SEARCH_PROVIDER_MONGO", '\Tripod\Mongo\MongoSearchProvider');
@@ -18,7 +22,11 @@ define('_ID_KEY', '_id');
 define('_ID_RESOURCE','r');
 define('_ID_CONTEXT','c');
 define('_ID_TYPE','type');
+define('_SPEC_KEY','_spec');
+define('_SPEC_REVISION','revision');
+define('_SPEC_TYPE','type');
 define('_VERSION','_version');
+define('_REVISION','_revision');
 define('_LOCKED_FOR_TRANS','_lockedForTrans');
 define('_LOCKED_FOR_TRANS_TS','_lts');
 define('_IMPACT_INDEX','_impactIndex');

--- a/src/mongo/MongoTripodConstants.php
+++ b/src/mongo/MongoTripodConstants.php
@@ -37,6 +37,11 @@ define('VALUE_LITERAL','l');
 define('_UPDATED_TS', '_uts');
 define('_CREATED_TS', '_cts');
 
+// available composite types
+define('COMPOSITE_TYPE_VIEWS','COMPOSITE_TYPE_VIEWS');
+define('COMPOSITE_TYPE_TABLES','COMPOSITE_TYPE_TABLES');
+define('COMPOSITE_TYPE_SEARCH','COMPOSITE_TYPE_SEARCH');
+
 // operations that Tripod performs
 define('OP_VIEWS','generate_views');
 define('OP_TABLES','generate_table_rows');

--- a/src/mongo/MongoTripodConstants.php
+++ b/src/mongo/MongoTripodConstants.php
@@ -7,10 +7,6 @@ define('VIEWS_COLLECTION', 'views');
 define('LOCKS_COLLECTION', 'locks');
 define('AUDIT_MANUAL_ROLLBACKS_COLLECTION','audit_manual_rollbacks');
 
-// Config specification keys
-define('CONFIG_KEY_SPEC_VIEWS', 'view_specifications');
-define('CONFIG_KEY_SPEC_TABLE_ROWS', 'table_specifications');
-
 // search
 define('SEARCH_INDEX_COLLECTION', 'search');
 define("SEARCH_PROVIDER_MONGO", '\Tripod\Mongo\MongoSearchProvider');

--- a/src/mongo/delegates/Views.class.php
+++ b/src/mongo/delegates/Views.class.php
@@ -12,7 +12,7 @@ use Tripod\Mongo\Labeller;
  * Class Views
  * @package Tripod\Mongo\Composites
  */
-class Views extends CompositeBase
+class Views extends CompositeBase implements ICompositeRegen
 {
 
     /**
@@ -877,4 +877,15 @@ class Views extends CompositeBase
         return $this->getConfigInstance()->getCollectionForView($this->storeName, $viewSpecId);
     }
 
+    
+    /**
+     * Regenerate a specific composite document from its spec and root CBD
+     * @param $specification
+     * @param $compositeCollection
+     * @param $rootCbd
+     * @return void
+     */
+    public function regenerateOne($specification, $compositeCollection, $rootCbd) {
+        $this->saveGeneratedView($specification, $compositeCollection, $rootCbd, $specification['from'], $this->defaultContext);
+    }
 }

--- a/src/mongo/delegates/Views.class.php
+++ b/src/mongo/delegates/Views.class.php
@@ -536,7 +536,7 @@ class Views extends CompositeBase
     * @param \MongoCollection $collection - the views composite collection
     * @param array $doc - the root CBD from which this view is generated
     * @param string $from - the name of the CBD collection from which $doc is drawn
-    * @param array $contextAlias - the context for this view
+    * @param string $contextAlias - the context for this view
     **/
     public function saveGeneratedView($viewSpec, $collection, $doc, $from, $contextAlias) {
         // set up ID

--- a/src/mongo/delegates/Views.class.php
+++ b/src/mongo/delegates/Views.class.php
@@ -19,7 +19,7 @@ class Views extends CompositeBase
      * Construct accepts actual objects rather than strings as this class is a delegate of
      * Tripod and should inherit connections set up there
      * @param string $storeName
-     * @param \MongoCollection $collection
+     * @param \MongoCollection $collection // TODO: should this really be a constructor arg?
      * @param $defaultContext
      * @param null $stat
      * @param string $readPreference

--- a/src/mongo/delegates/Views.class.php
+++ b/src/mongo/delegates/Views.class.php
@@ -169,6 +169,7 @@ class Views extends CompositeBase
         {
             $this->getStat()->increment(MONGO_VIEW_CACHE_MISS.".$viewType");
             $viewSpec = Config::getInstance()->getViewSpecification($this->storeName, $viewType);
+            // TODO: remove this line once discussion closed.
             if($viewSpec == null)
             {
                 return new \Tripod\Mongo\MongoGraph();

--- a/src/mongo/delegates/Views.class.php
+++ b/src/mongo/delegates/Views.class.php
@@ -534,7 +534,7 @@ class Views extends CompositeBase
         }
     }
 
-    protected function saveGeneratedView($viewSpec, $collection, $doc, $from, $contextAlias) {
+    public function saveGeneratedView($viewSpec, $collection, $doc, $from, $contextAlias) {
         // set up ID
         $generatedView = array(
             "_id" => array(

--- a/src/mongo/jobs/DiscoverOutdatedComposites.class.php
+++ b/src/mongo/jobs/DiscoverOutdatedComposites.class.php
@@ -1,0 +1,210 @@
+<?php
+
+namespace Tripod\Mongo\Jobs;
+
+use \Tripod\Mongo\Config;
+/**
+ * Class DiscoverImpactedSubjects
+ *
+ * This job finds documents in composite collections whose specs are out-of-date. It should be periodically triggered.
+ *
+ * The job will find all composite specifications, and for each of those, run a query to find a set of outdated documents.
+ *
+ * For a config with S specifications, each `perform()` call will therefore run S independent queries, each of which may
+ * return up to CURSOR_LIMIT documents to update, thus regenerating a maximum of `S*CURSOR_LIMIT` composite documents.
+ *
+ * @package Tripod\Mongo\Jobs
+ */
+class DiscoverOutdatedComposites extends JobBase {
+
+    const STORE_NAME_KEY = 'storeName';
+    const CURSOR_LIMIT = 'cursorLimit';
+
+    /**
+     * Run the DiscoverOutdatedComposites job
+     * @throws \Exception
+     */
+    public function perform()
+    {
+        $this->debugLog("DiscoverOutdatedComposites::perform() start");
+
+        $this->validateArgs();
+
+        $config = $this->args[self::TRIPOD_CONFIG_KEY];
+        $storeName = $this->args[self::STORE_NAME_KEY];
+        $cursorLimit = $this->args[self::CURSOR_LIMIT];
+
+        // set the config to what is received
+        \Tripod\Mongo\Config::setConfig($config);
+
+        // TODO: remove these fakes. Only here to satisfy Views, which probably does not
+        // need either of these as constructor arguments.
+        $fakeCollection = null;
+        $fakeDefaultContext = null;
+
+        $views = new \Tripod\Mongo\Composites\Views(
+            $storeName,
+            $fakeCollection,
+            $fakeDefaultContext
+        );
+
+        // closure around $cursorLimit in $this->getRegenTasksForMetadata
+        $getRegenTasksForMetadata = function($metadatum) use ($cursorLimit) { 
+            return $this->getRegenTasksForMetadata($metadatum, $cursorLimit); 
+        };
+
+        // TODO: optimisations... this currently fetches a collection for every composite spec, even when many 
+        // composites will share the same collection (e.g. db.views on data1, or db.table_rows on data2).
+        // It should be possible to compose each individual query into an '$or' query across all $metadatum 
+        // instances that share the same datasource/collection pair.
+        // That would reduce the number of queries from |specifications| to |<datasource,collection>| pairs.
+
+        // compile a list of all composite configuration metadata objects
+        $compositeMetadata = $this->getCompositeMetadata($config, $storeName);
+
+        // for each composite metadata instance, fetch regen tasks (where they exist), which include specific CBDs to regenerate
+        $regenTasksIncludingNulls = array_map($getRegenTasksForMetadata, $compositeMetadata);
+        $regenTasks = array_filter($regenTasksIncludingNulls, 'isset');
+
+        // for collected regeneration tasks, run the update
+        $this->runRegenerationTasks($regenTasks, $views);
+    }
+
+    /**
+     * @param array $data
+     * @param string|null $queueName
+     */
+    public function createJob(Array $data, $queueName=null)
+    {
+        if(!$queueName)
+        {
+            $queueName = Config::getDiscoverQueueName();
+        }
+        elseif(strpos($queueName, \Tripod\Mongo\Config::getDiscoverQueueName()) === false)
+        {
+            $queueName = \Tripod\Mongo\Config::getDiscoverQueueName() . '::' . $queueName;
+        }
+        $this->submitJob($queueName,get_class($this),$data);
+    }
+
+    /**
+     * Validate arguments in the job message
+     * @return array
+     */
+    protected function getMandatoryArgs()
+    {
+        return array(
+            self::TRIPOD_CONFIG_KEY,
+            self::STORE_NAME_KEY,
+            self::CURSOR_LIMIT
+        );
+    }
+
+    protected function runRegenerationTasks($regenTasks, $views) {
+        foreach ($regenTasks as $regenTask) {
+            $spec = $regenTask->specification;
+            $compositeCollection = $regenTask->compositeCollection;
+            foreach($cbdDocs as $cbdDoc) {
+                $this->regenerateComposite($specification, $compositeCollection, $cbdDoc, $views);
+            }
+        }
+    }
+
+    protected function getRegenTasksForMetadata($metadatum, $cursorLimit) {
+        $compositeCollection = $metadatum->compositeCollection;
+        $specification = $metadatum->specification;
+        $cbdCollection = $metadatum->cbdCollection;
+
+        $filterOutdated = $metadatum->getOutdatedQueryComponent();
+
+        if(!isset($filterOutdated)) {
+            return null;
+        } else {
+            // find one cursor page at a time for this composite
+            $outdatedComposites = 
+                $compositeCollection
+                    // TODO: select only the fields we need from the database, 
+                    // not entire composite document; just array(_ID_KEY)
+                    ->find($filterOutdated)
+                    ->limit($cursorLimit);
+
+            $outdatedCbdIds = array_map($this->composite2cbdId, $outdatedComposites);
+            $filterCbdsById = array('$or' => $outdatedCbdIds);
+            $cbdDocs = $cbdCollection->find($filterCbdsById);
+
+            return new CbdRegeneration($specification, $compositeCollection, $cbdDocs);
+        }
+    }
+
+    public function getCompositeMetadata($config, $storeName) {
+        // for a given view specification, collect the metadata we need to run queries
+        $view2metadata = function($spec) use ($config, $storeName) {
+            $viewCollection = $config->getCollectionForView($storeName, $spec[_ID_KEY]);
+            $cbdCollection = $config->getFromCollectionForSpec($storeName, $spec);
+            return new CompositeMetadata(OP_VIEWS, $spec, $viewCollection, $cbdCollection);
+        };
+
+        $viewMetadata = array_map($view2metadata, $config->getViewSpecifications($storeName));
+
+        // TODO: bring in the other composite types, too
+        return $viewMetadata;
+    }
+
+    protected function composite2cbdId($compositeDocument) {
+        // these must be valid - they come from a valid composite
+        $cbdResourceAlias = $compositeDocument[_ID_KEY][_ID_RESOURCE];
+        $cbdContextAlias = $compositeDocument[_ID_KEY][_ID_CONTEXT];
+        return array(_ID_KEY => 
+            array(_ID_RESOURCE => $cbdResourceAlias, _ID_CONTEXT => $cbdContextAlias));
+    }
+
+    // TODO: this is limited to views at present. Abstract it.
+    protected function regenerateComposite($spec, $compositeCollection, $cbdDoc, $views, $context=null) {
+        // regenerate this composite from the CBD
+        $contextAlias = $this->getContextAlias($context);
+        $views->saveGeneratedView($spec, $compositeCollection, $cbdDoc, $spec['from'], $contextAlias);
+    }
+
+}
+
+class CompositeMetadata {
+    public $compositeType;
+    public $specification;
+    public $compositeCollection;
+    public $cbdCollection;
+
+    public function __construct($compositeType, $specification, $compositeCollection, $cbdCollection)
+    {
+        $this->compositeType = $compositeType;
+        $this->specification = $specification;
+        $this->compositeCollection = $compositeCollection;
+        $this->cbdCollection = $cbdCollection;
+    }
+
+    public function getOutdatedQueryComponent() {
+        if(isset($this->specification[_REVISION])) {
+            $specType = _SPEC_KEY.'.'._SPEC_TYPE;
+            $specRevision = _SPEC_KEY.'.'._SPEC_REVISION;
+            return array(
+                $specType => $this->specification[_ID_KEY],
+                $specRevision => array('$lt' => $this->specification[_REVISION])
+            );
+        } else {
+            return null;
+        }
+    }
+}
+
+
+class CbdRegeneration {
+    public $specification;
+    public $compositeCollection;
+    public $cbdDocuments;
+
+    public function __construct($specification, $compositeCollection, $cbdDocuments)
+    {
+        $this->specification = $specification;
+        $this->compositeCollection = $compositeCollection;
+        $this->cbdDocuments = $cbdDocuments;
+    }
+}

--- a/src/mongo/jobs/DiscoverOutdatedComposites.class.php
+++ b/src/mongo/jobs/DiscoverOutdatedComposites.class.php
@@ -119,7 +119,7 @@ class DiscoverOutdatedComposites extends JobBase {
         };
 
         // views
-        $viewRegen = $this->makeViewRegenFunc($storeName);
+        $viewRegen = $this->makeViewRegenFunc($config, $storeName);
         $view2metadata = function($spec) use ($composite2metadata, $viewRegen) {
             return $composite2metadata(COMPOSITE_TYPE_VIEWS, $spec, $viewRegen);
         };
@@ -131,24 +131,24 @@ class DiscoverOutdatedComposites extends JobBase {
     }
 
     // TODO: this should really live in IComposite implementations, but cannot yet.
-    public function makeViewRegenFunc($storeName) {
+    public function makeViewRegenFunc($config, $storeName) {
+        $defaultContext = $config->getDefaultContextAlias();
         // TODO: remove $views from here. We need it because that class provides a method for
         // regenerating indvidual views.  However, that should probably be abstracted somewhere,
         // into a method capable of regenerating individual composites, by type.
 
         // TODO: these fakes are only here to satisfy Views, which probably does not
         // need either of these as constructor arguments (most methods in Views are agnostic)
-        $fakeCollection = \Tripod\Mongo\Config::getInstance()->getCollectionForCBD($storeName, 'CBD_testing');
-        $fakeDefaultContext = 'http://talisaspire.com/';
+        $fakeCollection = $config->getCollectionForCBD($storeName, 'CBD_testing');
 
         $views = new \Tripod\Mongo\Composites\Views(
             $storeName,
             $fakeCollection,
-            $fakeDefaultContext
+            $defaultContext
         );
 
-        return function($spec, $compositeCollection, $cbdDoc) use ($fakeDefaultContext, $views) {
-            $views->saveGeneratedView($spec, $compositeCollection, $cbdDoc, $spec['from'], $fakeDefaultContext);
+        return function($spec, $compositeCollection, $cbdDoc) use ($defaultContext, $views) {
+            $views->saveGeneratedView($spec, $compositeCollection, $cbdDoc, $spec['from'], $defaultContext);
         };
     }
     

--- a/src/mongo/jobs/DiscoverOutdatedComposites.class.php
+++ b/src/mongo/jobs/DiscoverOutdatedComposites.class.php
@@ -155,10 +155,8 @@ class DiscoverOutdatedComposites extends JobBase {
                 return null;
             } else {
                 // find IDs root CBDs required to regenerate the composite
-                $composite2cbdId = function($doc) { return $this->composite2cbdId($doc); };
-
                 $outdatedCbdIds = 
-                    array_map($composite2cbdId, iterator_to_array($outdatedComposites, false));
+                    array_map(array($this, 'composite2cbdId'), iterator_to_array($outdatedComposites, false));
 
                 // fetch the CBDs themselves
                 $filterCbdsById = array('$or' => $outdatedCbdIds);

--- a/src/mongo/jobs/DiscoverOutdatedComposites.class.php
+++ b/src/mongo/jobs/DiscoverOutdatedComposites.class.php
@@ -95,13 +95,18 @@ class DiscoverOutdatedComposites extends JobBase {
         );
     }
 
-    
+    /**
+    * Given an array of regeneration tasks, runs all those tasks.
+    *
+    * @param array $regenTasks
+    **/
     public function runRegenerationTasks($regenTasks) {
         foreach ($regenTasks as $regenTask) {
             $specification = $regenTask->specification;
             $compositeCollection = $regenTask->compositeCollection;
             $compositeRegenFunction = $regenTask->compositeRegenFunction;
             
+            // regenerate individual composites from root CBDs and specifications
             foreach($regenTask->cbdDocuments as $cbdDoc) {
                 $compositeRegenFunction($specification, $compositeCollection, $cbdDoc);
             }
@@ -183,6 +188,13 @@ class DiscoverOutdatedComposites extends JobBase {
         };
     }
 
+    /**
+    * Gets a list of all CompositeMetadata objects, one per composite in the specification.
+    *
+    * @param \Config $config - the configuration instance
+    * @param string $storeName
+    * @return array - an array of CompositeMetadata objects
+    **/
     public function getCompositeMetadata($config, $storeName) {
         // for a given composite type and specification, collect the metadata we need to run queries
         $composite2metadata = function($compositeType, $spec, $regenFunc) use ($config, $storeName) {
@@ -225,6 +237,9 @@ class DiscoverOutdatedComposites extends JobBase {
     }
 }
 
+/**
+* Represents data about a particular kind of composite, and provides tools for regenerating documents.
+**/
 class CompositeMetadata {
     public $compositeType;
     public $specification;
@@ -279,7 +294,12 @@ class CompositeMetadata {
     }
 }
 
-
+/**
+* Represents a task for regenerating a number of composites.
+* 
+* Contains enough information on the composite collection, and a list of root CBDs,
+* which are used to regenerate outdated composite documents.
+**/
 class CompositeRegenTask {
     public $compositeRegenFunction;
     public $specification;

--- a/src/mongo/jobs/DiscoverOutdatedComposites.class.php
+++ b/src/mongo/jobs/DiscoverOutdatedComposites.class.php
@@ -105,7 +105,7 @@ class DiscoverOutdatedComposites extends JobBase {
     **/
     public function getCompositeMetadata($config, $storeName) {
         // for a given composite type and specification, collect the metadata we need to run queries
-        $composite2metadata = function($compositeType, $spec, $regenFunc) use ($config, $storeName) {
+        $compositeToMetadata = function($compositeType, $spec, $regenFunc) use ($config, $storeName) {
             $compositeCollection = 
                 $config->getCollectionForCompositeType($compositeType, $storeName, $spec[_ID_KEY]);
             $cbdCollection = $config->getFromCollectionForSpec($storeName, $spec);
@@ -120,8 +120,8 @@ class DiscoverOutdatedComposites extends JobBase {
 
         // views
         $viewRegen = $this->makeViewRegenFunc($config, $storeName);
-        $view2metadata = function($spec) use ($composite2metadata, $viewRegen) {
-            return $composite2metadata(COMPOSITE_TYPE_VIEWS, $spec, $viewRegen);
+        $view2metadata = function($spec) use ($compositeToMetadata, $viewRegen) {
+            return $compositeToMetadata(COMPOSITE_TYPE_VIEWS, $spec, $viewRegen);
         };
 
         $viewMetadata = array_map($view2metadata, $config->getViewSpecifications($storeName));
@@ -188,7 +188,7 @@ class DiscoverOutdatedComposites extends JobBase {
             } else {
                 // find IDs root CBDs required to regenerate the composite
                 $outdatedCbdIds = 
-                    array_map(array($this, 'composite2cbdId'), iterator_to_array($outdatedComposites, false));
+                    array_map(array($this, 'compositeToCBDID'), iterator_to_array($outdatedComposites, false));
 
                 // fetch the CBDs themselves
                 $filterCbdsById = array('$or' => $outdatedCbdIds);
@@ -216,7 +216,7 @@ class DiscoverOutdatedComposites extends JobBase {
     * @param array $compositeDocument - the composite being examined
     * @return array - the ID of $compositeDocument's root CBD.
     **/
-    protected function composite2cbdId($compositeDocument) {
+    protected function compositeToCBDID($compositeDocument) {
         // these must be valid - they come from a valid composite
         $cbdResourceAlias = $compositeDocument[_ID_KEY][_ID_RESOURCE];
         $cbdContextAlias = $compositeDocument[_ID_KEY][_ID_CONTEXT];

--- a/src/mongo/jobs/DiscoverOutdatedComposites.class.php
+++ b/src/mongo/jobs/DiscoverOutdatedComposites.class.php
@@ -173,27 +173,23 @@ class DiscoverOutdatedComposites extends JobBase {
         }
     }
 
-    public function iterator2array($iterator) {
-        $array = array();
-        foreach($iterator as $item) {
-            $array[] = $item;
-        }
-        return $array;
-    }
-
     public function getCompositeMetadata($config, $storeName) {
-        // for a given view specification, collect the metadata we need to run queries
-        $view2metadata = function($spec) use ($config, $storeName) {
-            // TODO: it would be useful if config->getCollectionForView were abstracted
-            // to lookup by composite-type
-            $viewCollection = $config->getCollectionForView($storeName, $spec[_ID_KEY]);
+        // for a given composite type and specification, collect the metadata we need to run queries
+        $composite2metadata = function($compositeType, $spec) use ($config, $storeName) {
+            $compositeCollection = 
+                $config->getCollectionForCompositeType($compositeType, $storeName, $spec[_ID_KEY]);
             $cbdCollection = $config->getFromCollectionForSpec($storeName, $spec);
             return new CompositeMetadata(
-                COMPOSITE_TYPE_VIEWS, 
+                $compositeType, 
                 $spec, 
-                $viewCollection, 
+                $compositeCollection, 
                 $cbdCollection
             );
+        };
+
+        // views
+        $view2metadata = function($spec) use ($composite2metadata) {
+            return $composite2metadata(COMPOSITE_TYPE_VIEWS, $spec);
         };
 
         $viewMetadata = array_map($view2metadata, $config->getViewSpecifications($storeName));

--- a/src/mongo/jobs/DiscoverOutdatedComposites.class.php
+++ b/src/mongo/jobs/DiscoverOutdatedComposites.class.php
@@ -200,7 +200,7 @@ class DiscoverOutdatedComposites extends JobBase {
 
         // views
         $viewRegen = $this->makeViewRegenFunc($storeName);
-        $view2metadata = function($spec) use ($viewRegen) {
+        $view2metadata = function($spec) use ($composite2metadata, $viewRegen) {
             return $composite2metadata(COMPOSITE_TYPE_VIEWS, $spec, $viewRegen);
         };
 

--- a/src/tripod.inc.php
+++ b/src/tripod.inc.php
@@ -20,6 +20,7 @@ require_once TRIPOD_DIR.'mongo/MongoGraph.class.php';
 require_once TRIPOD_DIR.'mongo/ImpactedSubject.class.php';
 require_once TRIPOD_DIR . 'mongo/base/DriverBase.class.php';
 require_once TRIPOD_DIR.'mongo/IComposite.php';
+require_once TRIPOD_DIR.'mongo/ICompositeRegen.php';
 require_once TRIPOD_DIR.'mongo/base/CompositeBase.class.php';
 require_once TRIPOD_DIR . 'mongo/delegates/TransactionLog.class.php';
 require_once TRIPOD_DIR . 'mongo/delegates/Updates.class.php';

--- a/src/tripod.inc.php
+++ b/src/tripod.inc.php
@@ -34,6 +34,7 @@ require_once TRIPOD_DIR . '/mongo/Driver.class.php';
 
 require_once TRIPOD_DIR.'/mongo/base/JobBase.class.php';
 require_once TRIPOD_DIR . '/mongo/jobs/DiscoverImpactedSubjects.class.php';
+require_once TRIPOD_DIR . '/mongo/jobs/DiscoverOutdatedComposites.class.php';
 require_once TRIPOD_DIR.'/mongo/jobs/ApplyOperation.class.php';
 
 require_once TRIPOD_DIR . '/mongo/util/IndexUtils.class.php';

--- a/test/unit/mongo/DiscoverOutdatedCompositesTest.php
+++ b/test/unit/mongo/DiscoverOutdatedCompositesTest.php
@@ -1,0 +1,98 @@
+<?php
+
+require_once 'MongoTripodTestBase.php';
+/**
+ * Class DiscoverOutdatedCompositesTest
+ */
+class DiscoverOutdatedCompositesTest extends MongoTripodTestBase
+{
+    protected $args = array();
+    
+    public function testMandatoryArgTripodConfig() {
+        $this->setArgs();
+        unset($this->args['tripodConfig']);
+        $job = new \Tripod\Mongo\Jobs\DiscoverOutdatedComposites();
+        $job->args = $this->args;
+        $this->setExpectedException('Exception', "Argument tripodConfig was not present in supplied job args for job Tripod\Mongo\Jobs\DiscoverOutdatedComposites");
+        $job->perform();
+    }
+
+    public function testMandatoryArgStoreName() {
+        $this->setArgs();
+        unset($this->args['storeName']);
+        $job = new \Tripod\Mongo\Jobs\DiscoverOutdatedComposites();
+        $job->args = $this->args;
+        $this->setExpectedException('Exception', "Argument storeName was not present in supplied job args for job Tripod\Mongo\Jobs\DiscoverOutdatedComposites");
+        $job->perform();
+    }
+
+    public function testMandatoryArgCursorLimit() {
+        $this->setArgs();
+        unset($this->args['cursorLimit']);
+        $job = new \Tripod\Mongo\Jobs\DiscoverOutdatedComposites();
+        $job->args = $this->args;
+        $this->setExpectedException('Exception', "Argument cursorLimit was not present in supplied job args for job Tripod\Mongo\Jobs\DiscoverOutdatedComposites");
+        $job->perform();
+    }
+
+    public function testGetCompositeMetadataReturnsOnePerViewSpec() {
+        $CONFIG = \Tripod\Mongo\Config::getInstance();
+        $STORE_NAME = 'tripod_php_testing';
+        $ALL_VIEW_SPECS = $CONFIG->getViewSpecifications('tripod_php_testing');
+
+        $SPEC_KEY_REVISION = _SPEC_KEY.'.'._SPEC_REVISION;
+        $SPEC_KEY_TYPE     = _SPEC_KEY.'.'._SPEC_TYPE;
+
+        $this->setArgs();
+        $discoverOutdatedComposites = new \Tripod\Mongo\Jobs\DiscoverOutdatedComposites();
+        $discoverOutdatedComposites->args = $this->args;
+
+        // fetch all composite metadata
+        $compositeMetadata = $discoverOutdatedComposites->getCompositeMetadata($CONFIG, $STORE_NAME);
+
+        // fetch the views information only
+        $viewsOnly = array_filter($compositeMetadata, function($metadatum) { return $metadatum->compositeType === OP_VIEWS; });
+
+        // there should be one metadata entry per view
+        $this->assertCount(count($ALL_VIEW_SPECS), $viewsOnly);
+
+        // each metadata entry should have view-specific information
+        foreach ($viewsOnly as $viewMetadata) {
+            $this->assertEquals(OP_VIEWS, $viewMetadata->compositeType, "type of composite is incorrect");
+            $this->assertArrayHasKey(_ID_KEY, $viewMetadata->specification, "specification is not defined, or does not define an \"_id\" key");
+            $this->assertEquals("views", $viewMetadata->compositeCollection->getName(), "does not reference a collection called \"views\"");
+            $this->assertStringStartsWith("CBD_", $viewMetadata->cbdCollection->getName(), "does not reference a /^CBD_.*/ collection");
+
+            // $queryComponent should be a $lt on the specified revision for the view
+            $queryComponent = $viewMetadata->getOutdatedQueryComponent();
+
+            $expectedQuery = array(
+                $SPEC_KEY_TYPE     => $viewMetadata->specification['_id'],
+                $SPEC_KEY_REVISION => array('$lt' => $viewMetadata->specification['_revision'])
+            );
+            $this->assertEquals($expectedQuery, $queryComponent);
+        }
+
+        // there's one metadata entry per view spec
+        $meta2spec = function($meta) { return $meta->specification; };
+        $this->assertEquals($ALL_VIEW_SPECS, array_map($meta2spec, $viewsOnly));
+    }
+
+    public function testGetCompositeMetadataReturnsOnePerTableSpec() {
+        $this->markTestIncomplete('TODO: testGetCompositeMetadataReturnsOnePerViewSpec, but for table_rows');
+    }
+
+    public function testGetCompositeMetadataReturnsOnePerSearchSpec() {
+        $this->markTestIncomplete('TODO: testGetCompositeMetadataReturnsOnePerViewSpec, but for searches');   
+    }
+
+    protected function setArgs() {
+        $this->args = array(
+            'tripodConfig' => \Tripod\Mongo\Config::getConfig(),
+            'storeName'    => 'tripod_php_testing',
+            'podName'      => 'CBD_testing',
+            'cursorLimit'  => 50,
+            'contextAlias' => 'http://talisaspire.com/'
+        );
+    }
+}

--- a/test/unit/mongo/DiscoverOutdatedCompositesTest.php
+++ b/test/unit/mongo/DiscoverOutdatedCompositesTest.php
@@ -279,8 +279,7 @@ class DiscoverOutdatedCompositesTest extends MongoTripodTestBase
         // the task should contain all root CBDs used to regenerate the chosen composites
         // However, it's hard to compare this directly, so extract CBD IDs and compare with
         // those extracted directly from the affected views
-        $cbdDocs = iterator_to_array($actualRegenTask->cbdDocuments, false);
-        $actualCbdResourceIds = array_map($doc2resource, $cbdDocs);
+        $actualCbdResourceIds = array_map($doc2resource, $actualRegenTask->cbdDocuments);
 
         $this->assertEquals($expectedCbdResourceIds, $actualCbdResourceIds);
     }

--- a/test/unit/mongo/DiscoverOutdatedCompositesTest.php
+++ b/test/unit/mongo/DiscoverOutdatedCompositesTest.php
@@ -324,7 +324,7 @@ class DiscoverOutdatedCompositesTest extends MongoTripodTestBase
         $compositeMetadata = 
             new \Tripod\Mongo\Jobs\CompositeMetadata(
                 COMPOSITE_TYPE_VIEWS, $FAKE_VIEW_SPEC, $viewCollection, $cbdCollection, 
-                $discoverOutdatedComposites->makeViewRegenFunc(self::STORE_NAME)
+                $discoverOutdatedComposites->makeViewRegenFunc($CONFIG, self::STORE_NAME)
             );
 
         // setup to call getRegenTaskForMetadata

--- a/test/unit/mongo/DiscoverOutdatedCompositesTest.php
+++ b/test/unit/mongo/DiscoverOutdatedCompositesTest.php
@@ -6,7 +6,52 @@ require_once 'MongoTripodTestBase.php';
  */
 class DiscoverOutdatedCompositesTest extends MongoTripodTestBase
 {
+    // arguments passed to jobs
     protected $args = array();
+
+    /**
+     * @var \Tripod\Mongo\Composites\Views
+     */
+    protected $tripodViews = null;
+
+    protected function setUp()
+    {
+        parent::setup();
+
+        $this->tripodTransactionLog = new \Tripod\Mongo\TransactionLog();
+        $this->tripodTransactionLog->purgeAllTransactions();
+
+        // Stub ouf 'addToElastic' search to prevent writes into Elastic Search happening by default.
+        /** @var \Tripod\Mongo\Driver|PHPUnit_Framework_MockObject_MockObject $this->tripod */
+        $this->tripod = $this->getMock(
+            '\Tripod\Mongo\Driver',
+            array('addToSearchIndexQueue'),
+            array('CBD_testing','tripod_php_testing',
+                array(
+                    "defaultContext"=>"http://talisaspire.com/",
+                    "async"=>array(OP_VIEWS=>false)
+                )
+            ) // don't generate views syncronously when saving automatically - let unit tests deal with this
+        );
+        $this->tripod->expects($this->any())->method('addToSearchIndexQueue');
+
+        $this->getTripodCollection($this->tripod)->drop();
+        $this->tripod->setTransactionLog($this->tripodTransactionLog);
+
+        $this->tripodViews = new \Tripod\Mongo\Composites\Views(
+            $this->tripod->getStoreName(),
+            $this->getTripodCollection($this->tripod),
+            'http://talisaspire.com/'
+        );
+
+        foreach(\Tripod\Mongo\Config::getInstance()->getCollectionsForViews($this->tripod->getStoreName()) as $collection)
+        {
+            $collection->drop();
+        }
+
+        // load base data
+        $this->loadResourceDataViaTripod();
+    }
     
     public function testMandatoryArgTripodConfig() {
         $this->setArgs();
@@ -38,7 +83,7 @@ class DiscoverOutdatedCompositesTest extends MongoTripodTestBase
     public function testGetCompositeMetadataReturnsOnePerViewSpec() {
         $CONFIG = \Tripod\Mongo\Config::getInstance();
         $STORE_NAME = 'tripod_php_testing';
-        $ALL_VIEW_SPECS = $CONFIG->getViewSpecifications('tripod_php_testing');
+        $ALL_VIEW_SPECS = $CONFIG->getViewSpecifications($STORE_NAME);
 
         $SPEC_KEY_REVISION = _SPEC_KEY.'.'._SPEC_REVISION;
         $SPEC_KEY_TYPE     = _SPEC_KEY.'.'._SPEC_TYPE;
@@ -51,14 +96,14 @@ class DiscoverOutdatedCompositesTest extends MongoTripodTestBase
         $compositeMetadata = $discoverOutdatedComposites->getCompositeMetadata($CONFIG, $STORE_NAME);
 
         // fetch the views information only
-        $viewsOnly = array_filter($compositeMetadata, function($metadatum) { return $metadatum->compositeType === OP_VIEWS; });
+        $viewsOnly = array_filter($compositeMetadata, function($metadatum) { return $metadatum->compositeType === COMPOSITE_TYPE_VIEWS; });
 
         // there should be one metadata entry per view
         $this->assertCount(count($ALL_VIEW_SPECS), $viewsOnly);
 
         // each metadata entry should have view-specific information
         foreach ($viewsOnly as $viewMetadata) {
-            $this->assertEquals(OP_VIEWS, $viewMetadata->compositeType, "type of composite is incorrect");
+            $this->assertEquals(COMPOSITE_TYPE_VIEWS, $viewMetadata->compositeType, "type of composite is incorrect");
             $this->assertArrayHasKey(_ID_KEY, $viewMetadata->specification, "specification is not defined, or does not define an \"_id\" key");
             $this->assertEquals("views", $viewMetadata->compositeCollection->getName(), "does not reference a collection called \"views\"");
             $this->assertStringStartsWith("CBD_", $viewMetadata->cbdCollection->getName(), "does not reference a /^CBD_.*/ collection");
@@ -85,6 +130,175 @@ class DiscoverOutdatedCompositesTest extends MongoTripodTestBase
     public function testGetCompositeMetadataReturnsOnePerSearchSpec() {
         $this->markTestIncomplete('TODO: testGetCompositeMetadataReturnsOnePerViewSpec, but for searches');   
     }
+
+    public function testGetOutdatedQueryComponentReturnsNullWhenNoRevisionOnViewSpec() {
+        $CONFIG = \Tripod\Mongo\Config::getInstance();
+        $STORE_NAME = 'tripod_php_testing';
+        $VIEW_ID = 'v_resource_full';
+        $VIEW_SPEC = $CONFIG->getViewSpecification($STORE_NAME, $VIEW_ID);
+
+        // define a fake view specification with no revision
+        $FAKE_VIEW_SPEC = $VIEW_SPEC;
+        unset($FAKE_VIEW_SPEC[_REVISION]);
+
+        // construct a CompositeMetadata around the fake view spec
+        $compositeMetadata = new \Tripod\Mongo\Jobs\CompositeMetadata(COMPOSITE_TYPE_VIEWS, $FAKE_VIEW_SPEC, null, null);
+
+        // the outdated query-component should be null when revision is missing
+        $this->assertNull($compositeMetadata->getOutdatedQueryComponent(), 'For a CompositeMetadata whose spec has no "revision", getOutdatedQueryComponent() should return NULL.');
+    }
+
+    public function testGetOutdatedQueryComponentReturnsAQueryForValidRevisionOnViewSpec() {
+        $CONFIG = \Tripod\Mongo\Config::getInstance();
+        $STORE_NAME = 'tripod_php_testing';
+        $VIEW_ID = 'v_resource_full';
+        $VIEW_SPEC = $CONFIG->getViewSpecification($STORE_NAME, $VIEW_ID);
+
+        $SPEC_KEY_REVISION = _SPEC_KEY.'.'._SPEC_REVISION;
+        $SPEC_KEY_TYPE     = _SPEC_KEY.'.'._SPEC_TYPE;
+
+        // define a fake view specification with no revision
+        $FAKE_VIEW_SPEC = $VIEW_SPEC;
+        $FAKE_VIEW_SPEC[_REVISION] = 1;
+
+        // construct a CompositeMetadata around the fake view spec
+        $compositeMetadata = 
+            new \Tripod\Mongo\Jobs\CompositeMetadata(COMPOSITE_TYPE_VIEWS, $FAKE_VIEW_SPEC, null, null);
+
+        // $queryComponent should be a $lt on the specified revision for the view
+        $queryComponent = $compositeMetadata->getOutdatedQueryComponent();
+
+        $expectedQuery = array(
+            $SPEC_KEY_TYPE     => $VIEW_ID,
+            $SPEC_KEY_REVISION => array('$lt' => 1)
+        );
+        $this->assertEquals($expectedQuery, $queryComponent);
+    }
+
+    // -- DiscoverOutdatedComposites.getRegenTaskForMetadata
+
+    public function testGetRegenTasksForMetadataReturnsNullWhenNoRevisionOnViewSpec() {
+        $CONFIG = \Tripod\Mongo\Config::getInstance();
+        $STORE_NAME = 'tripod_php_testing';
+        $VIEW_ID = 'v_resource_full';
+        $VIEW_SPEC = $CONFIG->getViewSpecification($STORE_NAME, $VIEW_ID);
+
+        // mock a CompositeMetadata with a null outdated component
+        $mockCompositeMetadata = 
+            $this->getMockBuilder('\Tripod\Mongo\Jobs\CompositeMetadata')
+                ->setMethods(array('getOutdatedQueryComponent'))
+                ->setConstructorArgs(array(COMPOSITE_TYPE_VIEWS, $VIEW_SPEC, null, null))
+                ->getMock();
+        $mockCompositeMetadata->expects($this->once())
+            ->method('getOutdatedQueryComponent')
+            ->will($this->returnValue(null));
+
+        
+        // setup to call getRegenTaskForMetadata
+        $this->setArgs();
+        $discoverOutdatedComposites = new \Tripod\Mongo\Jobs\DiscoverOutdatedComposites();
+        $discoverOutdatedComposites->args = $this->args;
+
+        $regenTasks = $discoverOutdatedComposites
+            ->getRegenTaskForMetadata($mockCompositeMetadata, 10);
+
+        // ... which should return null
+        $this->assertNull($regenTasks, 'getRegenTaskForMetadata() should return NULL for a CompositeMetadata with NULL getOutdatedQueryComponent()');
+    }
+
+
+    public function testGetRegenTasksForMetadataReturnsNullWhenAllViewDocumentsUpToDate() {
+        $CONFIG = \Tripod\Mongo\Config::getInstance();
+        $STORE_NAME = 'tripod_php_testing';
+        $VIEW_ID = 'v_resource_full';
+        $VIEW_SPEC = $CONFIG->getViewSpecification($STORE_NAME, $VIEW_ID);
+
+        $viewCollection = $CONFIG->getCollectionForView($STORE_NAME, $VIEW_SPEC[_ID_KEY]);
+        $cbdCollection = $CONFIG->getFromCollectionForSpec($STORE_NAME, $VIEW_SPEC);
+
+        // construct a CompositeMetadata around specified view spec
+        $compositeMetadata = 
+            new \Tripod\Mongo\Jobs\CompositeMetadata(
+                COMPOSITE_TYPE_VIEWS, $VIEW_SPEC, $viewCollection, $cbdCollection
+            );
+
+        // setup to call getRegenTaskForMetadata
+        $this->setArgs();
+        $discoverOutdatedComposites = new \Tripod\Mongo\Jobs\DiscoverOutdatedComposites();
+        $discoverOutdatedComposites->args = $this->args;
+
+        $regenTask = $discoverOutdatedComposites
+            ->getRegenTaskForMetadata($compositeMetadata, 10);
+
+        // ... which should return null
+        $this->assertNull($regenTask, 'getRegenTaskForMetadata() should return NULL when there are no outdated documents in composite');
+    }
+
+
+    public function testGetRegenTasksForMetadataReturnsDocumentsToUpdateWhenViewRevised() {
+        $CONFIG = \Tripod\Mongo\Config::getInstance();
+        $STORE_NAME = 'tripod_php_testing';
+        $VIEW_ID = 'v_resource_full';
+        $VIEW_SPEC = $CONFIG->getViewSpecification($STORE_NAME, $VIEW_ID);
+
+        $mongo = new MongoClient($CONFIG->getConnStr($STORE_NAME));
+        $viewCollection = $CONFIG->getCollectionForView($STORE_NAME, $VIEW_SPEC[_ID_KEY]);
+
+        // trigger generation for some particular views (so the view documents exist)
+        $this->tripodViews->getViewForResource(
+            "http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA",
+            "v_resource_full"
+        );
+
+        // Create a fake view with an incremented revision
+        // Now, all documents for this view will be treated as "outdated"
+        $FAKE_VIEW_SPEC = $VIEW_SPEC;
+        $FAKE_VIEW_SPEC[_REVISION] += 1;
+
+        // fetch all documents from the view, and their CBD IDs. We will use these later
+        // as expected values, since all of these should be marked "outdated"
+        $filterToChosenView = array(_ID_KEY.'.'._ID_TYPE => $VIEW_ID);
+        $fieldsIdOnly = array(_ID_KEY.'.'._ID_RESOURCE => 1);
+        $allDocIdsFromView = 
+            $mongo
+                ->selectCollection($STORE_NAME, VIEWS_COLLECTION)
+                ->find($filterToChosenView, $fieldsIdOnly);
+
+        // extract the CBD resource IDs from the target views, for later comparison
+        $doc2resource = function($doc) { return $doc[_ID_KEY][_ID_RESOURCE]; };
+        $expectedCbdResourceIds = 
+            array_map($doc2resource, iterator_to_array($allDocIdsFromView, false));
+
+        // construct a CompositeMetadata around our fake view spec
+        $cbdCollection = $CONFIG->getFromCollectionForSpec($STORE_NAME, $VIEW_SPEC);
+        $compositeMetadata = 
+            new \Tripod\Mongo\Jobs\CompositeMetadata(
+                COMPOSITE_TYPE_VIEWS, $FAKE_VIEW_SPEC, $viewCollection, $cbdCollection
+            );
+
+        // setup to call getRegenTaskForMetadata
+        $this->setArgs();
+        $discoverOutdatedComposites = new \Tripod\Mongo\Jobs\DiscoverOutdatedComposites();
+        $discoverOutdatedComposites->args = $this->args;
+
+        // UNDER TEST: this returns a task describing how to regenerate outdated CBDs
+        $actualRegenTask = 
+            $discoverOutdatedComposites->getRegenTaskForMetadata($compositeMetadata, 10);
+
+        // the task should reference the right spec and composite collection
+        $this->assertEquals($FAKE_VIEW_SPEC, $actualRegenTask->specification);
+        $this->assertEquals($viewCollection, $actualRegenTask->compositeCollection);
+        
+        // the task should contain all root CBDs used to regenerate the chosen composites
+        // However, it's hard to compare this directly, so extract CBD IDs and compare with
+        // those extracted directly from the affected views
+        $cbdDocs = iterator_to_array($actualRegenTask->cbdDocuments, false);
+        $actualCbdResourceIds = array_map($doc2resource, $cbdDocs);
+
+        $this->assertEquals($expectedCbdResourceIds, $actualCbdResourceIds);
+    }
+
+    // -- utility methods
 
     protected function setArgs() {
         $this->args = array(

--- a/test/unit/mongo/MongoTripodConfigTest.php
+++ b/test/unit/mongo/MongoTripodConfigTest.php
@@ -874,6 +874,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
     public function testGetViewSpecification(){
         $expectedVspec = array(
             "_id"=> "v_resource_full",
+            "_revision" => 1,
             "_version" => "0.1",
             "from"=>"CBD_testing",
             "to_data_source"=>"rs1", // This should get added automatically

--- a/test/unit/mongo/MongoTripodViewsTest.php
+++ b/test/unit/mongo/MongoTripodViewsTest.php
@@ -69,6 +69,10 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
                 _ID_RESOURCE=>"http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA",
                 _ID_CONTEXT=>'http://talisaspire.com/',
                 "type"=>"v_resource_full"),
+            _SPEC_KEY => array(
+                _SPEC_TYPE => "v_resource_full",
+                _SPEC_REVISION => 1
+            ),
             "value"=>array(
                 _GRAPHS=>array(
                     array(
@@ -119,6 +123,10 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
                 _ID_RESOURCE=>"http://talisaspire.com/resources/filter1",
                 _ID_CONTEXT=>'http://talisaspire.com/',
                 "type"=>"v_resource_filter1"),
+            _SPEC_KEY => array(
+                _SPEC_TYPE => "v_resource_filter1",
+                _SPEC_REVISION => 1
+            ),
             "value"=>array(
                 _GRAPHS=>array(
                     // This Book should not be included in the view - we are filtering to include only chapters.
@@ -186,6 +194,10 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
                 _ID_RESOURCE=>"http://talisaspire.com/resources/filter1",
                 _ID_CONTEXT=>'http://talisaspire.com/',
                 "type"=>"v_resource_filter2"),
+            _SPEC_KEY => array(
+                _SPEC_TYPE => "v_resource_filter2",
+                _SPEC_REVISION => 1
+            ),
             "value"=>array(
                 _GRAPHS=>array(
                     // http://talisaspire.com/works/filter2 has the matching literal
@@ -247,6 +259,10 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
                 _ID_RESOURCE=>"http://talisaspire.com/resources/filter1",
                 _ID_CONTEXT=>'http://talisaspire.com/',
                 "type"=>"v_resource_filter1"),
+            _SPEC_KEY => array(
+                _SPEC_TYPE => "v_resource_filter1",
+                _SPEC_REVISION => 1
+            ),
             "value"=>array(
                 _GRAPHS=>array(
                     // This Book should not be included in the view - we are filtering to include only chapters.
@@ -316,6 +332,10 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
                 _ID_RESOURCE=>"http://talisaspire.com/resources/filter1",
                 _ID_CONTEXT=>'http://talisaspire.com/',
                 "type"=>"v_resource_filter1"),
+            _SPEC_KEY => array(
+                _SPEC_TYPE => "v_resource_filter1",
+                _SPEC_REVISION => 1
+            ),
             "value"=>array(
                 _GRAPHS=>array(
                     // This work is now included as it's type has changed to Chapter
@@ -381,6 +401,10 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
                 _ID_RESOURCE=>"http://talisaspire.com/resources/filter1",
                 _ID_CONTEXT=>'http://talisaspire.com/',
                 "type"=>"v_resource_rdfsequence"),
+            _SPEC_KEY => array(
+                _SPEC_TYPE => "v_resource_rdfsequence",
+                _SPEC_REVISION => 1
+            ),
             "value"=>array(
                 _GRAPHS=>array(
                      array(
@@ -454,6 +478,10 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
                 "r"=>"http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA",
                 "c"=>'http://talisaspire.com/',
                 "type"=>"v_resource_full_ttl"),
+            _SPEC_KEY => array(
+                _SPEC_TYPE => "v_resource_full_ttl",
+                _SPEC_REVISION => 1
+            ),
             "value"=>array(
                 _GRAPHS=>array(
                     array(
@@ -548,6 +576,10 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
                 "r"=>"http://talisaspire.com/works/4d101f63c10a6",
                 "c"=>"http://talisaspire.com/",
                 "type"=>"v_counts"),
+            _SPEC_KEY => array(
+                _SPEC_TYPE => "v_counts",
+                _SPEC_REVISION => 1
+            ),
             "value"=>array(
                 _GRAPHS=>array(
                     array(

--- a/test/unit/mongo/data/config.json
+++ b/test/unit/mongo/data/config.json
@@ -63,6 +63,7 @@
                 {
                     "_id": "v_resource_full",
                     "_version": "0.1",
+                    "_revision": 1,
                     "from": "CBD_testing",
                     "ensureIndexes": [
                         {
@@ -80,6 +81,7 @@
                 },
                 {
                     "_id": "v_resource_full_ttl",
+                    "_revision": 1,
                     "type": "acorn:Resource",
                     "from": "CBD_testing",
                     "to_data_source": "rs2",
@@ -93,6 +95,7 @@
                 },
                 {
                     "_id": "v_resource_to_single_source",
+                    "_revision": 1,
                     "type": "acorn:Resource",
                     "from": "CBD_testing",
                     "include": ["rdf:type"],
@@ -104,6 +107,7 @@
                 },
                 {
                     "_id": "v_work_see_also",
+                    "_revision": 1,
                     "type": "acorn:Work",
                     "from": "CBD_testing",
                     "joins": {
@@ -112,6 +116,7 @@
                 },
                 {
                     "_id": "v_work2_see_also",
+                    "_revision": 1,
                     "type": "http://talisaspire.com/schema#Work2",
                     "from": "CBD_testing",
                     "joins": {
@@ -120,6 +125,7 @@
                 },
                 {
                     "_id": "v_counts",
+                    "_revision": 1,
                     "type": "acorn:Work",
                     "from": "CBD_testing",
                     "to_data_source": "rs2",
@@ -168,6 +174,7 @@
                 },
                 {
                     "_id": "v_doc_with_seqeunce",
+                    "_revision": 1,
                     "type": ["baseData:DocWithSequence"],
                     "from": "CBD_testing",
                     "joins": {
@@ -183,6 +190,7 @@
                 {
                     "_id": "v_resource_filter1",
                     "_version": "0.1",
+                    "_revision": 1,
                     "from": "CBD_testing",
                     "type": "acorn:Resource",
                     "include": ["rdf:type", "searchterms:topic"],
@@ -198,6 +206,7 @@
                 {
                     "_id": "v_resource_filter2",
                     "_version": "0.1",
+                    "_revision": 1,
                     "from": "CBD_testing",
                     "type": "acorn:Resource",
                     "include": ["rdf:type", "searchterms:topic"],
@@ -213,6 +222,7 @@
                 {
                     "_id": "v_resource_rdfsequence",
                     "_version": "0.1",
+                    "_revision": 1,
                     "from": "CBD_testing",
                     "type": "acorn:Resource",
                     "include": ["_seq_", "rdf:type"],


### PR DESCRIPTION
This PR is still work-in-progress, but at a point where feedback is sought.
# Aims
- Adds a `revision` to composite specifications, a monotonically-increasing integer
- When a composite document is being saved, include the specification revision in the document
- Provide a query to find composite documents that are generated with older (outdated) specifications
- Regenerates outdated composite documents

The current code deals only with views, but should generalise to other composites.  Some of the mechanisms are already generic enough to support this, but where they are not, I've attempted to provide more abstract mechanisms.  There are some that need reworking.

The bulk of the code is in a new job, called `DiscoverOutdatedComposites`.  This is designed to run on a CRON schedule, and at each `perform` step, will iterate across all composites, find a list of documents that need regeneration, and trigger their regeneration.  The current code does this all inside `perform` for a single job, but the ultimate intention is to split out the regeneration from the discovery.

No effort has been made to include logging or profiling at this point.  No effort has been made to trigger jobs.  Testing is unit-test only.
## Representing Revisions

The code currently uses independent revision numbers for every composite spec.  This is simple, and makes comparisons easy, so documents need regeneration when:
- For a single document, its `revision` is less than the revision of its specification;
- For a query, we can just use mongodb's `$lt` operator to extract all matches.

It's also easy for distribution, since outdated replicas will naturally stop contributing (eventually).

Despite this simplicity, this revisioning scheme has issues:
- It's a lot of manual work to manage spec updates;
- It is hard to automate, because we need to retain a history of changes, making build-time revision update difficult (we need to store history somewhere external - a file of `<specification, revision, hash>` triples, perhaps?)
### Alternative: single revision number, plus per-specification hashes

The original suggestion from Chris was to use a hash, since it picks up semantic changes only, and is easy to compute.  Without some notion of order, however, it's possible to get into "tennis matches", where two replicas disagree on the correct hash, and attempt to undo each other's work.  By adding in a single global revision (again monotonically-increasing), we can provide the order needed to resolve this problem.

Using a hash makes comparisons more complex, so documents need regeneration when:
- For a single document, its `revision` is less than the global revision **and** its hash is different to the hash of its specification;
- For a query, we need `{ _revision: { $lt: <GLOBAL REVISION> }, _hash: { $ne: <SPEC. HASH> }}`

Note that the revision is checked first in both cases, so takes precedence over the hash.

The hash-based approach has a couple of nice properties:
- We can trivially automate incrementing the global revision (since we don't need to compare with previous versions - the hash will do that)
- The hash only captures semantic changes
## Issues with the current code
### Composite classes are tied to podNames

In order to construct a `Views` instance, I need a collection associated with a `podName`, which is broadly unused.  Within each composite, the collection/podName are rarely used, but they are enforced by the hierarchy (`Views <-- CompositeBase <-- DriverBase`).  It cannot be simply removed.

I'm not sure that Views/Tables/Search is conceptually tied to a pod.  Could do with some discussion here to figure out why it is tied thus at present.
### Regeneration is not uniformly available

We really need to create a generic mechanism for regenerating a document from its spec and root CBD, defined at the level of `IComposite`.  I've added another interface (`ICompositeRegen`) for now, so it need not be immediately applied to all composite types.
## TODO
- [ ] Remove comments that are present only for discussion in the PR;
- [ ] Settle the revision/hash debate
- [ ] Split the discovery and regeneration jobs on to separate queues
- [x] Abstract the regeneration code into (a subset of) `IComposite` implementors.
- [ ] Fetch all types of composites during the discovery step
- [ ] Add logging back in - especially for counts of outdated documents
- [ ] Add profiling
