### PR TITLE
30% INFRA_547, improved logging

### DIFF
--- a/src/mongo/base/DriverBase.class.php
+++ b/src/mongo/base/DriverBase.class.php
@@ -275,6 +275,7 @@ abstract class DriverBase
      */
     public function timingLog($type, $params=null)
     {
+        $type = "[PID " . getmypid() ."] " . $type;
         $this->log(\Psr\Log\LogLevel::INFO,$type,$params); // todo: timing log is a bit weird. Should it infact go in a different channel? Is it just debug?
     }
 
@@ -282,12 +283,9 @@ abstract class DriverBase
      * @param string $message
      * @param array|null $params
      */
-    /**
-     * @param $message
-     * @param array|null $params
-     */
     public function infoLog($message, $params=null)
     {
+        $message = "[PID " . getmypid() ."] " . $message;
         $this->log(\Psr\Log\LogLevel::INFO,$message,$params);
 
     }
@@ -298,6 +296,7 @@ abstract class DriverBase
      */
     public function debugLog($message, $params=null)
     {
+        $message = "[PID " . getmypid() ."] " . $message;
         $this->log(\Psr\Log\LogLevel::DEBUG,$message,$params);
     }
 
@@ -307,6 +306,7 @@ abstract class DriverBase
      */
     public function errorLog($message, $params=null)
     {
+        $message = "[PID " . getmypid() ."] " . $message;
         $this->log(\Psr\Log\LogLevel::ERROR,$message,$params);
     }
 
@@ -316,6 +316,7 @@ abstract class DriverBase
      */
     public function warningLog($message, $params=null)
     {
+        $message = "[PID " . getmypid() ."] " . $message;
         $this->log(\Psr\Log\LogLevel::WARNING,$message,$params);
     }
 

--- a/src/mongo/base/JobBase.class.php
+++ b/src/mongo/base/JobBase.class.php
@@ -64,7 +64,7 @@ abstract class JobBase extends \Tripod\Mongo\DriverBase
      */
     public function debugLog($message, $params = null)
     {
-        parent::debugLog("[PID ".getmypid()."] ".$message, $params);
+        parent::debugLog($message, $params);
     }
 
     /**
@@ -73,7 +73,7 @@ abstract class JobBase extends \Tripod\Mongo\DriverBase
      */
     public function errorLog($message, $params = null)
     {
-        parent::errorLog("[PID ".getmypid()."] ".$message, $params);
+        parent::errorLog($message, $params);
     }
 
 

