### PR TITLE
90% TENT-1872 Add retry logic to tripod

### DIFF
--- a/src/mongo/Config.class.php
+++ b/src/mongo/Config.class.php
@@ -1767,6 +1767,7 @@ class Config
                 try {
                     $this->connections[$dataSource] = new \MongoClient($ds['connection'], $connectionOptions);
                 } catch (\MongoConnectionException $e) {
+                    self::getLogger()->warn("MongoConnectionException: " . $e->getMessage());
                     sleep(1);
                     $retries++;
                     $exception = $e;
@@ -1775,6 +1776,7 @@ class Config
             } while ($retries < self::CONNECTION_RETRIES && (!isset($this->connections[$dataSource]) && $this->connections[$dataSource]>connected !== true ));
 
             if (!isset($this->connections[$dataSource])) {
+                self::getLogger()->warn("MongoConnectionException after " . self::CONNECTION_RETRIES . " attempts: " . $e->getMessage());
                 throw new \MongoConnectionException($exception);
             }
         }

--- a/src/mongo/Config.class.php
+++ b/src/mongo/Config.class.php
@@ -1762,10 +1762,16 @@ class Config
         {
             $retries = 1;
             $exception = null;
+            $connected = false;
 
             do {
                 try {
                     $this->connections[$dataSource] = $this->getMongoClient($ds['connection'], $connectionOptions);
+                    // Check if we are connected
+                    $connections = $this->connections[$dataSource]->getConnections();
+                    if (empty($connections) === false) {
+                        $connected = true;
+                    }
                 } catch (\MongoConnectionException $e) {
                     self::getLogger()->warn("MongoConnectionException: " . $e->getMessage());
                     sleep(1);
@@ -1773,7 +1779,7 @@ class Config
                     $exception = $e;
                 }
 
-            } while ($retries <= self::CONNECTION_RETRIES && (!isset($this->connections[$dataSource]) || (isset($this->connections[$dataSource]) && $this->connections[$dataSource]->connected !== true)));
+            } while ($retries <= self::CONNECTION_RETRIES && $connected == false);
 
             if (!isset($this->connections[$dataSource])) {
                 self::getLogger()->warn("MongoConnectionException after " . $retries . " attempts (MAX:".self::CONNECTION_RETRIES."): " . $e->getMessage());

--- a/src/mongo/Config.class.php
+++ b/src/mongo/Config.class.php
@@ -1773,16 +1773,16 @@ class Config
                         $connected = true;
                     }
                 } catch (\MongoConnectionException $e) {
-                    self::getLogger()->warn("MongoConnectionException: " . $e->getMessage());
+                    self::getLogger()->error("MongoConnectionException attempt ".$retries.". Retrying...:" . $e->getMessage());
                     sleep(1);
                     $retries++;
                     $exception = $e;
                 }
 
-            } while ($retries <= self::CONNECTION_RETRIES && $connected == false);
+            } while ($retries <= self::CONNECTION_RETRIES && $connected === false);
 
             if (!isset($this->connections[$dataSource])) {
-                self::getLogger()->warn("MongoConnectionException after " . $retries . " attempts (MAX:".self::CONNECTION_RETRIES."): " . $e->getMessage());
+                self::getLogger()->error("MongoConnectionException failed after " . $retries . " attempts (MAX:".self::CONNECTION_RETRIES."): " . $e->getMessage());
                 throw new \MongoConnectionException($exception);
             }
         }

--- a/src/mongo/Config.class.php
+++ b/src/mongo/Config.class.php
@@ -1773,7 +1773,7 @@ class Config
                     $exception = $e;
                 }
 
-            } while ($retries < self::CONNECTION_RETRIES && (!isset($this->connections[$dataSource]) && $this->connections[$dataSource]>connected !== true ));
+            } while ($retries < self::CONNECTION_RETRIES && (!isset($this->connections[$dataSource]) && $this->connections[$dataSource]->connected !== true ));
 
             if (!isset($this->connections[$dataSource])) {
                 self::getLogger()->warn("MongoConnectionException after " . self::CONNECTION_RETRIES . " attempts: " . $e->getMessage());

--- a/src/mongo/base/DriverBase.class.php
+++ b/src/mongo/base/DriverBase.class.php
@@ -208,7 +208,7 @@ abstract class DriverBase
                 }
                 $cursorSuccess = true;
             } catch (\MongoCursorException $e) {
-                self::getLogger()->addNotice("MongoCursorException: " . $e->getMessage());
+                self::getLogger()->warn("MongoCursorException: " . $e->getMessage());
                 sleep(1);
                 $retries++;
                 $exception = $e;
@@ -216,7 +216,7 @@ abstract class DriverBase
         } while ($retries < 30 && $cursorSuccess === false);
 
         if ($cursorSuccess === false) {
-            self::getLogger()->addNotice("MongoCursorException after " . self::CONNECTION_RETRIES . " attempts: " . $e->getMessage());
+            self::getLogger()->warn("MongoCursorException after " . self::CONNECTION_RETRIES . " attempts: " . $e->getMessage());
             throw new \MongoCursorException($exception);
         }
 

--- a/src/mongo/base/DriverBase.class.php
+++ b/src/mongo/base/DriverBase.class.php
@@ -183,22 +183,43 @@ abstract class DriverBase
 
         $ttlExpiredResources = false;
         $cursor->batchSize($cursorSize);
-        foreach($cursor as $result)
-        {
-            // handle MONGO_VIEWS that have expired due to ttl. These are expired
-            // on read (lazily) rather than on write
-            if ($type==MONGO_VIEW && array_key_exists(_EXPIRES,$result['value']))
-            {
-                // if expires < current date, regenerate view..
-                $currentDate = new \MongoDate();
-                if ($result['value'][_EXPIRES]<$currentDate)
+
+        $retries = 1;
+        $exception = null;
+        $cursorSuccess = false;
+
+        do {
+            try {
+                foreach($cursor as $result)
                 {
-                    // regenerate!
-                    $this->generateView($result['_id']['type'],$result['_id']['r']);
+                    // handle MONGO_VIEWS that have expired due to ttl. These are expired
+                    // on read (lazily) rather than on write
+                    if ($type==MONGO_VIEW && array_key_exists(_EXPIRES,$result['value']))
+                    {
+                        // if expires < current date, regenerate view..
+                        $currentDate = new \MongoDate();
+                        if ($result['value'][_EXPIRES]<$currentDate)
+                        {
+                            // regenerate!
+                            $this->generateView($result['_id']['type'],$result['_id']['r']);
+                        }
+                    }
+                    $graph->add_tripod_array($result);
                 }
+                $cursorSuccess = true;
+            } catch (\MongoCursorException $e) {
+                self::getLogger()->addNotice("MongoCursorException: " . $e->getMessage());
+                sleep(1);
+                $retries++;
+                $exception = $e;
             }
-            $graph->add_tripod_array($result);
+        } while ($retries < 30 && $cursorSuccess === false);
+
+        if ($cursorSuccess === false) {
+            self::getLogger()->addNotice("MongoCursorException after " . self::CONNECTION_RETRIES . " attempts: " . $e->getMessage());
+            throw new \MongoCursorException($exception);
         }
+
         if ($ttlExpiredResources)
         {
             // generate views and retry...

--- a/src/mongo/base/DriverBase.class.php
+++ b/src/mongo/base/DriverBase.class.php
@@ -213,10 +213,10 @@ abstract class DriverBase
                 $retries++;
                 $exception = $e;
             }
-        } while ($retries < 30 && $cursorSuccess === false);
+        } while ($retries <= Config::CONNECTION_RETRIES && $cursorSuccess === false);
 
         if ($cursorSuccess === false) {
-            self::getLogger()->warn("MongoCursorException after " . self::CONNECTION_RETRIES . " attempts: " . $e->getMessage());
+            self::getLogger()->warn("MongoCursorException after " . $retries . " attempts (MAX:".Config::CONNECTION_RETRIES."): " . $e->getMessage());
             throw new \MongoCursorException($exception);
         }
 

--- a/src/mongo/base/DriverBase.class.php
+++ b/src/mongo/base/DriverBase.class.php
@@ -208,7 +208,7 @@ abstract class DriverBase
                 }
                 $cursorSuccess = true;
             } catch (\MongoCursorException $e) {
-                self::getLogger()->warn("MongoCursorException: " . $e->getMessage());
+                self::getLogger()->error("MongoCursorException attempt ".$retries.". Retrying...:" . $e->getMessage());
                 sleep(1);
                 $retries++;
                 $exception = $e;
@@ -216,7 +216,7 @@ abstract class DriverBase
         } while ($retries <= Config::CONNECTION_RETRIES && $cursorSuccess === false);
 
         if ($cursorSuccess === false) {
-            self::getLogger()->warn("MongoCursorException after " . $retries . " attempts (MAX:".Config::CONNECTION_RETRIES."): " . $e->getMessage());
+            self::getLogger()->error("MongoCursorException failed after " . $retries . " attempts (MAX:".Config::CONNECTION_RETRIES."): " . $e->getMessage());
             throw new \MongoCursorException($exception);
         }
 

--- a/test/unit/mongo/MongoTripodConfigTest.php
+++ b/test/unit/mongo/MongoTripodConfigTest.php
@@ -1695,60 +1695,60 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $this->assertEquals(getenv(MONGO_TRIPOD_RESQUE_SERVER), \Tripod\Mongo\Config::getResqueServer());
     }
 
-    // MongoClient creation tests
-    public function testMongoConnectionNoExceptions()
-    {
-        $mockConfig = $this->getMock('TripodTestConfig', array('getMongoClient'));
-        $mockConfig->loadConfig(json_decode(file_get_contents(dirname(__FILE__).'/data/config.json'), true));
-        $mockConfig->expects($this->exactly(1))
-            ->method('getMongoClient')
-            ->with('mongodb://localhost', array('connectTimeoutMS' => 20000))
-            ->will($this->returnCallback(
-                function()
-                {
-                    $mongo = new MongoClient();
-                    return $mongo;
-                }
-            ));
-        $mockConfig->getDatabase('tripod_php_testing', 'rs1', MongoClient::RP_SECONDARY_PREFERRED);
-        $mockConfig->getCollectionForCBD('tripod_php_testing', 'CBD_testing', MongoClient::RP_SECONDARY_PREFERRED);
-        $mockConfig->getCollectionForCBD('tripod_php_testing', 'CBD_testing', MongoClient::RP_NEAREST);
-    }
-    public function testMongoConnectionExceptionThrown()
-    {
-        $this->setExpectedException('\MongoConnectionException', "Exception thrown when connecting to Mongo");
-        $mockConfig = $this->getMock('TripodTestConfig', array('getMongoClient'));
-        $mockConfig->loadConfig(json_decode(file_get_contents(dirname(__FILE__).'/data/config.json'), true));
-        $mockConfig->expects($this->exactly(30))
-            ->method('getMongoClient')
-            ->with('mongodb://localhost', array('connectTimeoutMS' => 20000))
-            ->will($this->throwException(new \MongoConnectionException('Exception thrown when connecting to Mongo')));
-
-        $mockConfig->getDatabase('tripod_php_testing', 'rs1', MongoClient::RP_SECONDARY_PREFERRED);
-    }
-    public function testMongoConnectionNoExceptionThrownWhenConnectionThrowsSomeExceptions()
-    {
-        $mockConfig = $this->getMock('TripodTestConfig', array('getMongoClient'));
-        $mockConfig->loadConfig(json_decode(file_get_contents(dirname(__FILE__).'/data/config.json'), true));
-        $mockConfig->expects($this->exactly(5))
-            ->method('getMongoClient')
-            ->with('mongodb://localhost', array('connectTimeoutMS' => 20000))
-            ->will($this->onConsecutiveCalls(
-                $this->throwException(new \MongoConnectionException('Exception thrown when connecting to Mongo')),
-                $this->throwException(new \MongoConnectionException('Exception thrown when connecting to Mongo')),
-                $this->throwException(new \MongoConnectionException('Exception thrown when connecting to Mongo')),
-                $this->throwException(new \MongoConnectionException('Exception thrown when connecting to Mongo')),
-                $this->returnCallback(
-                    function()
-                    {
-                        $mongo = new MongoClient();
-                        return $mongo;
-                    }
-                )
-            ));
-
-        $mockConfig->getDatabase('tripod_php_testing', 'rs1', MongoClient::RP_SECONDARY_PREFERRED);
-        $mockConfig->getCollectionForCBD('tripod_php_testing', 'CBD_testing', MongoClient::RP_SECONDARY_PREFERRED);
-        $mockConfig->getCollectionForCBD('tripod_php_testing', 'CBD_testing', MongoClient::RP_NEAREST);
-    }
+//    // MongoClient creation tests
+//    public function testMongoConnectionNoExceptions()
+//    {
+//        $mockConfig = $this->getMock('TripodTestConfig', array('getMongoClient'));
+//        $mockConfig->loadConfig(json_decode(file_get_contents(dirname(__FILE__).'/data/config.json'), true));
+//        $mockConfig->expects($this->exactly(1))
+//            ->method('getMongoClient')
+//            ->with('mongodb://localhost', array('connectTimeoutMS' => 20000))
+//            ->will($this->returnCallback(
+//                function()
+//                {
+//                    $mongo = new MongoClient();
+//                    return $mongo;
+//                }
+//            ));
+//        $mockConfig->getDatabase('tripod_php_testing', 'rs1', MongoClient::RP_SECONDARY_PREFERRED);
+//        $mockConfig->getCollectionForCBD('tripod_php_testing', 'CBD_testing', MongoClient::RP_SECONDARY_PREFERRED);
+//        $mockConfig->getCollectionForCBD('tripod_php_testing', 'CBD_testing', MongoClient::RP_NEAREST);
+//    }
+//    public function testMongoConnectionExceptionThrown()
+//    {
+//        $this->setExpectedException('\MongoConnectionException', "Exception thrown when connecting to Mongo");
+//        $mockConfig = $this->getMock('TripodTestConfig', array('getMongoClient'));
+//        $mockConfig->loadConfig(json_decode(file_get_contents(dirname(__FILE__).'/data/config.json'), true));
+//        $mockConfig->expects($this->exactly(30))
+//            ->method('getMongoClient')
+//            ->with('mongodb://localhost', array('connectTimeoutMS' => 20000))
+//            ->will($this->throwException(new \MongoConnectionException('Exception thrown when connecting to Mongo')));
+//
+//        $mockConfig->getDatabase('tripod_php_testing', 'rs1', MongoClient::RP_SECONDARY_PREFERRED);
+//    }
+//    public function testMongoConnectionNoExceptionThrownWhenConnectionThrowsSomeExceptions()
+//    {
+//        $mockConfig = $this->getMock('TripodTestConfig', array('getMongoClient'));
+//        $mockConfig->loadConfig(json_decode(file_get_contents(dirname(__FILE__).'/data/config.json'), true));
+//        $mockConfig->expects($this->exactly(5))
+//            ->method('getMongoClient')
+//            ->with('mongodb://localhost', array('connectTimeoutMS' => 20000))
+//            ->will($this->onConsecutiveCalls(
+//                $this->throwException(new \MongoConnectionException('Exception thrown when connecting to Mongo')),
+//                $this->throwException(new \MongoConnectionException('Exception thrown when connecting to Mongo')),
+//                $this->throwException(new \MongoConnectionException('Exception thrown when connecting to Mongo')),
+//                $this->throwException(new \MongoConnectionException('Exception thrown when connecting to Mongo')),
+//                $this->returnCallback(
+//                    function()
+//                    {
+//                        $mongo = new MongoClient();
+//                        return $mongo;
+//                    }
+//                )
+//            ));
+//
+//        $mockConfig->getDatabase('tripod_php_testing', 'rs1', MongoClient::RP_SECONDARY_PREFERRED);
+//        $mockConfig->getCollectionForCBD('tripod_php_testing', 'CBD_testing', MongoClient::RP_SECONDARY_PREFERRED);
+//        $mockConfig->getCollectionForCBD('tripod_php_testing', 'CBD_testing', MongoClient::RP_NEAREST);
+//    }
 }

--- a/test/unit/mongo/MongoTripodConfigTest.php
+++ b/test/unit/mongo/MongoTripodConfigTest.php
@@ -1695,60 +1695,60 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $this->assertEquals(getenv(MONGO_TRIPOD_RESQUE_SERVER), \Tripod\Mongo\Config::getResqueServer());
     }
 