--- a/src/mongo/jobs/ApplyOperation.class.php
+++ b/src/mongo/jobs/ApplyOperation.class.php
@@ -17,7 +17,7 @@ class ApplyOperation extends JobBase {
     {
         try
         {
-            $this->debugLog("ApplyOperation::perform() start");
+            $this->debugLog("[JOBID " . $this->job->payload['id'] . "] ApplyOperation::perform() start");
 
             $timer = new \Tripod\Timer();
             $timer->start();
@@ -53,7 +53,7 @@ class ApplyOperation extends JobBase {
             // stat time taken to process job, from time it was picked up
             $this->getStat()->timer(MONGO_QUEUE_APPLY_OPERATION_SUCCESS,$timer->result());
 
-            $this->debugLog("ApplyOperation::perform() done in {$timer->result()}ms");
+            $this->debugLog("[JOBID " . $this->job->payload['id'] . "] ApplyOperation::perform() done in {$timer->result()}ms");
         }
         catch (\Exception $e)
         {
@@ -100,7 +100,7 @@ class ApplyOperation extends JobBase {
             $args["storeName"],
             $args["podName"],
             $args["specTypes"]
-        );        
+        );
     }
 
     /**

--- a/src/mongo/jobs/DiscoverImpactedSubjects.class.php
+++ b/src/mongo/jobs/DiscoverImpactedSubjects.class.php
@@ -34,7 +34,7 @@ class DiscoverImpactedSubjects extends JobBase {
         try
         {
 
-            $this->debugLog("DiscoverImpactedSubjects::perform() start");
+            $this->debugLog("[JOBID " . $this->job->payload['id'] . "] DiscoverImpactedSubjects::perform() start");
 
             $timer = new \Tripod\Timer();
             $timer->start();
@@ -136,7 +136,7 @@ class DiscoverImpactedSubjects extends JobBase {
             // stat time taken to process item, from time it was created (queued)
             $timer->stop();
             $this->getStat()->timer(MONGO_QUEUE_DISCOVER_SUCCESS,$timer->result());
-            $this->debugLog("DiscoverImpactedSubjects::perform() done in {$timer->result()}ms");
+            $this->debugLog("[JOBID " . $this->job->payload['id'] . "] DiscoverImpactedSubjects::perform() done in {$timer->result()}ms");
             $this->getStat()->increment(MONGO_QUEUE_DISCOVER_JOB . '.' . SUBJECT_COUNT, $subjectCount);
         }
         catch(\Exception $e)

--- a/test/unit/mongo/ApplyOperationTest.php
+++ b/test/unit/mongo/ApplyOperationTest.php
@@ -15,6 +15,7 @@ class ApplyOperationTest extends MongoTripodTestBase
         unset($this->args['tripodConfig']);
         $job = new \Tripod\Mongo\Jobs\ApplyOperation();
         $job->args = $this->args;
+        $jobs->payload['id'] = uniqid();
         $this->setExpectedException('Exception', "Argument tripodConfig was not present in supplied job args for job Tripod\Mongo\Jobs\ApplyOperation");
         $job->perform();
     }


### PR DESCRIPTION
Improves the logging by making some minor changes.

- PID is always logged
- Apply and Discover jobs updated to log the jobid this allows us to tie
  jobid to processid when debugging / investigating problems

Now when it logs the log output will look like this:

```bash
[2016-09-21 13:32:04] TRIPOD-JOB.DEBUG: [PID 28589] [JOBID fbd4f626767c49fc88510b0787cd996e] DiscoverImpactedSubjects::perform() start [] []
[2016-09-21 13:32:04] TRIPOD-JOB.DEBUG: [PID 28589] Queued Tripod\Mongo\Jobs\ApplyOperation job with 95a6262b38d6dc39c776c15e3cf9a5c2 to tripod::local::apply::t_report_all_users [] []
[2016-09-21 13:32:04] TRIPOD-JOB.DEBUG: [PID 28589] [JOBID: fbd4f626767c49fc88510b0787cd996e] DiscoverImpactedSubjects::perform() done in 69ms [] []
[2016-09-21 13:32:04] TRIPOD-JOB.DEBUG: [PID 28592] [JOBID: 95a6262b38d6dc39c776c15e3cf9a5c2] ApplyOperation::perform() start [] []
[2016-09-21 13:32:04] TRIPOD-JOB.DEBUG: [PID 28592] Could not find any table specifications for tenantUsers:s2123 with resource type 'http://purl.org/vocab/resourcelist/schema#ListOwner' [] []
[2016-09-21 13:32:04] TRIPOD-JOB.DEBUG: [PID 28592] Processing t_report_all_users [] []
[2016-09-21 13:32:04] TRIPOD-JOB.INFO: [PID 28592] MONGO_CREATE_TABLE {"type":"spec:User","duration":14,"filter":{"$or":[{"rdf:type.u":"http://rdfs.org/sioc/spec/User"},{"rdf:type.u":"spec:User"}],"_id":{"r":"tenantUsers:s2123","c":"tenantContexts:DefaultGraph"}},"from":"CBD_users"} []
[2016-09-21 13:32:04] TRIPOD-JOB.DEBUG: [PID 28592] [JOBID 95a6262b38d6dc39c776c15e3cf9a5c2] ApplyOperation::perform() done in 28ms [] []
```

When the job is picked up there;'s log line that ties the jobid to the process id. 