-//    // MongoClient creation tests
-//    public function testMongoConnectionNoExceptions()
-//    {
-//        $mockConfig = $this->getMock('TripodTestConfig', array('getMongoClient'));
-//        $mockConfig->loadConfig(json_decode(file_get_contents(dirname(__FILE__).'/data/config.json'), true));
-//        $mockConfig->expects($this->exactly(1))
-//            ->method('getMongoClient')
-//            ->with('mongodb://localhost', array('connectTimeoutMS' => 20000))
-//            ->will($this->returnCallback(
-//                function()
-//                {
-//                    $mongo = new MongoClient();
-//                    return $mongo;
-//                }
-//            ));
-//        $mockConfig->getDatabase('tripod_php_testing', 'rs1', MongoClient::RP_SECONDARY_PREFERRED);
-//        $mockConfig->getCollectionForCBD('tripod_php_testing', 'CBD_testing', MongoClient::RP_SECONDARY_PREFERRED);
-//        $mockConfig->getCollectionForCBD('tripod_php_testing', 'CBD_testing', MongoClient::RP_NEAREST);
-//    }
-//    public function testMongoConnectionExceptionThrown()
-//    {
-//        $this->setExpectedException('\MongoConnectionException', "Exception thrown when connecting to Mongo");
-//        $mockConfig = $this->getMock('TripodTestConfig', array('getMongoClient'));
-//        $mockConfig->loadConfig(json_decode(file_get_contents(dirname(__FILE__).'/data/config.json'), true));
-//        $mockConfig->expects($this->exactly(30))
-//            ->method('getMongoClient')
-//            ->with('mongodb://localhost', array('connectTimeoutMS' => 20000))
-//            ->will($this->throwException(new \MongoConnectionException('Exception thrown when connecting to Mongo')));
-//
-//        $mockConfig->getDatabase('tripod_php_testing', 'rs1', MongoClient::RP_SECONDARY_PREFERRED);
-//    }
-//    public function testMongoConnectionNoExceptionThrownWhenConnectionThrowsSomeExceptions()
-//    {
-//        $mockConfig = $this->getMock('TripodTestConfig', array('getMongoClient'));
-//        $mockConfig->loadConfig(json_decode(file_get_contents(dirname(__FILE__).'/data/config.json'), true));
-//        $mockConfig->expects($this->exactly(5))
-//            ->method('getMongoClient')
-//            ->with('mongodb://localhost', array('connectTimeoutMS' => 20000))
-//            ->will($this->onConsecutiveCalls(
-//                $this->throwException(new \MongoConnectionException('Exception thrown when connecting to Mongo')),
-//                $this->throwException(new \MongoConnectionException('Exception thrown when connecting to Mongo')),
-//                $this->throwException(new \MongoConnectionException('Exception thrown when connecting to Mongo')),
-//                $this->throwException(new \MongoConnectionException('Exception thrown when connecting to Mongo')),
-//                $this->returnCallback(
-//                    function()
-//                    {
-//                        $mongo = new MongoClient();
-//                        return $mongo;
-//                    }
-//                )
-//            ));
-//
-//        $mockConfig->getDatabase('tripod_php_testing', 'rs1', MongoClient::RP_SECONDARY_PREFERRED);
-//        $mockConfig->getCollectionForCBD('tripod_php_testing', 'CBD_testing', MongoClient::RP_SECONDARY_PREFERRED);
-//        $mockConfig->getCollectionForCBD('tripod_php_testing', 'CBD_testing', MongoClient::RP_NEAREST);
-//    }
+    // MongoClient creation tests
+    public function testMongoConnectionNoExceptions()
+    {
+        $mockConfig = $this->getMock('TripodTestConfig', array('getMongoClient'));
+        $mockConfig->loadConfig(json_decode(file_get_contents(dirname(__FILE__).'/data/config.json'), true));
+        $mockConfig->expects($this->exactly(1))
+            ->method('getMongoClient')
+            ->with('mongodb://localhost', array('connectTimeoutMS' => 20000))
+            ->will($this->returnCallback(
+                function()
+                {
+                    $mongo = new MongoClient();
+                    return $mongo;
+                }
+            ));
+        $mockConfig->getDatabase('tripod_php_testing', 'rs1', MongoClient::RP_SECONDARY_PREFERRED);
+        $mockConfig->getCollectionForCBD('tripod_php_testing', 'CBD_testing', MongoClient::RP_SECONDARY_PREFERRED);
+        $mockConfig->getCollectionForCBD('tripod_php_testing', 'CBD_testing', MongoClient::RP_NEAREST);
+    }
+    public function testMongoConnectionExceptionThrown()
+    {
+        $this->setExpectedException('\MongoConnectionException', "Exception thrown when connecting to Mongo");
+        $mockConfig = $this->getMock('TripodTestConfig', array('getMongoClient'));
+        $mockConfig->loadConfig(json_decode(file_get_contents(dirname(__FILE__).'/data/config.json'), true));
+        $mockConfig->expects($this->exactly(30))
+            ->method('getMongoClient')
+            ->with('mongodb://localhost', array('connectTimeoutMS' => 20000))
+            ->will($this->throwException(new \MongoConnectionException('Exception thrown when connecting to Mongo')));
+
+        $mockConfig->getDatabase('tripod_php_testing', 'rs1', MongoClient::RP_SECONDARY_PREFERRED);
+    }
+    public function testMongoConnectionNoExceptionThrownWhenConnectionThrowsSomeExceptions()
+    {
+        $mockConfig = $this->getMock('TripodTestConfig', array('getMongoClient'));
+        $mockConfig->loadConfig(json_decode(file_get_contents(dirname(__FILE__).'/data/config.json'), true));
+        $mockConfig->expects($this->exactly(5))
+            ->method('getMongoClient')
+            ->with('mongodb://localhost', array('connectTimeoutMS' => 20000))
+            ->will($this->onConsecutiveCalls(
+                $this->throwException(new \MongoConnectionException('Exception thrown when connecting to Mongo')),
+                $this->throwException(new \MongoConnectionException('Exception thrown when connecting to Mongo')),
+                $this->throwException(new \MongoConnectionException('Exception thrown when connecting to Mongo')),
+                $this->throwException(new \MongoConnectionException('Exception thrown when connecting to Mongo')),
+                $this->returnCallback(
+                    function()
+                    {
+                        $mongo = new MongoClient();
+                        return $mongo;
+                    }
+                )
+            ));
+
+        $mockConfig->getDatabase('tripod_php_testing', 'rs1', MongoClient::RP_SECONDARY_PREFERRED);
+        $mockConfig->getCollectionForCBD('tripod_php_testing', 'CBD_testing', MongoClient::RP_SECONDARY_PREFERRED);
+        $mockConfig->getCollectionForCBD('tripod_php_testing', 'CBD_testing', MongoClient::RP_NEAREST);
+    }
 }

--- a/test/unit/mongo/MongoTripodViewsTest.php
+++ b/test/unit/mongo/MongoTripodViewsTest.php
@@ -1771,174 +1771,174 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             $this->fail();
         }
     }
-//    public function testCursorNoExceptions()
-//    {
-//        $uri1 = "http://uri1";
-//
-//        $viewType = "someView";
-//        $context = "http://someContext";
-//
-//        $returnedGraph = new \Tripod\ExtendedGraph();
-//        $returnedGraph->add_literal_triple($uri1,'http://somepred','someval');
-//
-//        $mockDb = $this->getMock("MongoDB", array("selectCollection"),array(new MongoClient(),"test"));
-//        $mockCursor = $this->getMock('MongoCursor', array(), array(new MongoClient(), 'test.views'));
-//        $mockColl = $this->getMock("MongoCollection", array('findOne'),array($mockDb,$this->tripod->getPodName()));
-//        $mockViewColl = $this->getMock("MongoCollection", array('findOne', 'find'), array($mockDb,VIEWS_COLLECTION));
-//        $mockViewColl->expects($this->once())->method('find')->will($this->returnValue($mockCursor));
-//
-//        $mockDb->expects($this->any())->method("selectCollection")->will($this->returnValue($mockColl));
-//        $mockColl->expects($this->once())->method("findOne")->will($this->returnValue(null));
-//
-//
-//        /** @var PHPUnit_Framework_MockObject_MockObject|TripodTestConfig $mockConfig */
-//        $mockConfig = $this->getMock(
-//            'TripodTestConfig',
-//            array('getCollectionForCBD','getCollectionForView')
-//        );
-//
-//        $mockConfig->expects($this->atLeastOnce())
-//            ->method('getCollectionForCBD')
-//            ->with('tripod_php_testing', $this->anything(), $this->anything())
-//            ->will($this->returnValue($mockColl));
-//
-//        $mockConfig->expects($this->atLeastOnce())
-//            ->method('getCollectionForView')
-//            ->with('tripod_php_testing', $this->anything(), $this->anything())
-//            ->will($this->returnValue($mockViewColl));
-//
-//        $mockConfig->loadConfig(\Tripod\Mongo\Config::getConfig());
-//
-//        /* @var $mockTripodViews|PHPUnit_Framework_MockObject_MockObject Views */
-//        $mockTripodViews = $this->getMock(
-//            '\Tripod\Mongo\Composites\Views',
-//            array('generateView', 'getConfigInstance'),
-//            array('tripod_php_testing',$mockColl,$context));
-//
-//        $mockTripodViews->expects($this->never())
-//            ->method('generateView');
-//
-//        $mockTripodViews->expects($this->atLeastOnce())
-//            ->method('getConfigInstance')
-//            ->will($this->returnValue($mockConfig));
-//
-//        $mockTripodViews->getViewForResources(array($uri1),$viewType,$context);
-//    }
-//    public function testCursorExceptionThrown()
-//    {
-//        $uri1 = "http://uri1";
-//
-//        $viewType = "someView";
-//        $context = "http://someContext";
-//
-//        $returnedGraph = new \Tripod\ExtendedGraph();
-//        $returnedGraph->add_literal_triple($uri1,'http://somepred','someval');
-//
-//        $mockDb = $this->getMock("MongoDB", array("selectCollection"),array(new MongoClient(),"test"));
-//        $mockCursor = $this->getMock('MongoCursor', array('rewind'), array(new MongoClient(), 'test.views'));
-//        $mockCursor->expects($this->exactly(30))->method('rewind')->will($this->throwException(new \MongoCursorException('Exception thrown when cursoring to Mongo')));
-//        $mockColl = $this->getMock("MongoCollection", array('findOne'),array($mockDb,$this->tripod->getPodName()));
-//        $mockViewColl = $this->getMock("MongoCollection", array('findOne', 'find'), array($mockDb,VIEWS_COLLECTION));
-//        $mockViewColl->expects($this->once())->method('find')->will($this->returnValue($mockCursor));
-//
-//        $mockDb->expects($this->any())->method("selectCollection")->will($this->returnValue($mockColl));
-//        $mockColl->expects($this->never())->method("findOne");
-//
-//
-//        /** @var PHPUnit_Framework_MockObject_MockObject|TripodTestConfig $mockConfig */
-//        $mockConfig = $this->getMock(
-//            'TripodTestConfig',
-//            array('getCollectionForCBD','getCollectionForView')
-//        );
-//
-//        $mockConfig->expects($this->never())
-//            ->method('getCollectionForCBD');
-//
-//        $mockConfig->expects($this->atLeastOnce())
-//            ->method('getCollectionForView')
-//            ->with('tripod_php_testing', $this->anything(), $this->anything())
-//            ->will($this->returnValue($mockViewColl));
-//
-//        $mockConfig->loadConfig(\Tripod\Mongo\Config::getConfig());
-//
-//        /* @var $mockTripodViews|PHPUnit_Framework_MockObject_MockObject Views */
-//        $mockTripodViews = $this->getMock(
-//            '\Tripod\Mongo\Composites\Views',
-//            array('generateView', 'getConfigInstance'),
-//            array('tripod_php_testing',$mockColl,$context));
-//
-//        $mockTripodViews->expects($this->never())
-//            ->method('generateView');
-//
-//        $mockTripodViews->expects($this->atLeastOnce())
-//            ->method('getConfigInstance')
-//            ->will($this->returnValue($mockConfig));
-//
-//        $this->setExpectedException('\MongoCursorException', "Exception thrown when cursoring to Mongo");
-//        $mockTripodViews->getViewForResources(array($uri1),$viewType,$context);
-//    }
-//    public function testCursorNoExceptionThrownWhenCursorThrowsSomeExceptions()
-//    {
-//        $uri1 = "http://uri1";
-//
-//        $viewType = "someView";
-//        $context = "http://someContext";
-//
-//        $returnedGraph = new \Tripod\ExtendedGraph();
-//        $returnedGraph->add_literal_triple($uri1,'http://somepred','someval');
-//
-//        $mockDb = $this->getMock("MongoDB", array("selectCollection"),array(new MongoClient(),"test"));
-//        $mockCursor = $this->getMock('MongoCursor', array('rewind'), array(new MongoClient(), 'test.views'));
-//
-//        $mockCursor->expects($this->exactly(5))
-//            ->method('rewind')
-//            ->will($this->onConsecutiveCalls(
-//                $this->throwException(new \MongoCursorException('Exception thrown when cursoring to Mongo')),
-//                $this->throwException(new \MongoCursorException('Exception thrown when cursoring to Mongo')),
-//                $this->throwException(new \MongoCursorException('Exception thrown when cursoring to Mongo')),
-//                $this->throwException(new \MongoCursorException('Exception thrown when cursoring to Mongo')),
-//                $this->returnValue($mockCursor)));
-//
-//
-//        $mockColl = $this->getMock("MongoCollection", array('findOne'),array($mockDb,$this->tripod->getPodName()));
-//        $mockViewColl = $this->getMock("MongoCollection", array('findOne', 'find'), array($mockDb,VIEWS_COLLECTION));
-//        $mockViewColl->expects($this->once())->method('find')->will($this->returnValue($mockCursor));
-//
-//        $mockDb->expects($this->any())->method("selectCollection")->will($this->returnValue($mockColl));
-//        $mockColl->expects($this->once())->method("findOne")->will($this->returnValue(null));
-//
-//
-//        /** @var PHPUnit_Framework_MockObject_MockObject|TripodTestConfig $mockConfig */
-//        $mockConfig = $this->getMock(
-//            'TripodTestConfig',
-//            array('getCollectionForCBD','getCollectionForView')
-//        );
-//
-//        $mockConfig->expects($this->atLeastOnce())
-//            ->method('getCollectionForCBD')
-//            ->with('tripod_php_testing', $this->anything(), $this->anything())
-//            ->will($this->returnValue($mockColl));
-//
-//        $mockConfig->expects($this->atLeastOnce())
-//            ->method('getCollectionForView')
-//            ->with('tripod_php_testing', $this->anything(), $this->anything())
-//            ->will($this->returnValue($mockViewColl));
-//
-//        $mockConfig->loadConfig(\Tripod\Mongo\Config::getConfig());
-//
-//        /* @var $mockTripodViews|PHPUnit_Framework_MockObject_MockObject Views */
-//        $mockTripodViews = $this->getMock(
-//            '\Tripod\Mongo\Composites\Views',
-//            array('generateView', 'getConfigInstance'),
-//            array('tripod_php_testing',$mockColl,$context));
-//
-//        $mockTripodViews->expects($this->never())
-//            ->method('generateView');
-//
-//        $mockTripodViews->expects($this->atLeastOnce())
-//            ->method('getConfigInstance')
-//            ->will($this->returnValue($mockConfig));
-//
-//        $mockTripodViews->getViewForResources(array($uri1),$viewType,$context);
-//    }
+    public function testCursorNoExceptions()
+    {
+        $uri1 = "http://uri1";
+
+        $viewType = "someView";
+        $context = "http://someContext";
+
+        $returnedGraph = new \Tripod\ExtendedGraph();
+        $returnedGraph->add_literal_triple($uri1,'http://somepred','someval');
+
+        $mockDb = $this->getMock("MongoDB", array("selectCollection"),array(new MongoClient(),"test"));
+        $mockCursor = $this->getMock('MongoCursor', array(), array(new MongoClient(), 'test.views'));
+        $mockColl = $this->getMock("MongoCollection", array('findOne'),array($mockDb,$this->tripod->getPodName()));
+        $mockViewColl = $this->getMock("MongoCollection", array('findOne', 'find'), array($mockDb,VIEWS_COLLECTION));
+        $mockViewColl->expects($this->once())->method('find')->will($this->returnValue($mockCursor));
+
+        $mockDb->expects($this->any())->method("selectCollection")->will($this->returnValue($mockColl));
+        $mockColl->expects($this->once())->method("findOne")->will($this->returnValue(null));
+
+
+        /** @var PHPUnit_Framework_MockObject_MockObject|TripodTestConfig $mockConfig */
+        $mockConfig = $this->getMock(
+            'TripodTestConfig',
+            array('getCollectionForCBD','getCollectionForView')
+        );
+
+        $mockConfig->expects($this->atLeastOnce())
+            ->method('getCollectionForCBD')
+            ->with('tripod_php_testing', $this->anything(), $this->anything())
+            ->will($this->returnValue($mockColl));
+
+        $mockConfig->expects($this->atLeastOnce())
+            ->method('getCollectionForView')
+            ->with('tripod_php_testing', $this->anything(), $this->anything())
+            ->will($this->returnValue($mockViewColl));
+
+        $mockConfig->loadConfig(\Tripod\Mongo\Config::getConfig());
+
+        /* @var $mockTripodViews|PHPUnit_Framework_MockObject_MockObject Views */
+        $mockTripodViews = $this->getMock(
+            '\Tripod\Mongo\Composites\Views',
+            array('generateView', 'getConfigInstance'),
+            array('tripod_php_testing',$mockColl,$context));
+
+        $mockTripodViews->expects($this->never())
+            ->method('generateView');
+
+        $mockTripodViews->expects($this->atLeastOnce())
+            ->method('getConfigInstance')
+            ->will($this->returnValue($mockConfig));
+
+        $mockTripodViews->getViewForResources(array($uri1),$viewType,$context);
+    }
+    public function testCursorExceptionThrown()
+    {
+        $uri1 = "http://uri1";
+
+        $viewType = "someView";
+        $context = "http://someContext";
+
+        $returnedGraph = new \Tripod\ExtendedGraph();
+        $returnedGraph->add_literal_triple($uri1,'http://somepred','someval');
+
+        $mockDb = $this->getMock("MongoDB", array("selectCollection"),array(new MongoClient(),"test"));
+        $mockCursor = $this->getMock('MongoCursor', array('rewind'), array(new MongoClient(), 'test.views'));
+        $mockCursor->expects($this->exactly(30))->method('rewind')->will($this->throwException(new \MongoCursorException('Exception thrown when cursoring to Mongo')));
+        $mockColl = $this->getMock("MongoCollection", array('findOne'),array($mockDb,$this->tripod->getPodName()));
+        $mockViewColl = $this->getMock("MongoCollection", array('findOne', 'find'), array($mockDb,VIEWS_COLLECTION));
+        $mockViewColl->expects($this->once())->method('find')->will($this->returnValue($mockCursor));
+
+        $mockDb->expects($this->any())->method("selectCollection")->will($this->returnValue($mockColl));
+        $mockColl->expects($this->never())->method("findOne");
+
+
+        /** @var PHPUnit_Framework_MockObject_MockObject|TripodTestConfig $mockConfig */
+        $mockConfig = $this->getMock(
+            'TripodTestConfig',
+            array('getCollectionForCBD','getCollectionForView')
+        );
+
+        $mockConfig->expects($this->never())
+            ->method('getCollectionForCBD');
+
+        $mockConfig->expects($this->atLeastOnce())
+            ->method('getCollectionForView')
+            ->with('tripod_php_testing', $this->anything(), $this->anything())
+            ->will($this->returnValue($mockViewColl));
+
+        $mockConfig->loadConfig(\Tripod\Mongo\Config::getConfig());
+
+        /* @var $mockTripodViews|PHPUnit_Framework_MockObject_MockObject Views */
+        $mockTripodViews = $this->getMock(
+            '\Tripod\Mongo\Composites\Views',
+            array('generateView', 'getConfigInstance'),
+            array('tripod_php_testing',$mockColl,$context));
+
+        $mockTripodViews->expects($this->never())
+            ->method('generateView');
+
+        $mockTripodViews->expects($this->atLeastOnce())
+            ->method('getConfigInstance')
+            ->will($this->returnValue($mockConfig));
+
+        $this->setExpectedException('\MongoCursorException', "Exception thrown when cursoring to Mongo");
+        $mockTripodViews->getViewForResources(array($uri1),$viewType,$context);
+    }
+    public function testCursorNoExceptionThrownWhenCursorThrowsSomeExceptions()
+    {
+        $uri1 = "http://uri1";
+
+        $viewType = "someView";
+        $context = "http://someContext";
+
+        $returnedGraph = new \Tripod\ExtendedGraph();
+        $returnedGraph->add_literal_triple($uri1,'http://somepred','someval');
+
+        $mockDb = $this->getMock("MongoDB", array("selectCollection"),array(new MongoClient(),"test"));
+        $mockCursor = $this->getMock('MongoCursor', array('rewind'), array(new MongoClient(), 'test.views'));
+
+        $mockCursor->expects($this->exactly(5))
+            ->method('rewind')
+            ->will($this->onConsecutiveCalls(
+                $this->throwException(new \MongoCursorException('Exception thrown when cursoring to Mongo')),
+                $this->throwException(new \MongoCursorException('Exception thrown when cursoring to Mongo')),
+                $this->throwException(new \MongoCursorException('Exception thrown when cursoring to Mongo')),
+                $this->throwException(new \MongoCursorException('Exception thrown when cursoring to Mongo')),
+                $this->returnValue($mockCursor)));
+
+
+        $mockColl = $this->getMock("MongoCollection", array('findOne'),array($mockDb,$this->tripod->getPodName()));
+        $mockViewColl = $this->getMock("MongoCollection", array('findOne', 'find'), array($mockDb,VIEWS_COLLECTION));
+        $mockViewColl->expects($this->once())->method('find')->will($this->returnValue($mockCursor));
+
+        $mockDb->expects($this->any())->method("selectCollection")->will($this->returnValue($mockColl));
+        $mockColl->expects($this->once())->method("findOne")->will($this->returnValue(null));
+
+
+        /** @var PHPUnit_Framework_MockObject_MockObject|TripodTestConfig $mockConfig */
+        $mockConfig = $this->getMock(
+            'TripodTestConfig',
+            array('getCollectionForCBD','getCollectionForView')
+        );
+
+        $mockConfig->expects($this->atLeastOnce())
+            ->method('getCollectionForCBD')
+            ->with('tripod_php_testing', $this->anything(), $this->anything())
+            ->will($this->returnValue($mockColl));
+
+        $mockConfig->expects($this->atLeastOnce())
+            ->method('getCollectionForView')
+            ->with('tripod_php_testing', $this->anything(), $this->anything())
+            ->will($this->returnValue($mockViewColl));
+
+        $mockConfig->loadConfig(\Tripod\Mongo\Config::getConfig());
+
+        /* @var $mockTripodViews|PHPUnit_Framework_MockObject_MockObject Views */
+        $mockTripodViews = $this->getMock(
+            '\Tripod\Mongo\Composites\Views',
+            array('generateView', 'getConfigInstance'),
+            array('tripod_php_testing',$mockColl,$context));
+
+        $mockTripodViews->expects($this->never())
+            ->method('generateView');
+
+        $mockTripodViews->expects($this->atLeastOnce())
+            ->method('getConfigInstance')
+            ->will($this->returnValue($mockConfig));
+
+        $mockTripodViews->getViewForResources(array($uri1),$viewType,$context);
+    }
 }

--- a/test/unit/mongo/MongoTripodViewsTest.php
+++ b/test/unit/mongo/MongoTripodViewsTest.php
@@ -1771,174 +1771,174 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             $this->fail();
         }
     }
-    public function testCursorNoExceptions()
-    {
-        $uri1 = "http://uri1";
-
-        $viewType = "someView";
-        $context = "http://someContext";
-
-        $returnedGraph = new \Tripod\ExtendedGraph();
-        $returnedGraph->add_literal_triple($uri1,'http://somepred','someval');
-
-        $mockDb = $this->getMock("MongoDB", array("selectCollection"),array(new MongoClient(),"test"));
-        $mockCursor = $this->getMock('MongoCursor', array(), array(new MongoClient(), 'test.views'));
-        $mockColl = $this->getMock("MongoCollection", array('findOne'),array($mockDb,$this->tripod->getPodName()));
-        $mockViewColl = $this->getMock("MongoCollection", array('findOne', 'find'), array($mockDb,VIEWS_COLLECTION));
-        $mockViewColl->expects($this->once())->method('find')->will($this->returnValue($mockCursor));
-
-        $mockDb->expects($this->any())->method("selectCollection")->will($this->returnValue($mockColl));
-        $mockColl->expects($this->once())->method("findOne")->will($this->returnValue(null));
-
-
-        /** @var PHPUnit_Framework_MockObject_MockObject|TripodTestConfig $mockConfig */
-        $mockConfig = $this->getMock(
-            'TripodTestConfig',
-            array('getCollectionForCBD','getCollectionForView')
-        );
-
-        $mockConfig->expects($this->atLeastOnce())
-            ->method('getCollectionForCBD')
-            ->with('tripod_php_testing', $this->anything(), $this->anything())
-            ->will($this->returnValue($mockColl));
-
-        $mockConfig->expects($this->atLeastOnce())
-            ->method('getCollectionForView')
-            ->with('tripod_php_testing', $this->anything(), $this->anything())
-            ->will($this->returnValue($mockViewColl));
-
-        $mockConfig->loadConfig(\Tripod\Mongo\Config::getConfig());
-
-        /* @var $mockTripodViews|PHPUnit_Framework_MockObject_MockObject Views */
-        $mockTripodViews = $this->getMock(
-            '\Tripod\Mongo\Composites\Views',
-            array('generateView', 'getConfigInstance'),
-            array('tripod_php_testing',$mockColl,$context));
-
-        $mockTripodViews->expects($this->never())
-            ->method('generateView');
-
-        $mockTripodViews->expects($this->atLeastOnce())
-            ->method('getConfigInstance')
-            ->will($this->returnValue($mockConfig));
-
-        $mockTripodViews->getViewForResources(array($uri1),$viewType,$context);
-    }
-    public function testCursorExceptionThrown()
-    {
-        $uri1 = "http://uri1";
-
-        $viewType = "someView";
-        $context = "http://someContext";
-
-        $returnedGraph = new \Tripod\ExtendedGraph();
-        $returnedGraph->add_literal_triple($uri1,'http://somepred','someval');
-
-        $mockDb = $this->getMock("MongoDB", array("selectCollection"),array(new MongoClient(),"test"));
-        $mockCursor = $this->getMock('MongoCursor', array('rewind'), array(new MongoClient(), 'test.views'));
-        $mockCursor->expects($this->exactly(30))->method('rewind')->will($this->throwException(new \MongoCursorException('Exception thrown when cursoring to Mongo')));
-        $mockColl = $this->getMock("MongoCollection", array('findOne'),array($mockDb,$this->tripod->getPodName()));
-        $mockViewColl = $this->getMock("MongoCollection", array('findOne', 'find'), array($mockDb,VIEWS_COLLECTION));
-        $mockViewColl->expects($this->once())->method('find')->will($this->returnValue($mockCursor));
-
-        $mockDb->expects($this->any())->method("selectCollection")->will($this->returnValue($mockColl));
-        $mockColl->expects($this->never())->method("findOne");
-
-
-        /** @var PHPUnit_Framework_MockObject_MockObject|TripodTestConfig $mockConfig */
-        $mockConfig = $this->getMock(
-            'TripodTestConfig',
-            array('getCollectionForCBD','getCollectionForView')
-        );
-
-        $mockConfig->expects($this->never())
-            ->method('getCollectionForCBD');
-
-        $mockConfig->expects($this->atLeastOnce())
-            ->method('getCollectionForView')
-            ->with('tripod_php_testing', $this->anything(), $this->anything())
-            ->will($this->returnValue($mockViewColl));
-
-        $mockConfig->loadConfig(\Tripod\Mongo\Config::getConfig());
-
-        /* @var $mockTripodViews|PHPUnit_Framework_MockObject_MockObject Views */
-        $mockTripodViews = $this->getMock(
-            '\Tripod\Mongo\Composites\Views',
-            array('generateView', 'getConfigInstance'),
-            array('tripod_php_testing',$mockColl,$context));
-
-        $mockTripodViews->expects($this->never())
-            ->method('generateView');
-
-        $mockTripodViews->expects($this->atLeastOnce())
-            ->method('getConfigInstance')
-            ->will($this->returnValue($mockConfig));
-
-        $this->setExpectedException('\MongoCursorException', "Exception thrown when cursoring to Mongo");
-        $mockTripodViews->getViewForResources(array($uri1),$viewType,$context);
-    }
-    public function testCursorNoExceptionThrownWhenCursorThrowsSomeExceptions()
-    {
-        $uri1 = "http://uri1";
-
-        $viewType = "someView";
-        $context = "http://someContext";
-
-        $returnedGraph = new \Tripod\ExtendedGraph();
-        $returnedGraph->add_literal_triple($uri1,'http://somepred','someval');
-
-        $mockDb = $this->getMock("MongoDB", array("selectCollection"),array(new MongoClient(),"test"));
-        $mockCursor = $this->getMock('MongoCursor', array('rewind'), array(new MongoClient(), 'test.views'));
-
-        $mockCursor->expects($this->exactly(5))
-            ->method('rewind')
-            ->will($this->onConsecutiveCalls(
-                $this->throwException(new \MongoCursorException('Exception thrown when cursoring to Mongo')),
-                $this->throwException(new \MongoCursorException('Exception thrown when cursoring to Mongo')),
-                $this->throwException(new \MongoCursorException('Exception thrown when cursoring to Mongo')),
-                $this->throwException(new \MongoCursorException('Exception thrown when cursoring to Mongo')),
-                $this->returnValue($mockCursor)));
-
-
-        $mockColl = $this->getMock("MongoCollection", array('findOne'),array($mockDb,$this->tripod->getPodName()));
-        $mockViewColl = $this->getMock("MongoCollection", array('findOne', 'find'), array($mockDb,VIEWS_COLLECTION));
-        $mockViewColl->expects($this->once())->method('find')->will($this->returnValue($mockCursor));
-
-        $mockDb->expects($this->any())->method("selectCollection")->will($this->returnValue($mockColl));
-        $mockColl->expects($this->once())->method("findOne")->will($this->returnValue(null));
-
-
-        /** @var PHPUnit_Framework_MockObject_MockObject|TripodTestConfig $mockConfig */
-        $mockConfig = $this->getMock(
-            'TripodTestConfig',
-            array('getCollectionForCBD','getCollectionForView')
-        );
-
-        $mockConfig->expects($this->atLeastOnce())
-            ->method('getCollectionForCBD')
-            ->with('tripod_php_testing', $this->anything(), $this->anything())
-            ->will($this->returnValue($mockColl));
-
-        $mockConfig->expects($this->atLeastOnce())
-            ->method('getCollectionForView')
-            ->with('tripod_php_testing', $this->anything(), $this->anything())
-            ->will($this->returnValue($mockViewColl));
-
-        $mockConfig->loadConfig(\Tripod\Mongo\Config::getConfig());
-
-        /* @var $mockTripodViews|PHPUnit_Framework_MockObject_MockObject Views */
-        $mockTripodViews = $this->getMock(
-            '\Tripod\Mongo\Composites\Views',
-            array('generateView', 'getConfigInstance'),
-            array('tripod_php_testing',$mockColl,$context));
-
-        $mockTripodViews->expects($this->never())
-            ->method('generateView');
-
-        $mockTripodViews->expects($this->atLeastOnce())
-            ->method('getConfigInstance')
-            ->will($this->returnValue($mockConfig));
-
-        $mockTripodViews->getViewForResources(array($uri1),$viewType,$context);
-    }
+//    public function testCursorNoExceptions()
+//    {
+//        $uri1 = "http://uri1";
+//
+//        $viewType = "someView";
+//        $context = "http://someContext";
+//
+//        $returnedGraph = new \Tripod\ExtendedGraph();
+//        $returnedGraph->add_literal_triple($uri1,'http://somepred','someval');
+//
+//        $mockDb = $this->getMock("MongoDB", array("selectCollection"),array(new MongoClient(),"test"));
+//        $mockCursor = $this->getMock('MongoCursor', array(), array(new MongoClient(), 'test.views'));
+//        $mockColl = $this->getMock("MongoCollection", array('findOne'),array($mockDb,$this->tripod->getPodName()));
+//        $mockViewColl = $this->getMock("MongoCollection", array('findOne', 'find'), array($mockDb,VIEWS_COLLECTION));
+//        $mockViewColl->expects($this->once())->method('find')->will($this->returnValue($mockCursor));
+//
+//        $mockDb->expects($this->any())->method("selectCollection")->will($this->returnValue($mockColl));
+//        $mockColl->expects($this->once())->method("findOne")->will($this->returnValue(null));
+//
+//
+//        /** @var PHPUnit_Framework_MockObject_MockObject|TripodTestConfig $mockConfig */
+//        $mockConfig = $this->getMock(
+//            'TripodTestConfig',
+//            array('getCollectionForCBD','getCollectionForView')
+//        );
+//
+//        $mockConfig->expects($this->atLeastOnce())
+//            ->method('getCollectionForCBD')
+//            ->with('tripod_php_testing', $this->anything(), $this->anything())
+//            ->will($this->returnValue($mockColl));
+//
+//        $mockConfig->expects($this->atLeastOnce())
+//            ->method('getCollectionForView')
+//            ->with('tripod_php_testing', $this->anything(), $this->anything())
+//            ->will($this->returnValue($mockViewColl));
+//
+//        $mockConfig->loadConfig(\Tripod\Mongo\Config::getConfig());
+//
+//        /* @var $mockTripodViews|PHPUnit_Framework_MockObject_MockObject Views */
+//        $mockTripodViews = $this->getMock(
+//            '\Tripod\Mongo\Composites\Views',
+//            array('generateView', 'getConfigInstance'),
+//            array('tripod_php_testing',$mockColl,$context));
+//
+//        $mockTripodViews->expects($this->never())
+//            ->method('generateView');
+//
+//        $mockTripodViews->expects($this->atLeastOnce())
+//            ->method('getConfigInstance')
+//            ->will($this->returnValue($mockConfig));
+//
+//        $mockTripodViews->getViewForResources(array($uri1),$viewType,$context);
+//    }
+//    public function testCursorExceptionThrown()
+//    {
+//        $uri1 = "http://uri1";
+//
+//        $viewType = "someView";
+//        $context = "http://someContext";
+//
+//        $returnedGraph = new \Tripod\ExtendedGraph();
+//        $returnedGraph->add_literal_triple($uri1,'http://somepred','someval');
+//
+//        $mockDb = $this->getMock("MongoDB", array("selectCollection"),array(new MongoClient(),"test"));
+//        $mockCursor = $this->getMock('MongoCursor', array('rewind'), array(new MongoClient(), 'test.views'));
+//        $mockCursor->expects($this->exactly(30))->method('rewind')->will($this->throwException(new \MongoCursorException('Exception thrown when cursoring to Mongo')));
+//        $mockColl = $this->getMock("MongoCollection", array('findOne'),array($mockDb,$this->tripod->getPodName()));
+//        $mockViewColl = $this->getMock("MongoCollection", array('findOne', 'find'), array($mockDb,VIEWS_COLLECTION));
+//        $mockViewColl->expects($this->once())->method('find')->will($this->returnValue($mockCursor));
+//
+//        $mockDb->expects($this->any())->method("selectCollection")->will($this->returnValue($mockColl));
+//        $mockColl->expects($this->never())->method("findOne");
+//
+//
+//        /** @var PHPUnit_Framework_MockObject_MockObject|TripodTestConfig $mockConfig */
+//        $mockConfig = $this->getMock(
+//            'TripodTestConfig',
+//            array('getCollectionForCBD','getCollectionForView')
+//        );
+//
+//        $mockConfig->expects($this->never())
+//            ->method('getCollectionForCBD');
+//
+//        $mockConfig->expects($this->atLeastOnce())
+//            ->method('getCollectionForView')
+//            ->with('tripod_php_testing', $this->anything(), $this->anything())
+//            ->will($this->returnValue($mockViewColl));
+//
+//        $mockConfig->loadConfig(\Tripod\Mongo\Config::getConfig());
+//
+//        /* @var $mockTripodViews|PHPUnit_Framework_MockObject_MockObject Views */
+//        $mockTripodViews = $this->getMock(
+//            '\Tripod\Mongo\Composites\Views',
+//            array('generateView', 'getConfigInstance'),
+//            array('tripod_php_testing',$mockColl,$context));
+//
+//        $mockTripodViews->expects($this->never())
+//            ->method('generateView');
+//
+//        $mockTripodViews->expects($this->atLeastOnce())
+//            ->method('getConfigInstance')
+//            ->will($this->returnValue($mockConfig));
+//
+//        $this->setExpectedException('\MongoCursorException', "Exception thrown when cursoring to Mongo");
+//        $mockTripodViews->getViewForResources(array($uri1),$viewType,$context);
+//    }
+//    public function testCursorNoExceptionThrownWhenCursorThrowsSomeExceptions()
+//    {
+//        $uri1 = "http://uri1";
+//
+//        $viewType = "someView";
+//        $context = "http://someContext";
+//
+//        $returnedGraph = new \Tripod\ExtendedGraph();
+//        $returnedGraph->add_literal_triple($uri1,'http://somepred','someval');
+//
+//        $mockDb = $this->getMock("MongoDB", array("selectCollection"),array(new MongoClient(),"test"));
+//        $mockCursor = $this->getMock('MongoCursor', array('rewind'), array(new MongoClient(), 'test.views'));
+//
+//        $mockCursor->expects($this->exactly(5))
+//            ->method('rewind')
+//            ->will($this->onConsecutiveCalls(
+//                $this->throwException(new \MongoCursorException('Exception thrown when cursoring to Mongo')),
+//                $this->throwException(new \MongoCursorException('Exception thrown when cursoring to Mongo')),
+//                $this->throwException(new \MongoCursorException('Exception thrown when cursoring to Mongo')),
+//                $this->throwException(new \MongoCursorException('Exception thrown when cursoring to Mongo')),
+//                $this->returnValue($mockCursor)));
+//
+//
+//        $mockColl = $this->getMock("MongoCollection", array('findOne'),array($mockDb,$this->tripod->getPodName()));
+//        $mockViewColl = $this->getMock("MongoCollection", array('findOne', 'find'), array($mockDb,VIEWS_COLLECTION));
+//        $mockViewColl->expects($this->once())->method('find')->will($this->returnValue($mockCursor));
+//
+//        $mockDb->expects($this->any())->method("selectCollection")->will($this->returnValue($mockColl));
+//        $mockColl->expects($this->once())->method("findOne")->will($this->returnValue(null));
+//
+//
+//        /** @var PHPUnit_Framework_MockObject_MockObject|TripodTestConfig $mockConfig */
+//        $mockConfig = $this->getMock(
+//            'TripodTestConfig',
+//            array('getCollectionForCBD','getCollectionForView')
+//        );
+//
+//        $mockConfig->expects($this->atLeastOnce())
+//            ->method('getCollectionForCBD')
+//            ->with('tripod_php_testing', $this->anything(), $this->anything())
+//            ->will($this->returnValue($mockColl));
+//
+//        $mockConfig->expects($this->atLeastOnce())
+//            ->method('getCollectionForView')
+//            ->with('tripod_php_testing', $this->anything(), $this->anything())
+//            ->will($this->returnValue($mockViewColl));
+//
+//        $mockConfig->loadConfig(\Tripod\Mongo\Config::getConfig());
+//
+//        /* @var $mockTripodViews|PHPUnit_Framework_MockObject_MockObject Views */
+//        $mockTripodViews = $this->getMock(
+//            '\Tripod\Mongo\Composites\Views',
+//            array('generateView', 'getConfigInstance'),
+//            array('tripod_php_testing',$mockColl,$context));
+//
+//        $mockTripodViews->expects($this->never())
+//            ->method('generateView');
+//
+//        $mockTripodViews->expects($this->atLeastOnce())
+//            ->method('getConfigInstance')
+//            ->will($this->returnValue($mockConfig));
+//
+//        $mockTripodViews->getViewForResources(array($uri1),$viewType,$context);
+//    }
 }

--- a/test/unit/mongo/MongoTripodViewsTest.php
+++ b/test/unit/mongo/MongoTripodViewsTest.php
@@ -1879,9 +1879,6 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
     }
     public function testCursorNoExceptionThrownWhenCursorThrowsSomeExceptions()
     {
-        error_reporting(E_ALL);
-        ini_set('display_errors', true);
-
         $uri1 = "http://uri1";
 
         $viewType = "someView";

--- a/test/unit/mongo/MongoTripodViewsTest.php
+++ b/test/unit/mongo/MongoTripodViewsTest.php
@@ -1771,4 +1771,177 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             $this->fail();
         }
     }
+    public function testCursorNoExceptions()
+    {
+        $uri1 = "http://uri1";
+
+        $viewType = "someView";
+        $context = "http://someContext";
+
+        $returnedGraph = new \Tripod\ExtendedGraph();
+        $returnedGraph->add_literal_triple($uri1,'http://somepred','someval');
+
+        $mockDb = $this->getMock("MongoDB", array("selectCollection"),array(new MongoClient(),"test"));
+        $mockCursor = $this->getMock('MongoCursor', array(), array(new MongoClient(), 'test.views'));
+        $mockColl = $this->getMock("MongoCollection", array('findOne'),array($mockDb,$this->tripod->getPodName()));
+        $mockViewColl = $this->getMock("MongoCollection", array('findOne', 'find'), array($mockDb,VIEWS_COLLECTION));
+        $mockViewColl->expects($this->once())->method('find')->will($this->returnValue($mockCursor));
+
+        $mockDb->expects($this->any())->method("selectCollection")->will($this->returnValue($mockColl));
+        $mockColl->expects($this->once())->method("findOne")->will($this->returnValue(null));
+
+
+        /** @var PHPUnit_Framework_MockObject_MockObject|TripodTestConfig $mockConfig */
+        $mockConfig = $this->getMock(
+            'TripodTestConfig',
+            array('getCollectionForCBD','getCollectionForView')
+        );
+
+        $mockConfig->expects($this->atLeastOnce())
+            ->method('getCollectionForCBD')
+            ->with('tripod_php_testing', $this->anything(), $this->anything())
+            ->will($this->returnValue($mockColl));
+
+        $mockConfig->expects($this->atLeastOnce())
+            ->method('getCollectionForView')
+            ->with('tripod_php_testing', $this->anything(), $this->anything())
+            ->will($this->returnValue($mockViewColl));
+
+        $mockConfig->loadConfig(\Tripod\Mongo\Config::getConfig());
+
+        /* @var $mockTripodViews|PHPUnit_Framework_MockObject_MockObject Views */
+        $mockTripodViews = $this->getMock(
+            '\Tripod\Mongo\Composites\Views',
+            array('generateView', 'getConfigInstance'),
+            array('tripod_php_testing',$mockColl,$context));
+
+        $mockTripodViews->expects($this->never())
+            ->method('generateView');
+
+        $mockTripodViews->expects($this->atLeastOnce())
+            ->method('getConfigInstance')
+            ->will($this->returnValue($mockConfig));
+
+        $mockTripodViews->getViewForResources(array($uri1),$viewType,$context);
+    }
+    public function testCursorExceptionThrown()
+    {
+        $uri1 = "http://uri1";
+
+        $viewType = "someView";
+        $context = "http://someContext";
+
+        $returnedGraph = new \Tripod\ExtendedGraph();
+        $returnedGraph->add_literal_triple($uri1,'http://somepred','someval');
+
+        $mockDb = $this->getMock("MongoDB", array("selectCollection"),array(new MongoClient(),"test"));
+        $mockCursor = $this->getMock('MongoCursor', array('rewind'), array(new MongoClient(), 'test.views'));
+        $mockCursor->expects($this->exactly(30))->method('rewind')->will($this->throwException(new \MongoCursorException('Exception thrown when cursoring to Mongo')));
+        $mockColl = $this->getMock("MongoCollection", array('findOne'),array($mockDb,$this->tripod->getPodName()));
+        $mockViewColl = $this->getMock("MongoCollection", array('findOne', 'find'), array($mockDb,VIEWS_COLLECTION));
+        $mockViewColl->expects($this->once())->method('find')->will($this->returnValue($mockCursor));
+
+        $mockDb->expects($this->any())->method("selectCollection")->will($this->returnValue($mockColl));
+        $mockColl->expects($this->never())->method("findOne");
+
+
+        /** @var PHPUnit_Framework_MockObject_MockObject|TripodTestConfig $mockConfig */
+        $mockConfig = $this->getMock(
+            'TripodTestConfig',
+            array('getCollectionForCBD','getCollectionForView')
+        );
+
+        $mockConfig->expects($this->never())
+            ->method('getCollectionForCBD');
+
+        $mockConfig->expects($this->atLeastOnce())
+            ->method('getCollectionForView')
+            ->with('tripod_php_testing', $this->anything(), $this->anything())
+            ->will($this->returnValue($mockViewColl));
+
+        $mockConfig->loadConfig(\Tripod\Mongo\Config::getConfig());
+
+        /* @var $mockTripodViews|PHPUnit_Framework_MockObject_MockObject Views */
+        $mockTripodViews = $this->getMock(
+            '\Tripod\Mongo\Composites\Views',
+            array('generateView', 'getConfigInstance'),
+            array('tripod_php_testing',$mockColl,$context));
+
+        $mockTripodViews->expects($this->never())
+            ->method('generateView');
+
+        $mockTripodViews->expects($this->atLeastOnce())
+            ->method('getConfigInstance')
+            ->will($this->returnValue($mockConfig));
+
+        $this->setExpectedException('\MongoCursorException', "Exception thrown when cursoring to Mongo");
+        $mockTripodViews->getViewForResources(array($uri1),$viewType,$context);
+    }
+    public function testCursorNoExceptionThrownWhenCursorThrowsSomeExceptions()
+    {
+        error_reporting(E_ALL);
+        ini_set('display_errors', true);
+
+        $uri1 = "http://uri1";
+
+        $viewType = "someView";
+        $context = "http://someContext";
+
+        $returnedGraph = new \Tripod\ExtendedGraph();
+        $returnedGraph->add_literal_triple($uri1,'http://somepred','someval');
+
+        $mockDb = $this->getMock("MongoDB", array("selectCollection"),array(new MongoClient(),"test"));
+        $mockCursor = $this->getMock('MongoCursor', array('rewind'), array(new MongoClient(), 'test.views'));
+
+        $mockCursor->expects($this->exactly(5))
+            ->method('rewind')
+            ->will($this->onConsecutiveCalls(
+                $this->throwException(new \MongoCursorException('Exception thrown when cursoring to Mongo')),
+                $this->throwException(new \MongoCursorException('Exception thrown when cursoring to Mongo')),
+                $this->throwException(new \MongoCursorException('Exception thrown when cursoring to Mongo')),
+                $this->throwException(new \MongoCursorException('Exception thrown when cursoring to Mongo')),
+                $this->returnValue($mockCursor)));
+
+
+        $mockColl = $this->getMock("MongoCollection", array('findOne'),array($mockDb,$this->tripod->getPodName()));
+        $mockViewColl = $this->getMock("MongoCollection", array('findOne', 'find'), array($mockDb,VIEWS_COLLECTION));
+        $mockViewColl->expects($this->once())->method('find')->will($this->returnValue($mockCursor));
+
+        $mockDb->expects($this->any())->method("selectCollection")->will($this->returnValue($mockColl));
+        $mockColl->expects($this->once())->method("findOne")->will($this->returnValue(null));
+
+
+        /** @var PHPUnit_Framework_MockObject_MockObject|TripodTestConfig $mockConfig */
+        $mockConfig = $this->getMock(
+            'TripodTestConfig',
+            array('getCollectionForCBD','getCollectionForView')
+        );
+
+        $mockConfig->expects($this->atLeastOnce())
+            ->method('getCollectionForCBD')
+            ->with('tripod_php_testing', $this->anything(), $this->anything())
+            ->will($this->returnValue($mockColl));
+
+        $mockConfig->expects($this->atLeastOnce())
+            ->method('getCollectionForView')
+            ->with('tripod_php_testing', $this->anything(), $this->anything())
+            ->will($this->returnValue($mockViewColl));
+
+        $mockConfig->loadConfig(\Tripod\Mongo\Config::getConfig());
+
+        /* @var $mockTripodViews|PHPUnit_Framework_MockObject_MockObject Views */
+        $mockTripodViews = $this->getMock(
+            '\Tripod\Mongo\Composites\Views',
+            array('generateView', 'getConfigInstance'),
+            array('tripod_php_testing',$mockColl,$context));
+
+        $mockTripodViews->expects($this->never())
+            ->method('generateView');
+
+        $mockTripodViews->expects($this->atLeastOnce())
+            ->method('getConfigInstance')
+            ->will($this->returnValue($mockConfig));
+
+        $mockTripodViews->getViewForResources(array($uri1),$viewType,$context);
+    }
 }


### PR DESCRIPTION
If there is momentary blip in comms, the mongo php driver handles it (or is supposed to). What it doesn't handle however, is a step down for the primary on the repset.

In that instance, we get a 500 error with "No candidate servers found", when really it should back off and try again. The connection will be available in a few seconds once a new primary is elected and then the code can continue as per normal.

As far as i can tell, the mongo PHP driver does not support this so we're going to create something to do it for us.

You get 2 exceptions in Tripod when there are blips (step downs) in the rep set. The first one is when the rep set is down when you attempt to connect to it (`MongoConnectionException`). You also get one when the rep set is up when you connect, but down when you try to use it (`MongoCursorException`).

#### Questions
* ~~Is this the right approach?~~
* What is a reasonable back off strategy? I've currently got 30 seconds of retrying with no exponential back off - it's just a simple sleep for a second until it's ready. Maybe a back off for 0.5s intervals and do it 30 times, so 15s but if you got a connection earlier, it would resolve quicker rather than have to wait for a whole second. Do we need to make it an exponential back off?
* If no connection can be found at all, is it reasonable to throw the last exception that occurred?

#### Manual testing
1. `rs.stepDown()` on node 1 (primary)
1. `db.shutdownServer()` on node 1
1. Bring the service online again
1. `rs.stepDown()` on node 2 (now the primary)
1. `db.shutdownServer()` on node2
1. Bring the service online again

Whilst doing this, I ran an ab command to keep hitting a list:
```bash
ab -c 5 -t 100000 -v 3 "http://life.ac.uk/lists/fdta102.html"|grep "Response code"
```
That told me that we were consistently getting 200 responses.

Tailing the logs meant I could see the Exceptions coming through and clearing.

For future reference - in order to do stepDowns and shutdownServer commands, you need an arbiter running locally. You can do this with the following command (ymmv):
```bash
$ sudo mkdir /mnt/arb
$ sudo chown mongodb /mnt/arb
$ sudo mongod --port 3000 --dbpath /mnt/arb --smallfiles --replSet repSetName
```

#### Todo
* [x] Confirm this works correctly when doing a step down of the repset primary. 
* [x] 30% PR review
* [x] Tests
* [x] 90% PR review
