### PR TITLE
Issue #109 Upgrade to latest PHP driver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ php:
 - 5.6
 - 5.5
 - 5.4
-- 5.3
 services:
 - mongodb
 - redis

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ before_install:
 - sudo apt-get install -y mongodb-org=2.6.9 mongodb-org-server=2.6.9 mongodb-org-shell=2.6.9 mongodb-org-mongos=2.6.9 mongodb-org-tools=2.6.9
 install:
 - composer install
+before_script:
+- echo "extension = mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+- sleep 15
 script: ant
 notifications:
   hipchat:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,18 +5,14 @@ php:
 - 5.5
 - 5.4
 services:
+- mongodb-2.6-precise
 - redis
+packages:
+- mongodb-org
 before_install:
 - pecl install mongodb
 install:
 - composer install
-before_script:
-  - apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
-  - echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | tee /etc/apt/sources.list.d/mongodb.list
-  - apt-get update
-  - apt-get install -y mongodb-org=2.6.9 mongodb-org-server=2.6.9 mongodb-org-shell=2.6.9 mongodb-org-mongos=2.6.9 mongodb-org-tools=2.6.9
-  - sleep 15
-  - mongo --version
 script: ant
 notifications:
   hipchat:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,10 @@ services:
 - redis
 before_install:
 - sudo apt-get install -y mongodb-org=2.6.9 mongodb-org-server=2.6.9 mongodb-org-shell=2.6.9 mongodb-org-mongos=2.6.9 mongodb-org-tools=2.6.9
-install:
-- composer install
-before_script:
 - echo "extension = mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 - sleep 15
+install:
+- composer install
 script: ant
 notifications:
   hipchat:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ services:
 install:
 - composer install
 before_script:
-- echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+- echo "extension = mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 - sleep 15
 script: ant
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,13 @@ php:
 - 5.5
 - 5.4
 services:
-- mongodb-2.6-precise
 - redis
-packages:
-- mongodb-org
 before_install:
+- sudo apt-get install -y mongodb-org=2.6.9 mongodb-org-server=2.6.9 mongodb-org-shell=2.6.9 mongodb-org-mongos=2.6.9 mongodb-org-tools=2.6.9
 - pecl install mongodb
 install:
 - composer install
+
 script: ant
 notifications:
   hipchat:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,10 @@ before_install:
 install:
 - composer install
 before_script:
-  - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
+  - apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
   - echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list
-  - sudo apt-get update
-  - sudo apt-get install -y mongodb-org=2.6.9 mongodb-org-server=2.6.9 mongodb-org-shell=2.6.9 mongodb-org-mongos=2.6.9 mongodb-org-tools=2.6.9
+  - apt-get update
+  - apt-get install -y mongodb-org=2.6.9 mongodb-org-server=2.6.9 mongodb-org-shell=2.6.9 mongodb-org-mongos=2.6.9 mongodb-org-tools=2.6.9
   - sleep 15
   - mongo --version
 script: ant

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,10 @@ php:
 services:
 - mongodb
 - redis
+before_install:
+- pecl install mongodb
 install:
 - composer install
-before_script:
-- pecl install mongodb
-- sleep 15
 script: ant
 notifications:
   hipchat:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ services:
 - redis
 before_install:
 - sudo apt-get install -y mongodb-org=2.6.9 mongodb-org-server=2.6.9 mongodb-org-shell=2.6.9 mongodb-org-mongos=2.6.9 mongodb-org-tools=2.6.9
-- pecl install mongodb
 install:
 - composer install
 script: ant

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 sudo: required
 php:
+- 7.0
 - 5.6
 - 5.5
 - 5.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
 - composer install
 before_script:
   - apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
-  - echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list
+  - echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | tee /etc/apt/sources.list.d/mongodb.list
   - apt-get update
   - apt-get install -y mongodb-org=2.6.9 mongodb-org-server=2.6.9 mongodb-org-shell=2.6.9 mongodb-org-mongos=2.6.9 mongodb-org-tools=2.6.9
   - sleep 15

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 sudo: required
 php:
-- 7.0
 - 5.6
 - 5.5
 - 5.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,18 @@ php:
 - 5.5
 - 5.4
 services:
-- mongodb
 - redis
 before_install:
 - pecl install mongodb
 install:
 - composer install
+before_script:
+  - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
+  - echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list
+  - sudo apt-get update
+  - sudo apt-get install -y mongodb-org=2.6.9 mongodb-org-server=2.6.9 mongodb-org-shell=2.6.9 mongodb-org-mongos=2.6.9 mongodb-org-tools=2.6.9
+  - sleep 15
+  - mongo --version
 script: ant
 notifications:
   hipchat:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ services:
 install:
 - composer install
 before_script:
-- echo "extension = mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+- pecl install mongodb
 - sleep 15
 script: ant
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-sudo: false
+sudo: required
 php:
 - 5.6
 - 5.5
@@ -11,7 +11,6 @@ before_install:
 - pecl install mongodb
 install:
 - composer install
-
 script: ant
 notifications:
   hipchat:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
-sudo: required
+sudo: false
 php:
+- 7.0
 - 5.6
 - 5.5
 - 5.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-sudo: false
+sudo: required
 php:
 - 7.0
 - 5.6

--- a/README.md
+++ b/README.md
@@ -80,11 +80,11 @@ $tripod->saveChanges(
 Requirements
 ----
 
-PHP >= 5.3.x
+PHP >= 5.4.x
 
-Mongo 2.x and up, although at least 2.2 is recommended to take advantage of database level locking, especially in the case of shared datasets.
+Mongo 2.6.x and up.
 
-MongoPHP driver version 1.3.4 and up
+MongoDB PHP driver version. http://mongodb.github.io/mongo-php-driver/#installation
 
 
 What does the config look like?
@@ -319,7 +319,6 @@ Coming soon (aka a loose roadmap)
 * ~~Node version - probably read-only subset in the first instance~~ It's [here](https://github.com/talis/tripod-node).
 * ~~Improvements to the background queue, currently this is a long running php script working from a queue of updates held in mongo. Only ever intended for the PoC but it's still here 2 years later!~~
 * An alternative persistence technology for the tlog. Memory mapped databases are not good for datasets with rapid turnover as the data files grow even if the data set is pruned. Implement a more specialist append-only database or even a RDBMS for the tlog persistence. Being worked on: [issue](https://github.com/talis/tripod-php/issues/7), [branch](https://github.com/talis/tripod-php/tree/pgsql-tlog) and [PR](https://github.com/talis/tripod-php/pull/6)
-* ~~PHP >5.3.0 only. We still have some legacy servers on PHP 5.2 which is the only reason we continue support.~~
 * Performance improvements for ```ExtendedGraph```. The internal structure of this object is a relic from the days of Talis' own proprietary triple store and how it used to return data. We bootstrap onto that using the ```MongoGraph``` object to marshal data in and out. This relies heavily on regex and we know that from our own data gathered in the field this is a single point of optimisation that would cut CPU cycles and memory usage. On the bright side it's nice to have such targeted, low hanging fruit to pick.
 * Versioned config. This will allow views and tables to self-heal when their specs are updated. At present you have to delete and re-gen the lot when specs change.
 * ~~Publish updates to a spout for [Apache Storm](http://storm.incubator.apache.org/)~~ We implemented [event hooks](https://github.com/talis/tripod-php/blob/master/docs/primers/hooks.md) which would allow you to implement this.

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     "require": {
         "semsol/arc2": "v2.2.4",
         "chrisboulton/php-resque": "dev-master#98fde571db008a8b48e73022599d1d1c07d4a7b5",
-        "monolog/monolog" : "~1.13"
+        "monolog/monolog" : "~1.13",
+        "mongodb/mongodb": "^1.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "4.1.*"

--- a/src/mongo/Config.class.php
+++ b/src/mongo/Config.class.php
@@ -1783,7 +1783,8 @@ class Config
                     $command = new Command(['ping' => 1]);
                     $manager->executeCommand('admin', $command);
 
-                    if(empty($manager->getServers()) === false) {
+                    $servers = $manager->getServers();
+                    if(empty($servers) === false) {
                         $connected = true;
                     }
                 } catch (ConnectionTimeoutException $e) {

--- a/src/mongo/Config.class.php
+++ b/src/mongo/Config.class.php
@@ -8,7 +8,7 @@ use \MongoDB\Collection;
 use \MongoDB\Driver\ReadPreference;
 use \MongoDB\Driver\Command;
 use \MongoDB\Driver\Manager;
-use \MongoDB\Driver\Exception;
+use \MongoDB\Driver\Exception\ConnectionTimeoutException;
 
 /**
  * Holds the global configuration for Tripod

--- a/src/mongo/Config.class.php
+++ b/src/mongo/Config.class.php
@@ -2060,7 +2060,7 @@ class Config
 
     /**
      * @param $readPreference
-     * @return \MongoDB
+     * @return Database
      * @throws \Tripod\Exceptions\ConfigException
      */
     public function getTransactionLogDatabase($readPreference = ReadPreference::RP_PRIMARY_PREFERRED)

--- a/src/mongo/Config.class.php
+++ b/src/mongo/Config.class.php
@@ -2073,8 +2073,9 @@ class Config
     public function getTransactionLogDatabase($readPreference = ReadPreference::RP_PRIMARY_PREFERRED)
     {
         $client = $this->getConnectionForDataSource($this->tConfig['data_source']);
-        $db = $client->selectDB($this->tConfig['database']);
-        $db->setReadPreference($readPreference);
+        $db = $client->selectDatabase($this->tConfig['database']);
+
+        $db = $db->withOptions(array('readPreference' => new ReadPreference($readPreference)));
         return $db;
     }
 

--- a/src/mongo/Config.class.php
+++ b/src/mongo/Config.class.php
@@ -1832,7 +1832,7 @@ class Config
      * @param string $podName
      * @param string $readPreference
      * @throws \Tripod\Exceptions\ConfigException
-     * @return \MongoCollection
+     * @return Collection
      */
     public function getCollectionForCBD($storeName, $podName, $readPreference = ReadPreference::RP_PRIMARY_PREFERRED)
     {
@@ -1851,7 +1851,7 @@ class Config
      * @param string $viewId
      * @param string $readPreference
      * @throws \Tripod\Exceptions\ConfigException
-     * @return \MongoCollection
+     * @return Collection
      */
     public function getCollectionForView($storeName, $viewId, $readPreference = ReadPreference::RP_PRIMARY_PREFERRED)
     {
@@ -1870,7 +1870,7 @@ class Config
      * @param string $searchDocumentId
      * @param string $readPreference
      * @throws \Tripod\Exceptions\ConfigException
-     * @return \MongoCollection
+     * @return Collection
      */
     public function getCollectionForSearchDocument($storeName, $searchDocumentId, $readPreference = ReadPreference::RP_PRIMARY_PREFERRED)
     {
@@ -1889,7 +1889,7 @@ class Config
      * @param string $tableId
      * @param string $readPreference
      * @throws \Tripod\Exceptions\ConfigException
-     * @return \MongoCollection
+     * @return Collection
      */
     public function getCollectionForTable($storeName, $tableId, $readPreference = ReadPreference::RP_PRIMARY_PREFERRED)
     {
@@ -1908,7 +1908,7 @@ class Config
      * @param array $tables
      * @param string $readPreference
      * @throws \Tripod\Exceptions\ConfigException
-     * @return \MongoCollection[]
+     * @return Collection[]
      */
     public function getCollectionsForTables($storeName, array $tables = array(), $readPreference = ReadPreference::RP_PRIMARY_PREFERRED)
     {
@@ -1949,7 +1949,7 @@ class Config
      * @param array $views
      * @param string $readPreference
      * @throws \Tripod\Exceptions\ConfigException
-     * @return \MongoCollection[]
+     * @return Collection[]
      */
     public function getCollectionsForViews($storeName, array $views = array(), $readPreference = ReadPreference::RP_PRIMARY_PREFERRED)
     {
@@ -1990,7 +1990,7 @@ class Config
      * @param array $searchSpecIds
      * @param string $readPreference
      * @throws \Tripod\Exceptions\ConfigException
-     * @return \MongoCollection[]
+     * @return Collection[]
      */
     public function getCollectionsForSearch($storeName, array $searchSpecIds = array(), $readPreference = ReadPreference::RP_PRIMARY_PREFERRED)
     {
@@ -2029,7 +2029,7 @@ class Config
     /**
      * @param string $storeName
      * @param string $readPreference
-     * @return \MongoCollection
+     * @return Collection
      */
     public function getCollectionForTTLCache($storeName, $readPreference = ReadPreference::RP_PRIMARY_PREFERRED)
     {
@@ -2042,7 +2042,7 @@ class Config
     /**
      * @param string $storeName
      * @param string $readPreference
-     * @return \MongoCollection
+     * @return Collection
      */
     public function getCollectionForLocks($storeName, $readPreference = ReadPreference::RP_PRIMARY_PREFERRED)
     {
@@ -2055,7 +2055,7 @@ class Config
     /**
      * @param string $storeName
      * @param string $readPreference
-     * @return \MongoCollection
+     * @return Collection
      */
     public function getCollectionForManualRollbackAudit($storeName, $readPreference = ReadPreference::RP_PRIMARY_PREFERRED)
     {

--- a/src/mongo/Config.class.php
+++ b/src/mongo/Config.class.php
@@ -1773,20 +1773,12 @@ class Config
         {
             $retries = 1;
             $exception = null;
-            $connected = false;
 
             do {
                 try {
                     $connectionString = $ds['connection'] . '?' . http_build_query($connectionOptions);
                     $this->connections[$dataSource] = $this->getMongoClient($connectionString);
-                    $manager = new Manager($connectionString);
-                    $command = new Command(['ping' => 1]);
-                    $manager->executeCommand('admin', $command);
-
-                    $servers = $manager->getServers();
-                    if(empty($servers) === false) {
-                        $connected = true;
-                    }
+                    break;
                 } catch (ConnectionTimeoutException $e) {
                     self::getLogger()->error("ConnectionTimeoutException attempt ".$retries.". Retrying...:" . $e->getMessage());
                     sleep(1);
@@ -1794,7 +1786,7 @@ class Config
                     $exception = $e;
                 }
 
-            } while ($retries <= self::CONNECTION_RETRIES && $connected === false);
+            } while ($retries <= self::CONNECTION_RETRIES);
 
             if (!isset($this->connections[$dataSource])) {
                 self::getLogger()->error("MongoConnectionException failed after " . $retries . " attempts (MAX:".self::CONNECTION_RETRIES."): " . $e->getMessage());

--- a/src/mongo/Driver.class.php
+++ b/src/mongo/Driver.class.php
@@ -331,7 +331,7 @@ class Driver extends DriverBase implements \Tripod\IDriver
             $id['query'] = $query;
             $id['groupBy'] = $groupBy;
             $this->debugLog("Looking in cache",array("id"=>$id));
-            $candidate = $this->config->getCollectionForTTLCache($this->storeName)->findOne(array("_id"=>$id));
+            $candidate = $this->config->getCollectionForTTLCache($this->storeName)->findOne(array(_ID_KEY => $id));
             if (!empty($candidate))
             {
                 $this->debugLog("Found candidate",array("candidate"=>$candidate));
@@ -356,7 +356,7 @@ class Driver extends DriverBase implements \Tripod\IDriver
             {
                 $ops = [
                     ['$match' => $query],
-                    ['$group' => ['_id' => '$'.$groupBy,'total' => ['$sum' => 1]]]
+                    ['$group' => [_ID_KEY => '$'.$groupBy,'total' => ['$sum' => 1]]]
                 ];
                 $cursor = $this->collection->aggregate($ops);
                 foreach($cursor as $doc) {
@@ -376,7 +376,7 @@ class Driver extends DriverBase implements \Tripod\IDriver
             {
                 // add to cache
                 $cachedResults = array();
-                $cachedResults['_id'] = $id;
+                $cachedResults[_ID_KEY] = $id;
                 $cachedResults['results'] = $results;
                 $cachedResults['created'] = new UTCDateTime(floor(microtime(true))*1000);
                 $this->debugLog("Adding result to cache",$cachedResults);

--- a/src/mongo/Driver.class.php
+++ b/src/mongo/Driver.class.php
@@ -6,6 +6,7 @@ namespace Tripod\Mongo;
 
 use Tripod\Exceptions\Exception;
 use Tripod\IEventHook;
+use \MongoDB;
 
 $TOTAL_TIME=0;
 
@@ -60,11 +61,12 @@ class Driver extends DriverBase implements \Tripod\IDriver
      */
     public function __construct($podName, $storeName, $opts=array())
     {
+
         $opts = array_merge(array(
                 'defaultContext'=>null,
                 OP_ASYNC=>array(OP_VIEWS=>false,OP_TABLES=>true,OP_SEARCH=>true),
                 'statsConfig'=>array(),
-                'readPreference'=>\MongoClient::RP_PRIMARY_PREFERRED,
+                'readPreference'=>MongoDB\Driver\ReadPreference::RP_PRIMARY_PREFERRED,
                 'retriesToGetLock' => 20)
             ,$opts);
         $this->podName = $podName;

--- a/src/mongo/Driver.class.php
+++ b/src/mongo/Driver.class.php
@@ -459,7 +459,7 @@ class Driver extends DriverBase implements \Tripod\IDriver
             $row = array();
             foreach ($doc as $key=>$value)
             {
-                if ($key == "_id" || $key === '_version')
+                if ($key == _ID_KEY || $key === _VERSION)
                 {
                     $row[$key] = $value;
                 }

--- a/src/mongo/Driver.class.php
+++ b/src/mongo/Driver.class.php
@@ -459,7 +459,7 @@ class Driver extends DriverBase implements \Tripod\IDriver
             $row = array();
             foreach ($doc as $key=>$value)
             {
-                if ($key == "_id")
+                if ($key == "_id" || $key === '_version')
                 {
                     $row[$key] = $value;
                 }

--- a/src/mongo/Driver.class.php
+++ b/src/mongo/Driver.class.php
@@ -671,7 +671,8 @@ class Driver extends DriverBase implements \Tripod\IDriver
     {
         if(!isset($this->dataUpdater))
         {
-            $readPreference = $this->collection->getReadPreference();
+            $readPreference = $this->collection->__debugInfo()['readPreference']->getMode();
+
             $opts = array(
                 'defaultContext'=>$this->defaultContext,
                 OP_ASYNC=>$this->async,

--- a/src/mongo/Driver.class.php
+++ b/src/mongo/Driver.class.php
@@ -380,7 +380,10 @@ class Driver extends DriverBase implements \Tripod\IDriver
                 $cachedResults['results'] = $results;
                 $cachedResults['created'] = new UTCDateTime(floor(microtime(true))*1000);
                 $this->debugLog("Adding result to cache",$cachedResults);
-                $this->config->getCollectionForTTLCache($this->storeName)->insertOne($cachedResults);
+                $result = $this->config->getCollectionForTTLCache($this->storeName)->insertOne($cachedResults);
+                if (!$result->isAcknowledged()) {
+                    $this->debugLog("Insert cache result not acknowledged");
+                }
             }
         }
 

--- a/src/mongo/Driver.class.php
+++ b/src/mongo/Driver.class.php
@@ -540,10 +540,7 @@ class Driver extends DriverBase implements \Tripod\IDriver
         /* @var $lastUpdatedDate UTCDateTime */
         $lastUpdatedDate = ($doc!=null && array_key_exists(_UPDATED_TS,$doc)) ? $doc[_UPDATED_TS] : null;
 
-//        echo '<pre>'.print_r($doc,true).'</pre>';
-//        echo 'last updated:'.print_r($lastUpdatedDate,true).'<br />';
-//        die();
-        return (isset($lastUpdatedDate) == null) ? '' : $lastUpdatedDate->sec;
+        return (isset($lastUpdatedDate) == null) ? '' : $lastUpdatedDate->__toString();
     }
 
     /**

--- a/src/mongo/Driver.class.php
+++ b/src/mongo/Driver.class.php
@@ -6,7 +6,7 @@ namespace Tripod\Mongo;
 
 use Tripod\Exceptions\Exception;
 use Tripod\IEventHook;
-use \MongoDB;
+use \MongoDB\Driver\ReadPreference;
 
 $TOTAL_TIME=0;
 
@@ -66,7 +66,7 @@ class Driver extends DriverBase implements \Tripod\IDriver
                 'defaultContext'=>null,
                 OP_ASYNC=>array(OP_VIEWS=>false,OP_TABLES=>true,OP_SEARCH=>true),
                 'statsConfig'=>array(),
-                'readPreference'=>MongoDB\Driver\ReadPreference::RP_PRIMARY_PREFERRED,
+                'readPreference'=>ReadPreference::RP_PRIMARY_PREFERRED,
                 'retriesToGetLock' => 20)
             ,$opts);
         $this->podName = $podName;

--- a/src/mongo/ImpactedSubject.class.php
+++ b/src/mongo/ImpactedSubject.class.php
@@ -1,6 +1,9 @@
 <?php
 
 namespace Tripod\Mongo;
+
+use \MongoDB\Driver\ReadPreference;
+
 /**
  * A subject that has been involved in an modification event (create/update, delete) and will therefore require
  * view, table and search doc generation
@@ -150,6 +153,8 @@ class ImpactedSubject
      */
     protected function getTripod()
     {
-        return new Driver($this->getPodName(),$this->getStoreName(),array("readPreference"=>\MongoClient::RP_PRIMARY));
+        return new Driver($this->getPodName(),$this->getStoreName(),array(
+            'readPreference' => ReadPreference::RP_PRIMARY
+        ));
     }
 }

--- a/src/mongo/base/CompositeBase.class.php
+++ b/src/mongo/base/CompositeBase.class.php
@@ -133,7 +133,7 @@ abstract class CompositeBase extends \Tripod\Mongo\DriverBase implements \Tripod
     /**
      * @param array $resourcesAndPredicates
      * @param string $contextAlias
-     * @return mixed // @todo: This may eventually return a either a MongoCursor or array
+     * @return mixed // @todo: This may eventually return a either a Cursor or array
      */
     public abstract function findImpactedComposites(Array $resourcesAndPredicates,$contextAlias);
 

--- a/src/mongo/base/CompositeBase.class.php
+++ b/src/mongo/base/CompositeBase.class.php
@@ -30,11 +30,13 @@ abstract class CompositeBase extends \Tripod\Mongo\DriverBase implements \Tripod
             $filter[] = array(_ID_RESOURCE=>$resourceAlias,_ID_CONTEXT=>$contextAlias);
         }
         $query = array(_ID_KEY=>array('$in'=>$filter));
-        $docs = $this->getCollection()->find($query, array(_ID_KEY=>true, 'rdf:type'=>true));
+        $docs = $this->getCollection()->find($query, array(
+            'projection' => array(_ID_KEY=>true, 'rdf:type'=>true)
+        ));
 
         $types = $this->getTypesInSpecifications();
 
-        if($docs->count() !== 0 ) {
+        if($this->getCollection()->count($query) !== 0 ) {
             foreach($docs as $doc)
             {
                 $docResource = $doc[_ID_KEY][_ID_RESOURCE];

--- a/src/mongo/base/DriverBase.class.php
+++ b/src/mongo/base/DriverBase.class.php
@@ -11,6 +11,7 @@ use Tripod\Exceptions\Exception;
 use Tripod\IEventHook;
 use \MongoDB\Driver\ReadPreference;
 use \MongoDB\Collection;
+use \MongoDB\BSON\UTCDateTime;
 
 /**
  * Class DriverBase
@@ -201,7 +202,7 @@ abstract class DriverBase
                     if ($type==MONGO_VIEW && array_key_exists(_EXPIRES,$result['value']))
                     {
                         // if expires < current date, regenerate view..
-                        $currentDate = new \MongoDate();
+                        $currentDate = new UTCDateTime(floor(microtime(true))*1000);
                         if ($result['value'][_EXPIRES]<$currentDate)
                         {
                             // regenerate!

--- a/src/mongo/base/DriverBase.class.php
+++ b/src/mongo/base/DriverBase.class.php
@@ -9,6 +9,7 @@ $TOTAL_TIME=0;
 use Monolog\Logger;
 use Tripod\Exceptions\Exception;
 use Tripod\IEventHook;
+use \MongoDB\Driver\ReadPreference;
 use \MongoDB\Collection;
 
 /**
@@ -60,7 +61,7 @@ abstract class DriverBase
     /**
      * @var string
      */
-    protected $readPreference;
+    protected $readPreference = ReadPreference::RP_PRIMARY_PREFERRED;
 
     /**
      * @return \Tripod\ITripodStat

--- a/src/mongo/base/DriverBase.class.php
+++ b/src/mongo/base/DriverBase.class.php
@@ -56,7 +56,7 @@ abstract class DriverBase
     protected $statsConfig = array();
 
     /**
-     * @var \MongoDB
+     * @var Database
      */
     protected $db = null;
 
@@ -214,7 +214,7 @@ abstract class DriverBase
                 }
                 $cursorSuccess = true;
             } catch (\Exception $e) {
-                self::getLogger()->error("MongoCursorException attempt ".$retries.". Retrying...:" . $e->getMessage());
+                self::getLogger()->error("CursorException attempt ".$retries.". Retrying...:" . $e->getMessage());
                 sleep(1);
                 $retries++;
                 $exception = $e;
@@ -222,7 +222,7 @@ abstract class DriverBase
         } while ($retries <= Config::CONNECTION_RETRIES && $cursorSuccess === false);
 
         if ($cursorSuccess === false) {
-            self::getLogger()->error("MongoCursorException failed after " . $retries . " attempts (MAX:".Config::CONNECTION_RETRIES."): " . $e->getMessage());
+            self::getLogger()->error("CursorException failed after " . $retries . " attempts (MAX:".Config::CONNECTION_RETRIES."): " . $e->getMessage());
             throw new \Exception($exception);
         }
 
@@ -436,7 +436,7 @@ abstract class DriverBase
     }
 
     /**
-     * @return\MongoDB
+     * @return Database
      */
     protected function getDatabase()
     {

--- a/src/mongo/base/DriverBase.class.php
+++ b/src/mongo/base/DriverBase.class.php
@@ -223,7 +223,7 @@ abstract class DriverBase
 
         if ($cursorSuccess === false) {
             self::getLogger()->error("MongoCursorException failed after " . $retries . " attempts (MAX:".Config::CONNECTION_RETRIES."): " . $e->getMessage());
-            throw new \MongoCursorException($exception);
+            throw new \Exception($exception);
         }
 
         if ($ttlExpiredResources)
@@ -457,13 +457,6 @@ abstract class DriverBase
      * @return array
      */
     protected function getLastDBError(\MongoDB\Database $db) {
-//        if (is_null($db)) {
-//            $db = $this->config->getDatabase(
-//                $this->storeName,
-//                $this->config->getDataSourceForPod($this->storeName, $this->podName),
-//                $this->readPreference
-//            );
-//        }
         return $db->command([
             'getLastError' =>  1
         ])->toArray()[0];

--- a/src/mongo/base/DriverBase.class.php
+++ b/src/mongo/base/DriverBase.class.php
@@ -9,6 +9,7 @@ $TOTAL_TIME=0;
 use Monolog\Logger;
 use Tripod\Exceptions\Exception;
 use Tripod\IEventHook;
+use \MongoDB\Collection;
 
 /**
  * Class DriverBase
@@ -24,7 +25,7 @@ abstract class DriverBase
     const HOOK_FN_FAILURE = "failure";
 
     /**
-     * @var \MongoCollection
+     * @var Collection
      */
     protected $collection;
 
@@ -145,7 +146,7 @@ abstract class DriverBase
     /**
      * @param array $query
      * @param string $type
-     * @param \MongoCollection|null $collection
+     * @param Collection|null $collection
      * @param array $includeProperties
      * @param int $cursorSize
      * @return MongoGraph
@@ -448,7 +449,7 @@ abstract class DriverBase
     }
 
     /**
-     * @return \MongoCollection
+     * @return Collection
      */
     protected function getCollection()
     {

--- a/src/mongo/base/DriverBase.class.php
+++ b/src/mongo/base/DriverBase.class.php
@@ -160,11 +160,11 @@ abstract class DriverBase
         if ($collection==null)
         {
             $collection = $this->collection;
-            $collectionName = $collection->getName();
+            $collectionName = $collection->getCollectionName();
         }
         else
         {
-            $collectionName = $collection->getName();
+            $collectionName = $collection->getCollectionName();
         }
 
         if (empty($includeProperties))
@@ -178,11 +178,13 @@ abstract class DriverBase
             {
                 $fields[$this->labeller->uri_to_alias($property)] = true;
             }
-            $cursor = $collection->find($query,$fields);
+            $cursor = $collection->find($query, array(
+                'projection' => $fields,
+                'batchSize' => $cursorSize
+            ));
         }
 
         $ttlExpiredResources = false;
-        $cursor->batchSize($cursorSize);
 
         $retries = 1;
         $exception = null;

--- a/src/mongo/base/JobBase.class.php
+++ b/src/mongo/base/JobBase.class.php
@@ -3,6 +3,7 @@
 namespace Tripod\Mongo\Jobs;
 use Tripod\Exceptions\Exception;
 use Tripod\Exceptions\JobException;
+use \MongoDB\Driver\ReadPreference;
 
 /**
  * Todo: How to inject correct stat class... :-S
@@ -23,7 +24,7 @@ abstract class JobBase extends \Tripod\Mongo\DriverBase
     protected function getTripod($storeName,$podName,$opts=array()) {
         $opts = array_merge($opts,array(
             'stat'=>$this->getStat(),
-            'readPreference'=>\MongoClient::RP_PRIMARY // important: make sure we always read from the primary
+            'readPreference' => ReadPreference::RP_PRIMARY // important: make sure we always read from the primary
         ));
         if ($this->tripod == null) {
             $this->tripod = new \Tripod\Mongo\Driver(

--- a/src/mongo/delegates/SearchDocuments.class.php
+++ b/src/mongo/delegates/SearchDocuments.class.php
@@ -76,8 +76,9 @@ class SearchDocuments extends DriverBase
                 // add id of current record to rules..
                 $indexRules['condition']['_id'] = array(
                     'r'=>$this->labeller->uri_to_alias($resource),
-                    'c'=>$this->labeller->uri_to_alias($context));				
-                if (Config::getInstance()->getCollectionForCBD($this->storeName, $irFrom)->find($indexRules['condition'])->hasNext())
+                    'c'=>$this->labeller->uri_to_alias($context));
+
+                if (Config::getInstance()->getCollectionForCBD($this->storeName, $irFrom)->findOne($indexRules['condition']))
                 {
                     // match found, add this spec id to those that should be generated
                    $proceedWithGeneration = true;

--- a/src/mongo/delegates/SearchDocuments.class.php
+++ b/src/mongo/delegates/SearchDocuments.class.php
@@ -119,7 +119,7 @@ class SearchDocuments extends DriverBase
         Config::getInstance()->getCollectionForSearchDocument(
             $this->storeName,
             $specId)
-            ->ensureIndex(
+            ->createIndex(
                 array('_id.type'=>1),
                 array(
                     'background'=>1
@@ -129,7 +129,7 @@ class SearchDocuments extends DriverBase
         Config::getInstance()->getCollectionForSearchDocument(
             $this->storeName,
             $specId)
-            ->ensureIndex(
+            ->createIndex(
                 array('_impactIndex'=>1),
                 array(
                     'background'=>1
@@ -221,8 +221,9 @@ class SearchDocuments extends DriverBase
                     : $config->getCollectionForCBD($this->storeName, $from)
                 );
 
-                $cursor = $collection->find(array('_id'=>array('$in'=>$joinUris)));
-                $cursor->timeout(\Tripod\Mongo\Config::getInstance()->getMongoCursorTimeout());
+                $cursor = $collection->find(array('_id'=>array('$in'=>$joinUris)), array(
+                    'maxTimeMS' => \Tripod\Mongo\Config::getInstance()->getMongoCursorTimeout()
+                ));
 
                 // add to impact index
                 $this->addIdToImpactIndex($joinUris, $target);

--- a/src/mongo/delegates/SearchDocuments.class.php
+++ b/src/mongo/delegates/SearchDocuments.class.php
@@ -2,6 +2,9 @@
 
 namespace Tripod\Mongo;
 
+use \MongoDB\Driver\ReadPreference;
+use \MongoDB\Collection;
+
 /**
  * Class SearchDocuments
  * @package Tripod\Mongo
@@ -12,12 +15,12 @@ class SearchDocuments extends DriverBase
      * Construct accepts actual objects rather than strings as this class is a delegate of
      * Tripod and should inherit connections set up there
      * @param string $storeName
-     * @param \MongoCollection $collection
+     * @param Collection $collection
      * @param string $defaultContext
      * @param \Tripod\ITripodStat|null $stat
      * @param string $readPreference
      */
-    public function __construct($storeName, \MongoCollection $collection, $defaultContext, $stat=null , $readPreference=\MongoClient::RP_PRIMARY)
+    public function __construct($storeName, Collection $collection, $defaultContext, $stat=null , $readPreference = ReadPreference::RP_PRIMARY)
     {
         $this->labeller = new Labeller();
         $this->storeName = $storeName;

--- a/src/mongo/delegates/SearchDocuments.class.php
+++ b/src/mongo/delegates/SearchDocuments.class.php
@@ -22,7 +22,7 @@ class SearchDocuments extends DriverBase
         $this->labeller = new Labeller();
         $this->storeName = $storeName;
         $this->collection = $collection;
-        $this->podName = $collection->getName();
+        $this->podName = $collection->getCollectionName();
         $this->defaultContext = $defaultContext;
         $this->stat = $stat;
         $this->readPreference = $readPreference;

--- a/src/mongo/delegates/SearchIndexer.class.php
+++ b/src/mongo/delegates/SearchIndexer.class.php
@@ -124,8 +124,10 @@ class SearchIndexer extends CompositeBase
             'c'=>$this->getContextAlias($context)
         ));
 
-        $resourceAndType = $mongoCollection->find($query,array("_id"=>1,"rdf:type"=>1));
-        $resourceAndType->timeout($this->config->getMongoCursorTimeout());
+        $resourceAndType = $mongoCollection->find($query,array(
+            'projection' => array("_id"=>1,"rdf:type"=>1),
+            'maxTimeMS' => $this->config->getMongoCursorTimeout()
+        ));
         foreach ($resourceAndType as $rt)
         {
             if (array_key_exists("rdf:type",$rt))
@@ -203,8 +205,9 @@ class SearchIndexer extends CompositeBase
             $filter["_id"] = array(_ID_RESOURCE=>$this->labeller->uri_to_alias($resource),_ID_CONTEXT=>$contextAlias);
         }
 
-        $docs = $this->config->getCollectionForCBD($this->getStoreName(), $from)->find($filter);
-        $docs->timeout($this->config->getMongoCursorTimeout());
+        $docs = $this->config->getCollectionForCBD($this->getStoreName(), $from)->find($filter, array(
+            'maxTimeMS' => $this->config->getMongoCursorTimeout()
+        ));
         foreach ($docs as $doc)
         {
             if($queueName && !$resourceUri)

--- a/src/mongo/delegates/SearchIndexer.class.php
+++ b/src/mongo/delegates/SearchIndexer.class.php
@@ -10,6 +10,9 @@ require_once TRIPOD_DIR . 'exceptions/SearchException.class.php';
 use Tripod\Mongo\Config;
 use Tripod\Mongo\ImpactedSubject;
 use Tripod\Mongo\Labeller;
+use \MongoDB\Driver\ReadPreference;
+use \MongoDB\Collection;
+
 /**
  * Class SearchIndexer
  * @package Tripod\Mongo\Composites
@@ -32,7 +35,7 @@ class SearchIndexer extends CompositeBase
      * @param string $readPreference
      * @throws \Tripod\Exceptions\SearchException
      */
-    public function __construct(\Tripod\Mongo\Driver $tripod, $readPreference=\MongoClient::RP_PRIMARY)
+    public function __construct(\Tripod\Mongo\Driver $tripod, $readPreference = ReadPreference::RP_PRIMARY)
     {
         $this->tripod = $tripod;
         $this->storeName = $tripod->getStoreName();
@@ -271,11 +274,11 @@ class SearchIndexer extends CompositeBase
     }
 
     /**
-     * @param \MongoCollection $collection
+     * @param Collection $collection
      * @param string $context
      * @return \Tripod\Mongo\SearchDocuments
      */
-    protected function getSearchDocumentGenerator(\MongoCollection $collection, $context )
+    protected function getSearchDocumentGenerator(Collection $collection, $context )
     {
         return new \Tripod\Mongo\SearchDocuments($this->storeName, $collection, $context, $this->tripod->getStat());
     }

--- a/src/mongo/delegates/Tables.class.php
+++ b/src/mongo/delegates/Tables.class.php
@@ -79,7 +79,7 @@ class Tables extends CompositeBase
         $this->labeller = new Labeller();
         $this->storeName = $storeName;
         $this->collection = $collection;
-        $this->podName = $collection->getName();
+        $this->podName = $collection->getCollectionName();
         $this->config = Config::getInstance();
         $this->defaultContext = $this->labeller->uri_to_alias($defaultContext); // make sure default context is qnamed if applicable
         $this->stat = $stat;
@@ -666,9 +666,9 @@ class Tables extends CompositeBase
         // Find the name of any indexed fields
         $indexedFields = array();
         $indexesGroupedByCollection = $this->config->getIndexesGroupedByCollection($this->storeName);
-        if (isset($indexesGroupedByCollection) && isset($indexesGroupedByCollection[$collection->getName()]))
+        if (isset($indexesGroupedByCollection) && isset($indexesGroupedByCollection[$collection->getCollectionName()]))
         {
-            $indexes = $indexesGroupedByCollection[$collection->getName()];
+            $indexes = $indexesGroupedByCollection[$collection->getCollectionName()];
             if (isset($indexes))
             {
                 foreach($indexes as $repset)

--- a/src/mongo/delegates/Tables.class.php
+++ b/src/mongo/delegates/Tables.class.php
@@ -651,13 +651,13 @@ class Tables extends CompositeBase
     {
         try
         {
-            $collection->insertOne($generatedRow);
+            $collection->updateOne($generatedRow['_id'], array('$set' => $generatedRow), array('upsert' => true));
         } catch (\Exception $e) {
             // We only truncate and retry the save if the \Exception contains this text.
             if (strpos($e->getMessage(),"Btree::insert: key too large to index") !== FALSE)
             {
                 $this->truncateFields($collection, $generatedRow);
-                $collection->insertOne($generatedRow);
+                $collection->updateOne($generatedRow['_id'], array('$set' => $generatedRow), array('upsert' => true));
             }
             else
             {

--- a/src/mongo/delegates/Tables.class.php
+++ b/src/mongo/delegates/Tables.class.php
@@ -575,7 +575,7 @@ class Tables extends CompositeBase
         }
 
         $docs = $this->config->getCollectionForCBD($this->storeName, $from)->find($filter, array(
-            'maxTimeMS' => \Tripod\Mongo\Config::getInstance()->getMongoCursorTimeout()
+            'maxTimeMS' => 1000000
         ));
 
         foreach ($docs as $doc)
@@ -1326,8 +1326,9 @@ class Tables extends CompositeBase
                     ? $this->config->getCollectionForCBD($this->storeName, $ruleset['from'])
                     : $this->config->getCollectionForCBD($this->storeName, $from)
                 );
+
                 $cursor = $collection->find(array('_id'=>array('$in'=>$joinUris)), array(
-                    'maxTimeMS' => \Tripod\Mongo\Config::getInstance()->getMongoCursorTimeout()
+                    'maxTimeMS' => 1000000
                 ));
 
                 $this->addIdToImpactIndex($joinUris, $dest);

--- a/src/mongo/delegates/Tables.class.php
+++ b/src/mongo/delegates/Tables.class.php
@@ -203,7 +203,7 @@ class Tables extends CompositeBase
         {
             $t = new \Tripod\Timer();
             $t->start();
-            $tableRows = $collection->find($query, array("_id"=>true));
+            $tableRows = $collection->find($query, array('projection' => array("_id"=>true)));
             $t->stop();
             $this->timingLog(MONGO_FIND_IMPACTED, array('duration'=>$t->result(), 'query'=>$query, 'storeName'=>$this->storeName, 'collection'=>$collection));
             foreach($tableRows as $t)
@@ -254,11 +254,11 @@ class Tables extends CompositeBase
 
         $findOptions = array();
         if (!empty($limit)) {
-           $findOptions['skip'] = $offset;
-           $findOptions['limit'] = $limit;
+           $findOptions['skip'] = (int) $offset;
+           $findOptions['limit'] = (int) $limit;
         }
         if (isset($sortBy)) {
-            $findOptions['sortBy'] = $sortBy;
+            $findOptions['sort'] = $sortBy;
         }
         $results = $collection->find($filter, $findOptions);
 
@@ -397,7 +397,7 @@ class Tables extends CompositeBase
         // now go through the types
         $query = array("_id"=>array('$in'=>$filter));
         $resourceAndType = $this->config->getCollectionForCBD($this->storeName, $this->podName)
-            ->find($query,array("_id"=>1,"rdf:type"=>1));
+            ->find($query, array('projection' => array("_id"=>1,"rdf:type"=>1)));
 
         foreach ($resourceAndType as $rt)
         {

--- a/src/mongo/delegates/Tables.class.php
+++ b/src/mongo/delegates/Tables.class.php
@@ -707,7 +707,7 @@ class Tables extends CompositeBase
                 {
                     // The key will have the index name in the following format added to it.
                     // Adjust the max key size allowed to take it into account.
-                    $maxKeySize = 1024 - strlen("value_".$indexedFieldname."_1");
+                    $maxKeySize = 1020 - strlen("value_".$indexedFieldname."_1");
 
                     if (array_key_exists($indexedFieldname, $field))
                     {

--- a/src/mongo/delegates/Tables.class.php
+++ b/src/mongo/delegates/Tables.class.php
@@ -10,6 +10,7 @@ use Tripod\Mongo\ImpactedSubject;
 use Tripod\Mongo\Labeller;
 use \MongoDB\Driver\ReadPreference;
 use \MongoDB\Collection;
+use \MongoDB\BSON\UTCDateTime;
 
 /**
  * Class Tables
@@ -1267,7 +1268,8 @@ class Tables extends CompositeBase
                     if(is_array($value)) $value = implode($options['glue'], $value);
                     break;
                 case 'date':
-                    if(is_string($value)) $value = new \MongoDate(strtotime($value));
+                    if(is_string($value)) $value = new UTCDateTime((strtotime($value) * 1000));
+                    //if(is_string($value)) $value = new \MongoDate(strtotime($value));
                     break;
                 default:
                     throw new \Exception("Could not apply modifier:".$modifier);

--- a/src/mongo/delegates/Tables.class.php
+++ b/src/mongo/delegates/Tables.class.php
@@ -1269,7 +1269,6 @@ class Tables extends CompositeBase
                     break;
                 case 'date':
                     if(is_string($value)) $value = new UTCDateTime((strtotime($value) * 1000));
-                    //if(is_string($value)) $value = new \MongoDate(strtotime($value));
                     break;
                 default:
                     throw new \Exception("Could not apply modifier:".$modifier);

--- a/src/mongo/delegates/TransactionLog.class.php
+++ b/src/mongo/delegates/TransactionLog.class.php
@@ -162,7 +162,7 @@ class TransactionLog
             $query['endTime'] = $q;
         }
 
-        return $this->transaction_collection->find($query)->sort(array('endTime'=>1));
+        return $this->transaction_collection->find($query, array('sort' => array('endTime'=>1)));
     }
 
     /**

--- a/src/mongo/delegates/TransactionLog.class.php
+++ b/src/mongo/delegates/TransactionLog.class.php
@@ -45,9 +45,9 @@ class TransactionLog
             "sessionId" => ((session_id() != '') ? session_id() : '')
         );
 
-        $ret = $this->insertTransaction($transaction);
+        $result = $this->insertTransaction($transaction);
 
-        if(isset($ret['err']) && $ret['err'] != NULL ){
+        if (!$result->isAcknowledged()) {
             throw new \Tripod\Exceptions\Exception("Error creating new transaction: " . var_export($ret,true));
         }
     }
@@ -201,7 +201,7 @@ class TransactionLog
      */
     protected function insertTransaction($transaction)
     {
-        return $this->transaction_collection->insert($transaction, array("w" => 1));
+        return $this->transaction_collection->insertOne($transaction, array("w" => 1));
     }
 
     /**
@@ -214,7 +214,7 @@ class TransactionLog
      */
     protected function updateTransaction($query, $update, $options)
     {
-        return $this->transaction_collection->update($query, $update, $options);
+        return $this->transaction_collection->updateMany($query, $update, $options);
     }
 
 

--- a/src/mongo/delegates/TransactionLog.class.php
+++ b/src/mongo/delegates/TransactionLog.class.php
@@ -216,7 +216,7 @@ class TransactionLog
      */
     protected function updateTransaction($query, $update, $options)
     {
-        return $this->transaction_collection->updateMany($query, $update, $options);
+        return $this->transaction_collection->updateOne($query, $update, $options);
     }
 
 

--- a/src/mongo/delegates/TransactionLog.class.php
+++ b/src/mongo/delegates/TransactionLog.class.php
@@ -160,13 +160,13 @@ class TransactionLog
 
         if(!empty($fromDate)) {
             $q = array();
-            $q['$gte'] = (int) (new UTCDateTime(floor((new \DateTime($fromDate))->format('U') )))->__toString();
+            $q['$gte'] = new UTCDateTime(strtotime($fromDate)*1000);
 
             if(!empty($toDate)){
-                $q['$lte'] = (int) (new UTCDateTime(floor((new \DateTime($toDate))->format('U') )))->__toString();
+                $q['$lte'] = new UTCDateTime(strtotime($toDate)*1000);
             }
 
-            $query['endTime.sec'] = $q;
+            $query['endTime'] = $q;
         }
 
         return $this->transaction_collection->find($query, array('sort' => array('endTime'=>1)));

--- a/src/mongo/delegates/TransactionLog.class.php
+++ b/src/mongo/delegates/TransactionLog.class.php
@@ -6,6 +6,7 @@ require_once TRIPOD_DIR . 'mongo/Config.class.php';
 use \MongoDB\BSON\UTCDateTime;
 use \MongoDB\InsertOneResult;
 use \MongoDB\UpdateOneResult;
+use \MongoDB\Driver\Cursor;
 
 /**
  * Class TransactionLog
@@ -144,7 +145,7 @@ class TransactionLog
      * @param string $podName
      * @param string|null $fromDate only transactions after this specified date will be replayed. This must be a datetime string i.e. '2010-01-15 00:00:00'
      * @param string|null $toDate only transactions after this specified date will be replayed. This must be a datetime string i.e. '2010-01-15 00:00:00'
-     * @return \MongoCursor
+     * @return Cursor
      * @throws \InvalidArgumentException
      */
     public function getCompletedTransactions($storeName=null, $podName=null, $fromDate=null, $toDate=null)

--- a/src/mongo/delegates/Updates.class.php
+++ b/src/mongo/delegates/Updates.class.php
@@ -232,6 +232,8 @@ class Updates extends DriverBase {
     /**
      * Change the read preferences to RP_PRIMARY
      * Used for a write operation
+     * @todo When there is a getReadPreference function available in the PHP Mongo library (or the read
+     * preference is readable) we should use that instead of the debugInfo function we're using here.
      */
     protected function setReadPreferenceToPrimary()
     {

--- a/src/mongo/delegates/Updates.class.php
+++ b/src/mongo/delegates/Updates.class.php
@@ -162,6 +162,7 @@ class Updates extends DriverBase {
             "newGraph"=>$newGraph,
             "context"=>$context
         ));
+
         $this->setReadPreferenceToPrimary();
         try{
             $contextAlias = $this->getContextAlias($context);
@@ -884,9 +885,9 @@ class Updates extends DriverBase {
             if(!empty($fromDateTime)) $query[_LOCKED_FOR_TRANS_TS][MONGO_OPERATION_GTE] = new \MongoDate(strtotime($fromDateTime));
             if(!empty($tillDateTime)) $query[_LOCKED_FOR_TRANS_TS][MONGO_OPERATION_LTE] = new \MongoDate(strtotime($tillDateTime));
         }
-        $docs = $this->getLocksCollection()->find($query)->sort(array(_LOCKED_FOR_TRANS => 1));
+        $docs = $this->getLocksCollection()->find($query, array('sort' => array(_LOCKED_FOR_TRANS => 1)));
 
-        if($docs->count() == 0 ) {
+        if($this->getLocksCollection()->count($query) == 0 ) {
             return array();
         }
 
@@ -986,9 +987,10 @@ class Updates extends DriverBase {
      */
     public function removeInertLocks($transaction_id, $reason)
     {
-        $docs = $this->getLocksCollection()->find(array(_LOCKED_FOR_TRANS => $transaction_id));
+        $query = array(_LOCKED_FOR_TRANS => $transaction_id);
+        $docs = $this->getLocksCollection()->find($query);
 
-        if($docs->count() == 0 ) {
+        if($this->getLocksCollection()->count($query) == 0 ) {
             return false;
         }else{
 
@@ -1140,7 +1142,7 @@ class Updates extends DriverBase {
             $document  = $this->getCollection()->findOne(array(_ID_KEY => array(_ID_RESOURCE => $this->labeller->uri_to_alias($s), _ID_CONTEXT => $contextAlias)));
             if(empty($document)){ //if document is not there, create it
                 try{
-                    $result = $this->getCollection()->insert(
+                    $result = $this->getCollection()->insertOne(
                         array(
                             _ID_KEY => array(_ID_RESOURCE => $this->labeller->uri_to_alias($s), _ID_CONTEXT => $contextAlias)
                         ),

--- a/src/mongo/delegates/Updates.class.php
+++ b/src/mongo/delegates/Updates.class.php
@@ -5,6 +5,7 @@ namespace Tripod\Mongo;
 use Tripod\Exceptions\Exception;
 use Tripod\IEventHook;
 use \MongoDB\Driver\ReadPreference;
+use \MongoDB\Database;
 use \MongoDB\Collection;
 use \MongoDB\Operation\FindOneAndUpdate;
 use \MongoDB\BSON\UTCDateTime;
@@ -1228,7 +1229,7 @@ class Updates extends DriverBase {
     }
 
     /**
-     * @return \MongoDate
+     * @return UTCDateTime
      */
     protected function getMongoDate()
     {
@@ -1355,7 +1356,7 @@ class Updates extends DriverBase {
     }
 
     /**
-     * @return \MongoDB
+     * @return Database
      */
     protected function getLocksDatabase()
     {

--- a/src/mongo/delegates/Updates.class.php
+++ b/src/mongo/delegates/Updates.class.php
@@ -4,6 +4,8 @@ namespace Tripod\Mongo;
 
 use Tripod\Exceptions\Exception;
 use Tripod\IEventHook;
+use \MongoDB\Driver\ReadPreference;
+use \MongoDB\Collection;
 
 require_once TRIPOD_DIR . 'mongo/Config.class.php';
 
@@ -57,7 +59,7 @@ class Updates extends DriverBase {
     protected $locksDb;
 
     /**
-     * @var \MongoCollection
+     * @var Collection
      */
     protected $locksCollection;
 
@@ -91,7 +93,7 @@ class Updates extends DriverBase {
                 'defaultContext'=>null,
                 OP_ASYNC=>array(OP_VIEWS=>false,OP_TABLES=>true,OP_SEARCH=>true),
                 'stat'=>null,
-                'readPreference'=>\MongoClient::RP_PRIMARY_PREFERRED,
+                'readPreference' => ReadPreference::RP_PRIMARY_PREFERRED,
                 'retriesToGetLock' => 20)
             ,$opts);
         $this->readPreference = $opts['readPreference'];
@@ -230,18 +232,18 @@ class Updates extends DriverBase {
     {
         // Set db preference
         $dbPref = $this->getDatabase()->getReadPreference();
-        if($dbPref['type'] !== \MongoClient::RP_PRIMARY){
+        if($dbPref['type'] !== ReadPreference::RP_PRIMARY){
             $this->originalDbReadPreference = $this->db->getReadPreference();
             $tagsets = (isset($dbPref['tagsets']) ? $dbPref['tagsets'] : array());
-            $this->db->setReadPreference(\MongoClient::RP_PRIMARY, $tagsets);
+            $this->db->setReadPreference(ReadPreference::RP_PRIMARY, $tagsets);
         }
 
         $collPref = $this->getCollection()->getReadPreference();
         // Set collection preference
-        if($collPref['type'] !== \MongoClient::RP_PRIMARY){
+        if($collPref['type'] !== ReadPreference::RP_PRIMARY){
             $this->originalCollectionReadPreference = $this->collection->getReadPreference();
             $tagsets = (isset($collPref['tagsets']) ? $collPref['tagsets'] : array());
-            $this->collection->setReadPreference(\MongoClient::RP_PRIMARY, $tagsets);
+            $this->collection->setReadPreference(ReadPreference::RP_PRIMARY, $tagsets);
         }
     }
 
@@ -1170,7 +1172,7 @@ class Updates extends DriverBase {
     /// Collection methods
 
     /**
-     * @return \MongoCollection
+     * @return Collection
      */
     protected function getAuditManualRollbacksCollection()
     {
@@ -1334,7 +1336,7 @@ class Updates extends DriverBase {
     }
 
     /**
-     * @return \MongoCollection
+     * @return Collection
      */
     protected function getLocksCollection()
     {

--- a/src/mongo/delegates/Updates.class.php
+++ b/src/mongo/delegates/Updates.class.php
@@ -7,6 +7,8 @@ use Tripod\IEventHook;
 use \MongoDB\Driver\ReadPreference;
 use \MongoDB\Collection;
 use \MongoDB\Operation\FindOneAndUpdate;
+use \MongoDB\BSON\UTCDateTime;
+use \MongoDB\BSON\ObjectId;
 
 require_once TRIPOD_DIR . 'mongo/Config.class.php';
 
@@ -609,7 +611,7 @@ class Updates extends DriverBase {
                 // currently the only criteria is the doc id
                 //var_dump($targetGraph->to_tripod_array($subjectOfChange));
 
-                $updatedAt = new \MongoDate();
+                $updatedAt = new UTCDateTime(floor(microtime(true))*1000);
 
                 if (!isset($doc[_VERSION]))
                 {
@@ -897,8 +899,8 @@ class Updates extends DriverBase {
         if(!empty($fromDateTime) || !empty($tillDateTime)){
             $query[_LOCKED_FOR_TRANS_TS] = array();
 
-            if(!empty($fromDateTime)) $query[_LOCKED_FOR_TRANS_TS][MONGO_OPERATION_GTE] = new \MongoDate(strtotime($fromDateTime));
-            if(!empty($tillDateTime)) $query[_LOCKED_FOR_TRANS_TS][MONGO_OPERATION_LTE] = new \MongoDate(strtotime($tillDateTime));
+            if(!empty($fromDateTime)) $query[_LOCKED_FOR_TRANS_TS][MONGO_OPERATION_GTE] = new UTCDateTime(strtotime($fromDateTime) * 1000);
+            if(!empty($tillDateTime)) $query[_LOCKED_FOR_TRANS_TS][MONGO_OPERATION_LTE] = new UTCDateTime(strtotime($tillDateTime) * 1000);
         }
         $docs = $this->getLocksCollection()->find($query, array('sort' => array(_LOCKED_FOR_TRANS => 1)));
 
@@ -1132,7 +1134,7 @@ class Updates extends DriverBase {
                     array(
                         _ID_KEY => array(_ID_RESOURCE => $this->labeller->uri_to_alias($s), _ID_CONTEXT => $contextAlias),
                         _LOCKED_FOR_TRANS => $transaction_id,
-                        _LOCKED_FOR_TRANS_TS=>new \MongoDate()
+                        _LOCKED_FOR_TRANS_TS => new UTCDateTime(floor(microtime(true))*1000)
                     ),
                     array("w" => 1)
                 );
@@ -1206,11 +1208,11 @@ class Updates extends DriverBase {
     }
 
     /**
-     * @return \MongoId
+     * @return ObjectId
      */
     protected function generateIdForNewMongoDocument()
     {
-        return new \MongoId();
+        return new ObjectId();
     }
 
     /**
@@ -1218,7 +1220,7 @@ class Updates extends DriverBase {
      */
     protected function getMongoDate()
     {
-        return new \MongoDate();
+        return new UTCDateTime(floor(microtime(true))*1000);
     }
 
 

--- a/src/mongo/delegates/Updates.class.php
+++ b/src/mongo/delegates/Updates.class.php
@@ -58,7 +58,7 @@ class Updates extends DriverBase {
     private $async = null;
 
     /**
-     * @var \MongoDB
+     * @var Database
      */
     protected $locksDb;
 

--- a/src/mongo/delegates/Updates.class.php
+++ b/src/mongo/delegates/Updates.class.php
@@ -1047,7 +1047,8 @@ class Updates extends DriverBase {
                     )
                 );
                 if (!$result->isAcknowledged()) {
-                    throw new \Exception("Failed to create audit entry with error message- " . $result['err']);
+                    $error = $this->getLastDBError($this->getDatabase());
+                    throw new \Exception("Failed to create audit entry with error message- " . $error['err']);
                 }
             }
             catch(\Exception $e) { //simply send false as status as we are unable to create audit entry
@@ -1073,7 +1074,8 @@ class Updates extends DriverBase {
 
                 if(!$result->isAcknowledged())
                 {
-                    throw new \Exception("Failed to update audit entry with error message- " . $result['err']);
+                    $error = $this->getLastDBError($this->getDatabase());
+                    throw new \Exception("Failed to update audit entry with error message- " . $error['err']);
                 }
             }
             catch(\Exception $e) {
@@ -1088,7 +1090,8 @@ class Updates extends DriverBase {
 
                 if(!$result->isAcknowledged())
                 {
-                    $logInfo['additional-error']=  "Failed to update audit entry with error message- " . $result['err'];
+                    $error = $this->getLastDBError($this->getDatabase());
+                    $logInfo['additional-error']=  "Failed to update audit entry with error message- " . $error['err'];
                 }
 
                 $this->errorLog(MONGO_LOCK, $logInfo);
@@ -1155,7 +1158,8 @@ class Updates extends DriverBase {
                 );
 
                 if (!$result->isAcknowledged()) {
-                    throw new \Exception("Failed to lock document with error message- " . $result['err']);
+                    $error = $this->getLastDBError($this->getDatabase());
+                    throw new \Exception("Failed to lock document with error message- " . $error['err']);
                 }
             }
             catch(\Exception $e) { //Subject is already locked or unable to lock
@@ -1182,7 +1186,8 @@ class Updates extends DriverBase {
                     );
 
                     if (!$result->isAcknowledged()) {
-                        throw new \Exception("Failed to create new document with error message- " . $result['err']);
+                        $error = $this->getLastDBError($this->getDatabase());
+                        throw new \Exception("Failed to create new document with error message- " . $error['err']);
                     }
                     $document  = $this->getCollection()->findOne(array(_ID_KEY => array(_ID_RESOURCE => $this->labeller->uri_to_alias($s), _ID_CONTEXT => $contextAlias)));
                 }

--- a/src/mongo/delegates/Updates.class.php
+++ b/src/mongo/delegates/Updates.class.php
@@ -476,7 +476,7 @@ class Updates extends DriverBase {
     protected function applyChangeSet(\Tripod\ChangeSet $cs, $originalCBDs, $contextAlias, $transaction_id)
     {
         $subjectsAndPredicatesOfChange = array();
-        if (in_array($this->getCollection()->getName(), $this->getConfigInstance()->getPods($this->getStoreName())))
+        if (in_array($this->getCollection()->getCollectionName(), $this->getConfigInstance()->getPods($this->getStoreName())))
         {
             // how many subjects of change?
             /** @noinspection PhpParamsInspection */

--- a/src/mongo/delegates/Updates.class.php
+++ b/src/mongo/delegates/Updates.class.php
@@ -408,7 +408,7 @@ class Updates extends DriverBase {
                     'description'=>'Save Failed Rolling back transaction:' . $e->getMessage(),
                     'transaction_id'=>$transaction_id,
                     'subjectsOfChange'=>implode(",",$subjectsOfChange),
-                    'mongoDriverError' => $this->getDatabase()->lastError(),
+                    'mongoDriverError' => $this->getLastDBError($this->getDatabase()),
                     'exceptionMessage' => $e->getMessage()
                 )
             );
@@ -444,7 +444,7 @@ class Updates extends DriverBase {
                             'description' => 'Driver::rollbackTransaction - Error updating transaction',
                             'exception_message' => $exception->getMessage(),
                             'transaction_id' => $transaction_id,
-                            'mongoDriverError' => $this->getDatabase()->lastError()
+                            'mongoDriverError' => $this->getLastDBError($this->getDatabase())
                         )
                     );
                     throw new \Exception("Failed to restore Original CBDS for transaction: {$transaction_id} stopped at ".$g[_ID_KEY]);
@@ -458,7 +458,7 @@ class Updates extends DriverBase {
                     'description'=>'Driver::rollbackTransaction - Unlocking documents',
                     'exception_message' => $exception->getMessage(),
                     'transaction_id'=>$transaction_id,
-                    'mongoDriverError' => $this->getDatabase()->lastError()
+                    'mongoDriverError' => $this->getLastDBError($this->getDatabase())
                 )
             );
         }
@@ -653,7 +653,7 @@ class Updates extends DriverBase {
                         array(
                             'description'=>'Error with Mongo DB findOneAndUpdate:' . $e->getMessage(),
                             'transaction_id'=>$transaction_id,
-                            'mongoDriverError' => $this->getDatabase()->lastError()
+                            'mongoDriverError' => $this->getLastDBError($this->getDatabase())
                         )
                     );
                     throw new \Exception($e);
@@ -906,8 +906,12 @@ class Updates extends DriverBase {
         if(!empty($fromDateTime) || !empty($tillDateTime)){
             $query[_LOCKED_FOR_TRANS_TS] = array();
 
-            if(!empty($fromDateTime)) $query[_LOCKED_FOR_TRANS_TS][MONGO_OPERATION_GTE] = new UTCDateTime(strtotime($fromDateTime) * 1000);
-            if(!empty($tillDateTime)) $query[_LOCKED_FOR_TRANS_TS][MONGO_OPERATION_LTE] = new UTCDateTime(strtotime($tillDateTime) * 1000);
+            if (!empty($fromDateTime)) {
+                $query[_LOCKED_FOR_TRANS_TS][MONGO_OPERATION_GTE] = new UTCDateTime(strtotime($fromDateTime)*1000);
+            }
+            if (!empty($tillDateTime)) {
+                $query[_LOCKED_FOR_TRANS_TS][MONGO_OPERATION_LTE] = new UTCDateTime(strtotime($tillDateTime)*1000);
+            }
         }
         $docs = $this->getLocksCollection()->find($query, array('sort' => array(_LOCKED_FOR_TRANS => 1)));
 
@@ -996,7 +1000,7 @@ class Updates extends DriverBase {
                 'retries' => $this->retriesToGetLock,
                 'transaction_id'=>$transaction_id,
                 'subjectsOfChange'=>implode(", ",$subjectsOfChange),
-                'mongoDriverError' => $this->getDatabase()->lastError()
+                'mongoDriverError' => $this->getLastDBError($this->getDatabase()),
             )
         );
         return NULL;
@@ -1105,7 +1109,7 @@ class Updates extends DriverBase {
             $this->errorLog(MONGO_LOCK,
                 array(
                     'description'=>'Driver::unlockAllDocuments - Failed to unlock documents (transaction_id - ' .$transaction_id .')',
-                    'mongoDriverError' => $this->getLocksDatabase()->lastError(),
+                    'mongoDriverError' => $this->getLastDBError($this->getLocksDatabase()),
                     $result
                 )
             );

--- a/src/mongo/delegates/Updates.class.php
+++ b/src/mongo/delegates/Updates.class.php
@@ -1073,7 +1073,7 @@ class Updates extends DriverBase {
                 );
 
                 //4. Update audit entry to say it was failed with error
-                $result = $auditCollection->update(array(_ID_KEY => $auditDocumentId), array(MONGO_OPERATION_SET => array("status" => AUDIT_STATUS_ERROR, _UPDATED_TS => $this->getMongoDate(), 'error' => $e->getMessage())));
+                $result = $auditCollection->updateOne(array(_ID_KEY => $auditDocumentId), array(MONGO_OPERATION_SET => array("status" => AUDIT_STATUS_ERROR, _UPDATED_TS => $this->getMongoDate(), 'error' => $e->getMessage())));
 
                 if($result['err']!=NULL )
                 {
@@ -1095,7 +1095,7 @@ class Updates extends DriverBase {
      */
     protected function unlockAllDocuments($transaction_id)
     {
-        $result = $this->getLocksCollection()->deleteOne(array(_LOCKED_FOR_TRANS => $transaction_id), array('w' => 1));
+        $result = $this->getLocksCollection()->deleteMany(array(_LOCKED_FOR_TRANS => $transaction_id), array('w' => 1));
 
         // I can't check $res['n']>0 here, because same method is called in rollback where there might be no locked subjects at all
         if(!$result->isAcknowledged()) {
@@ -1131,9 +1131,9 @@ class Updates extends DriverBase {
                 )
             );
 
-        if($countEntriesInLocksCollection > 0) //Subject is already locked
+        if ($countEntriesInLocksCollection > 0){ //Subject is already locked
             return false;
-        else{
+        } else {
             try{ //Add a entry to locks collection for this subject, will throws exception if an entry already there
                 $result = $this->getLocksCollection()->insertOne(
                     array(
@@ -1333,7 +1333,7 @@ class Updates extends DriverBase {
      */
     protected function updateCollection($query, $update, $options)
     {
-        return $this->getCollection()->updateMany($query, $update, $options);
+        return $this->getCollection()->replaceOne($query, $update, $options);
     }
 
     /**

--- a/src/mongo/delegates/Views.class.php
+++ b/src/mongo/delegates/Views.class.php
@@ -7,6 +7,8 @@ require_once TRIPOD_DIR . 'mongo/base/DriverBase.class.php';
 use Tripod\Mongo\Config;
 use Tripod\Mongo\ImpactedSubject;
 use Tripod\Mongo\Labeller;
+use \MongoDB\Driver\ReadPreference;
+use \MongoDB\Collection;
 
 /**
  * Class Views
@@ -19,12 +21,12 @@ class Views extends CompositeBase
      * Construct accepts actual objects rather than strings as this class is a delegate of
      * Tripod and should inherit connections set up there
      * @param string $storeName
-     * @param \MongoCollection $collection
+     * @param Collection $collection
      * @param $defaultContext
      * @param null $stat
      * @param string $readPreference
      */
-    function __construct($storeName, \MongoCollection $collection,$defaultContext,$stat=null,$readPreference=\MongoClient::RP_PRIMARY) // todo: $collection -> podname
+    function __construct($storeName, Collection $collection,$defaultContext,$stat=null,$readPreference = ReadPreference::RP_PRIMARY) // todo: $collection -> podname
     {
         $this->storeName = $storeName;
         $this->labeller = new Labeller();
@@ -845,7 +847,7 @@ class Views extends CompositeBase
 
     /**
      * @param string $viewSpecId
-     * @return \MongoCollection
+     * @return Collection
      */
     protected function getCollectionForViewSpec($viewSpecId)
     {

--- a/src/mongo/delegates/Views.class.php
+++ b/src/mongo/delegates/Views.class.php
@@ -102,7 +102,7 @@ class Views extends CompositeBase
         {
             $t = new \Tripod\Timer();
             $t->start();
-            $views = $collection->find($query,array("_id"=>true));
+            $views = $collection->find($query, array('projection' => array("_id"=>true)));
             $t->stop();
             $this->timingLog(MONGO_FIND_IMPACTED, array('duration'=>$t->result(), 'query'=>$query, 'storeName'=>$this->storeName, 'collection'=>$collection));
             foreach($views as $v)
@@ -306,7 +306,7 @@ class Views extends CompositeBase
 
         // now generate view for $resources themselves... Maybe an optimisation down the line to cut out the query here
         $query = array("_id"=>array('$in'=>$filter));
-        $resourceAndType = $this->collection->find($query,array("_id"=>1,"rdf:type"=>1));
+        $resourceAndType = $this->collection->find($query, array('projection' => array("_id"=>1,"rdf:type"=>1)));
 
         foreach ($resourceAndType as $rt)
         {

--- a/src/mongo/delegates/Views.class.php
+++ b/src/mongo/delegates/Views.class.php
@@ -513,7 +513,7 @@ class Views extends CompositeBase
                     if (isset($viewSpec['ttl']))
                     {
                         $buildImpactIndex=false;
-                        $value[_EXPIRES] = new UTCDateTime($this->getExpirySecFromNow(30) * 1000);
+                        $value[_EXPIRES] = new UTCDateTime($this->getExpirySecFromNow($viewSpec['ttl']) * 1000);
                     }
                     else
                     {

--- a/src/mongo/delegates/Views.class.php
+++ b/src/mongo/delegates/Views.class.php
@@ -29,7 +29,7 @@ class Views extends CompositeBase
         $this->storeName = $storeName;
         $this->labeller = new Labeller();
         $this->collection = $collection;
-        $this->podName = $collection->getName();
+        $this->podName = $collection->getCollectionName();
         $this->defaultContext = $defaultContext;
         $this->config = Config::getInstance();
         $this->stat = $stat;

--- a/src/mongo/delegates/Views.class.php
+++ b/src/mongo/delegates/Views.class.php
@@ -9,6 +9,7 @@ use Tripod\Mongo\ImpactedSubject;
 use Tripod\Mongo\Labeller;
 use \MongoDB\Driver\ReadPreference;
 use \MongoDB\Collection;
+use \MongoDB\BSON\UTCDateTime;
 
 /**
  * Class Views
@@ -512,7 +513,7 @@ class Views extends CompositeBase
                     if (isset($viewSpec['ttl']))
                     {
                         $buildImpactIndex=false;
-                        $value[_EXPIRES] = new \MongoDate($this->getExpirySecFromNow($viewSpec['ttl']));
+                        $value[_EXPIRES] = new UTCDateTime($this->getExpirySecFromNow(30) * 1000);
                     }
                     else
                     {

--- a/src/mongo/providers/MongoSearchProvider.class.php
+++ b/src/mongo/providers/MongoSearchProvider.class.php
@@ -69,7 +69,10 @@ class MongoSearchProvider implements \Tripod\ISearchProvider
             $collection->createIndex(array('_id.type' => 1), array('background' => 1));
             $collection->createIndex(array('_id.r' => 1, '_id.c' => 1), array('background' => 1));
             $collection->createIndex(array('_impactIndex' => 1), array('background' => 1));
-            $collection->insertOne($document);
+            $result = $collection->insertOne($document);
+            if (!$result->isAcknowledged()) {
+                throw new \Tripod\Exceptions\SearchException("Inserting search document not acknowledged");
+            }
         } catch (\Exception $e) {
             throw new \Tripod\Exceptions\SearchException("Failed to Index Document \n" . print_r($document, true), 0, $e);
         }

--- a/src/mongo/providers/MongoSearchProvider.class.php
+++ b/src/mongo/providers/MongoSearchProvider.class.php
@@ -64,10 +64,10 @@ class MongoSearchProvider implements \Tripod\ISearchProvider
         }
 
         try {
-            $collection->ensureIndex(array('_id.type' => 1), array('background' => 1));
-            $collection->ensureIndex(array('_id.r' => 1, '_id.c' => 1), array('background' => 1));
-            $collection->ensureIndex(array('_impactIndex' => 1), array('background' => 1));
-            $collection->save($document);
+            $collection->createIndex(array('_id.type' => 1), array('background' => 1));
+            $collection->createIndex(array('_id.r' => 1, '_id.c' => 1), array('background' => 1));
+            $collection->createIndex(array('_impactIndex' => 1), array('background' => 1));
+            $collection->insertOne($document);
         } catch (\Exception $e) {
             throw new \Tripod\Exceptions\SearchException("Failed to Index Document \n" . print_r($document, true), 0, $e);
         }
@@ -112,7 +112,7 @@ class MongoSearchProvider implements \Tripod\ISearchProvider
             }
             foreach($this->config->getCollectionsForSearch($this->storeName, $searchTypes) as $collection)
             {
-                $collection->remove($query);
+                $collection->deleteMany($query);
             }
         } catch (\Exception $e) {
             throw new \Tripod\Exceptions\SearchException("Failed to Remove Document with id \n" . print_r($query, true), 0, $e);
@@ -347,7 +347,7 @@ class MongoSearchProvider implements \Tripod\ISearchProvider
     	}
     	    	
     	return $this->config->getCollectionForSearchDocument($this->storeName, $typeId)
-            ->remove(array("_id.type" => $typeId));
+            ->deleteMany(array("_id.type" => $typeId));
     }
 
     /**

--- a/src/mongo/providers/MongoSearchProvider.class.php
+++ b/src/mongo/providers/MongoSearchProvider.class.php
@@ -7,6 +7,8 @@ require_once TRIPOD_DIR . 'mongo/delegates/SearchDocuments.class.php';
 require_once TRIPOD_DIR . 'mongo/providers/ISearchProvider.php';
 require_once TRIPOD_DIR.'classes/Timer.class.php';
 
+use \MongoDB\BSON\Regex;
+
 /**
  * Class MongoSearchProvider
  * @package Tripod\Mongo
@@ -252,7 +254,7 @@ class MongoSearchProvider implements \Tripod\ISearchProvider
 
         $regexes = array();
         foreach($terms as $t){
-            $regexes[] = new \MongoRegex("/{$t}/");
+            $regexes[] = new Regex("{$t}", '');
         }
 
         $query = array();

--- a/src/mongo/providers/MongoSearchProvider.class.php
+++ b/src/mongo/providers/MongoSearchProvider.class.php
@@ -210,7 +210,7 @@ class MongoSearchProvider implements \Tripod\ISearchProvider
         $searchDocs = array();
         foreach($this->config->getCollectionsForSearch($this->storeName, $searchTypes) as $collection)
         {
-            $cursor = $collection->find($query, array('_id'=>true));
+            $cursor = $collection->find($query, array('projection' => array('_id'=>true)));
             foreach($cursor as $d)
             {
                 $searchDocs[] = $d;
@@ -275,9 +275,10 @@ class MongoSearchProvider implements \Tripod\ISearchProvider
         $searchTimer = new \Tripod\Timer();
         $searchTimer->start();
         $cursor = $this->config->getCollectionForSearchDocument($this->storeName, $type)
-            ->find($query, $fieldsToReturn)
-            ->limit($limit)
-            ->skip($offset);
+            ->find($query, array(
+                'projection' => $fieldsToReturn,
+                'limit' => $limit,
+                'skip' => $offset));
 
         $searchResults = array();
         $searchResults['head'] = array();
@@ -289,8 +290,9 @@ class MongoSearchProvider implements \Tripod\ISearchProvider
         $searchResults['head']['query_terms_used'] = $terms;
         $searchResults['results']   = array();
 
-        if($cursor->count() > 0) {
-            $searchResults['head']['count']     = $cursor->count();
+        $count = $this->config->getCollectionForSearchDocument($this->storeName, $type)->count($query);
+        if($count > 0) {
+            $searchResults['head']['count']     = $count;
 
             foreach($cursor as $result)
             {

--- a/src/mongo/util/IndexUtils.class.php
+++ b/src/mongo/util/IndexUtils.class.php
@@ -41,7 +41,7 @@ class IndexUtils
                     {
                         // no name
                         $config->getCollectionForCBD($storeName, $collectionName)
-                            ->ensureIndex(
+                            ->createIndex(
                                 $fields,
                                 array(
                                     "background"=>$background
@@ -51,7 +51,7 @@ class IndexUtils
                     else
                     {
                         $config->getCollectionForCBD($storeName, $collectionName)
-                            ->ensureIndex(
+                            ->createIndex(
                                 $fields,
                                 array(
                                     'name'=>$indexName,
@@ -79,7 +79,7 @@ class IndexUtils
                     }
                     foreach($indexes as $index)
                     {
-                        $collection->ensureIndex(
+                        $collection->createIndex(
                             $index,
                             array(
                                 "background"=>$background
@@ -106,7 +106,7 @@ class IndexUtils
                     }
                     foreach($indexes as $index)
                     {
-                        $collection->ensureIndex(
+                        $collection->createIndex(
                             $index,
                             array(
                                 "background"=>$background

--- a/src/mongo/util/TriplesUtil.class.php
+++ b/src/mongo/util/TriplesUtil.class.php
@@ -300,7 +300,7 @@ class TriplesUtil
             $collection->insertOne($cbdGraph->to_tripod_array($cbdSubject,$context),array("w"=>1));
             print ".";
         }
-        catch (\MongoException $e)
+        catch (\Exception $e)
         {
             if (preg_match('/E11000/',$e->getMessage()))
             {
@@ -314,7 +314,7 @@ class TriplesUtil
                 {
                     $collection->update($criteria,$existingGraph->to_tripod_array($cbdSubject,$context),array("w"=>1));
                 }
-                catch (\MongoException $e2)
+                catch (\Exception $e2)
                 {
                     throw new \Exception($e2->getMessage()); // todo: would be good to have typed exception
                 }
@@ -327,7 +327,7 @@ class TriplesUtil
                 {
                     $collection->insertOne($cbdGraph->to_tripod_array($cbdSubject,$context),array("w"=>1));
                 }
-                catch (\MongoException $e2)
+                catch (\Exception $e2)
                 {
                     throw new \Exception($e2->getMessage()); // todo: would be good to have typed exception
                 }

--- a/src/mongo/util/TriplesUtil.class.php
+++ b/src/mongo/util/TriplesUtil.class.php
@@ -100,7 +100,7 @@ class TriplesUtil
         else
         {
             $m = new \MongoClient(Config::getInstance()->getConnStr($storeName));
-            $collection = $m->selectDB($storeName)->selectCollection($podName);
+            $collection = $m->selectDatabase($storeName)->selectCollection($podName);
         }
 
         $graph = new MongoGraph();
@@ -297,7 +297,7 @@ class TriplesUtil
         }
         try
         {
-            $collection->insert($cbdGraph->to_tripod_array($cbdSubject,$context),array("w"=>1));
+            $collection->insertOne($cbdGraph->to_tripod_array($cbdSubject,$context),array("w"=>1));
             print ".";
         }
         catch (\MongoException $e)
@@ -325,7 +325,7 @@ class TriplesUtil
                 print "MongoCursorException on update: ".$e->getMessage().", retrying\n";
                 try
                 {
-                    $collection->insert($cbdGraph->to_tripod_array($cbdSubject,$context),array("w"=>1));
+                    $collection->insertOne($cbdGraph->to_tripod_array($cbdSubject,$context),array("w"=>1));
                 }
                 catch (\MongoException $e2)
                 {

--- a/test/rest-interface/vagrant/bootstrap.sh
+++ b/test/rest-interface/vagrant/bootstrap.sh
@@ -2,13 +2,13 @@ apt-get update -y
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
 echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | tee /etc/apt/sources.list.d/mongodb.list
 apt-get update -y
-apt-get install -y mongodb-10gen=2.2.2 -y
+apt-get install -y mongodb-org=2.6.9 mongodb-org-server=2.6.9 mongodb-org-shell=2.6.9 mongodb-org-mongos=2.6.9 mongodb-org-tools=2.6.9
 apt-get install php5 php-pear -y
-yes '' | pecl install mongo
+yes '' | pecl install mongodb
 apt-get install git siege -y
 a2enmod rewrite
-touch /etc/php5/apache2/conf.d/mongo.ini
-echo "extension=mongo.so" > /etc/php5/apache2/conf.d/mongo.ini
+touch /etc/php5/apache2/conf.d/mongodb.ini
+echo "extension=mongodb.so" > /etc/php5/apache2/conf.d/mongodb.ini
 sed -i "s/DocumentRoot \/var\/www/DocumentRoot \/vagrant/" /etc/apache2/sites-enabled/000-default
 sed -i "s/Directory \/var\/www\//Directory \/vagrant\//" /etc/apache2/sites-enabled/000-default
 sed -i "s/AllowOverride None/AllowOverride All/" /etc/apache2/sites-enabled/000-default

--- a/test/unit/mongo/MongoSearchProviderTest.php
+++ b/test/unit/mongo/MongoSearchProviderTest.php
@@ -1,8 +1,8 @@
 <?php
-    require_once 'MongoTripodTestBase.php';
-    require_once 'src/mongo/Driver.class.php';
-    require_once 'src/mongo/delegates/SearchIndexer.class.php';
-    require_once 'src/mongo/providers/MongoSearchProvider.class.php';
+require_once 'MongoTripodTestBase.php';
+require_once 'src/mongo/Driver.class.php';
+require_once 'src/mongo/delegates/SearchIndexer.class.php';
+require_once 'src/mongo/providers/MongoSearchProvider.class.php';
 
 /**
  * Class MongoSearchProviderTest
@@ -53,7 +53,6 @@ class MongoSearchProviderTest extends MongoTripodTestBase
     }
 
     public function testSearchIndexing() {
-
 
         // assert that there are only 12 based on the data we loaded into tripod
         $actualSearchDocumentCount = $this->getCountForSearchSpecs($this->tripod);

--- a/test/unit/mongo/MongoSearchProviderTest.php
+++ b/test/unit/mongo/MongoSearchProviderTest.php
@@ -187,7 +187,7 @@ class MongoSearchProviderTest extends MongoTripodTestBase
         // update a document
         $id = array('_id.r'=>'http://talisaspire.com/resources/doc1');
         $this->getTripodCollection($this->tripod)
-            ->update($id, array('$set'=>array("rdf:type"=>array("u"=>"bibo:Article"))));
+            ->updateOne($id, array('$set'=>array("rdf:type"=>array("u"=>"bibo:Article"))));
 
         // reindex
         $this->indexer->generateAndIndexSearchDocuments('http://talisaspire.com/resources/doc1', 'http://talisaspire.com/', $this->tripod->getPodName());
@@ -218,7 +218,7 @@ class MongoSearchProviderTest extends MongoTripodTestBase
             "resourcelists:description"=>array("l"=>"foo bar baz"),
 
         );
-        $this->getTripodCollection($this->tripod)->update($id, array('$set'=> $newData));
+        $this->getTripodCollection($this->tripod)->updateOne($id, array('$set'=> $newData));
 
         // reindex
         $this->indexer->generateAndIndexSearchDocuments('http://talisaspire.com/resources/doc1', 'http://talisaspire.com/', $this->tripod->getPodName());
@@ -253,7 +253,7 @@ class MongoSearchProviderTest extends MongoTripodTestBase
             "spec:name"=>array("l"=>"my list title"),
             "resourcelist:description"=>array("l"=>"foo bar baz"),
         );
-        $this->getTripodCollection($this->tripod)->update($id, array('$set'=> $newData));
+        $this->getTripodCollection($this->tripod)->updateOne($id, array('$set'=> $newData));
 
         // reindex
         $this->indexer->generateAndIndexSearchDocuments('http://talisaspire.com/resources/doc1', 'http://talisaspire.com/', $this->tripod->getPodName());
@@ -300,7 +300,7 @@ class MongoSearchProviderTest extends MongoTripodTestBase
         $newData = array(
             "rdf:type"=>array("u"=>"bibo:Book")
         );
-        $this->getTripodCollection($this->tripod)->update($id, array('$set'=> $newData));
+        $this->getTripodCollection($this->tripod)->updateOne($id, array('$set'=> $newData));
 
         // reindex
         $this->indexer->generateAndIndexSearchDocuments('http://talisaspire.com/resources/doc1', 'http://talisaspire.com/', $this->tripod->getPodName());
@@ -575,7 +575,7 @@ class MongoSearchProviderTest extends MongoTripodTestBase
     			"spec:name"=>array("l"=>"my list title"),
     			"resourcelist:description"=>array("l"=>"foo bar baz"),
     	);
-    	$this->getTripodCollection($this->tripod)->update($id, array('$set'=> $newData));
+    	$this->getTripodCollection($this->tripod)->updateOne($id, array('$set'=> $newData));
 
     	// reindex
     	$this->indexer->generateAndIndexSearchDocuments('http://talisaspire.com/resources/doc1', 'http://talisaspire.com/', $this->tripod->getPodName());

--- a/test/unit/mongo/MongoTransactionLogTest.php
+++ b/test/unit/mongo/MongoTransactionLogTest.php
@@ -12,8 +12,8 @@ class MongoTransactionLogTest extends MongoTripodTestBase
     /**
      * @var \Tripod\Mongo\Driver
      */
-    protected $tripod
-    ;
+    protected $tripod;
+
     /**
      * @var \Tripod\Mongo\TransactionLog
      */
@@ -716,10 +716,19 @@ class MongoTransactionLogTest extends MongoTripodTestBase
      */
     public function testCreateNewTransactionThrowsExceptionIfInsertFails()
     {
+        $mockInsert = $this->getMockBuilder('\MongoDB\InsertOneResult')
+            ->disableOriginalConstructor()
+            ->setMethods(['isAcknowledged'])
+            ->getMock();
+        $mockInsert
+            ->expects($this->once())
+            ->method('isAcknowledged')
+            ->will($this->returnValue(false));
+
         $mockTransactionLog = $this->getMock('\Tripod\Mongo\TransactionLog', array('insertTransaction'), array(), '', false, true);
         $mockTransactionLog->expects($this->once())
             ->method('insertTransaction')
-            ->will($this->returnValue(array('err'=>'something went wrong')));
+            ->will($this->returnValue($mockInsert));
 
         /* @var $mockTransactionLog \Tripod\Mongo\TransactionLog */
         try {

--- a/test/unit/mongo/MongoTransactionLogTest.php
+++ b/test/unit/mongo/MongoTransactionLogTest.php
@@ -24,7 +24,6 @@ class MongoTransactionLogTest extends MongoTripodTestBase
     protected function setUp()
     {
         parent::setup();
-        //Mongo::setPoolSize(200);
 
         // Stub ouf 'addToElastic' search to prevent writes into Elastic Search happening by default.
         /** @var \Tripod\Mongo\Driver|PHPUnit_Framework_MockObject_MockObject $tripod */

--- a/test/unit/mongo/MongoTransactionLogTest.php
+++ b/test/unit/mongo/MongoTransactionLogTest.php
@@ -4,6 +4,8 @@ require_once 'src/mongo/Driver.class.php';
 require_once 'src/mongo/delegates/TransactionLog.class.php';
 require_once 'src/mongo/MongoGraph.class.php';
 
+use \MongoDB\BSON\UTCDateTime;
+
 /**
  * Class MongoTransactionLogTest
  */
@@ -440,15 +442,15 @@ class MongoTransactionLogTest extends MongoTripodTestBase
             ),
             'collectionName' => 'CBD_testing',
             'dbName' => 'tripod_php_testing',
-            'startTime' => new MongoDate(strtotime($startTime)),
-            'endTime' => new MongoDate(strtotime($endTime)),
+            'startTime' => new UTCDateTime(strtotime($startTime)*1000),
+            'endTime' => new UTCDateTime(strtotime($endTime)*1000),
             'status' => 'completed',
             'newCBDs' => array(array(
                 "_id" => array('r' => $subjectOfChange, 'c' => 'http://talisaspire.com/'),
                 "searchterms:title" => array('l' => 'anything at all'),
                 "_version" => $_version,
-                "_uts" => new MongoDate(),
-                "_cts" => new MongoDate(),
+                "_uts" => new UTCDateTime(floor(microtime(true))*1000),
+                "_cts" => new UTCDateTime(floor(microtime(true))*1000),
             )),
             'originalCBDs' => array(array(
                 "_id" => array('r' => $subjectOfChange, 'c' => 'http://talisaspire.com/')

--- a/test/unit/mongo/MongoTripodDocumentStructureTest.php
+++ b/test/unit/mongo/MongoTripodDocumentStructureTest.php
@@ -79,9 +79,10 @@ class MongoTripodDocumentStructureTest extends MongoTripodTestBase
         // assert that the $_updated_ts has changed, but the created_ts is the same
         $updated_document = $this->getDocument($id);
         $this->assertEquals($_created_ts, $updated_document[_CREATED_TS]);
-        $this->assertNotEquals($_updated_ts, $updated_document[_UPDATED_TS]);
+        $this->assertNotEquals($_updated_ts->__toString(), $updated_document[_UPDATED_TS]->__toString());
         // assert that the seconds for the updated document _updated_ts is greated than the first version
-        $this->assertGreaterThan($_updated_ts->sec, $updated_document[_UPDATED_TS]->sec);
+
+        $this->assertGreaterThan($_updated_ts->__toString(), $updated_document[_UPDATED_TS]->__toString());
 
         sleep(1);
 
@@ -97,8 +98,8 @@ class MongoTripodDocumentStructureTest extends MongoTripodTestBase
         // assert that the $_updated_ts has changed, but the created_ts is the same
         $final_document = $this->getDocument($id);
         $this->assertEquals($updated_document[_CREATED_TS], $final_document[_CREATED_TS]);
-        $this->assertNotEquals($updated_document[_UPDATED_TS], $final_document[_UPDATED_TS]);
-        $this->assertGreaterThan($updated_document[_UPDATED_TS]->sec, $final_document[_UPDATED_TS]->sec);
+        $this->assertNotEquals($updated_document[_UPDATED_TS]->__toString(), $final_document[_UPDATED_TS]->__toString());
+        $this->assertGreaterThan($updated_document[_UPDATED_TS]->__toString(), $final_document[_UPDATED_TS]->__toString());
 
         sleep(1);
 
@@ -114,8 +115,8 @@ class MongoTripodDocumentStructureTest extends MongoTripodTestBase
         $this->assertDocumentDoesNotHaveProperty($id, 'searchterms:title');
 
         $this->assertEquals($final_document[_CREATED_TS], $deleted_document[_CREATED_TS]);
-        $this->assertNotEquals($final_document[_UPDATED_TS], $deleted_document[_UPDATED_TS]);
-        $this->assertGreaterThan($final_document[_UPDATED_TS]->sec, $deleted_document[_UPDATED_TS]->sec);
+        $this->assertNotEquals($final_document[_UPDATED_TS]->__toString(), $deleted_document[_UPDATED_TS]->__toString());
+        $this->assertGreaterThan($final_document[_UPDATED_TS]->__toString(), $deleted_document[_UPDATED_TS]->__toString());
     }
 
 

--- a/test/unit/mongo/MongoTripodDriverTest.php
+++ b/test/unit/mongo/MongoTripodDriverTest.php
@@ -4,6 +4,8 @@ require_once 'src/ITripodStat.php';
 require_once 'src/classes/StatsD.class.php';
 require_once 'src/mongo/Driver.class.php';
 
+use \MongoDB\Driver\ReadPreference;
+
 /**
  * Class MongoTripodDriverTest
  */
@@ -653,7 +655,7 @@ class MongoTripodDriverTest extends MongoTripodTestBase
             'TestTripod',
             array('getDataUpdater'),
             array('CBD_testing','tripod_php_testing',
-                array('defaultContext'=>'http://talisaspire.com/', 'readPreference'=>MongoClient::RP_SECONDARY_PREFERRED))
+                array('defaultContext'=>'http://talisaspire.com/', 'readPreference'=>ReadPreference::RP_SECONDARY_PREFERRED))
         );
 
         $tripodUpdate = $this->getMock('\Tripod\Mongo\Updates',
@@ -674,7 +676,7 @@ class MongoTripodDriverTest extends MongoTripodTestBase
             ->will($this->returnValue($tripodUpdate));
 
         $expectedCollectionReadPreference = $tripodMock->getCollectionReadPreference();
-        $this->assertEquals($expectedCollectionReadPreference['type'], MongoClient::RP_SECONDARY_PREFERRED);
+        $this->assertEquals($expectedCollectionReadPreference->getMode(), ReadPreference::RP_SECONDARY_PREFERRED);
 
         // Assert that a simple save results in read preferences being restored
         $g = new \Tripod\Mongo\MongoGraph();

--- a/test/unit/mongo/MongoTripodDriverTest.php
+++ b/test/unit/mongo/MongoTripodDriverTest.php
@@ -226,6 +226,16 @@ class MongoTripodDriverTest extends MongoTripodTestBase
         $count = $this->tripod->getCount(array("rdf:type.".VALUE_URI=>"bibo:Book"));
         $this->assertEquals(9,$count);
     }
+    public function testGetCountWithGroupBy() {
+        $count = $this->tripod->getCount(array("rdf:type.".VALUE_URI=>"bibo:Book"), "bibo:isbn13.l");
+
+        $this->assertCount(5, $count);
+        $this->assertEquals(2, $count['1234567890123']);
+        $this->assertEquals(1, $count['']);
+        $this->assertEquals(1, $count['9780393929691;9780393929691-2']);
+        $this->assertEquals(4, $count['9780393929691']);
+        $this->assertEquals(1, $count['9780393929690']);
+    }
 
     public function testTripodSaveChangesRemovesLiteralTriple()
     {

--- a/test/unit/mongo/MongoTripodTablesTest.php
+++ b/test/unit/mongo/MongoTripodTablesTest.php
@@ -310,13 +310,13 @@ class MongoTripodTablesTest extends MongoTripodTestBase
     {
         $this->tripodTables->generateTableRows("t_resource");
 
-        $t1 = $this->tripodTables->getTableRows("t_resource",array(),array("value.isbn"=>-1));
-        // expecting two rows, first row should be one with highest numberic value of ISBN, due to sort DESC
+        $t1 = $this->tripodTables->getTableRows("t_resource",array(),array("value.isbn" => -1, "_id.r" => 1));
+        // expecting two rows, first row should be one with highest numeric value of ISBN, due to sort DESC
         $this->assertEquals('http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA-2',$t1['results'][0]['_id']['r']);
 
-        $t1 = $this->tripodTables->getTableRows("t_resource",array(),array("value.isbn"=>1));
+        $t1 = $this->tripodTables->getTableRows("t_resource",array(),array("value.isbn" => 1, "_id.r" => 1));
 
-        // expecting two rows, first row should be one with lowest numberic value of ISBN, due to sort ASC
+        // expecting two rows, first row should be one with lowest numeric value of ISBN, due to sort ASC
         $this->assertEquals('http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA',$t1['results'][0]['_id']['r']);
     }
 
@@ -562,7 +562,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
         // We should have 1 result and it should have modified fields
         $this->assertTrue($rows["head"]["count"]==1,"Expected one row");
 
-        $this->assertInstanceOf('MongoDate', $rows['results'][0]['mongoDate']);
+        $this->assertInstanceOf('\MongoDB\BSON\UTCDateTime', $rows['results'][0]['mongoDate']);
     }
 
     /**
@@ -617,10 +617,8 @@ class MongoTripodTablesTest extends MongoTripodTestBase
 
         // Check borked data
         // Trying to use date but passed in a string - should default to 0 for sec and usec
-        $this->assertInstanceOf('MongoDate', $rows['results'][0]['mongoDateInvalid']);
-        $this->assertEquals(0, $rows['results'][0]['mongoDateInvalid']->sec);
-        $this->assertEquals(0, $rows['results'][0]['mongoDateInvalid']->usec);
-
+        $this->assertInstanceOf('\MongoDB\BSON\UTCDateTime', $rows['results'][0]['mongoDateInvalid']);
+        $this->assertEquals(0, $rows['results'][0]['mongoDateInvalid']->__toString());
     }
 
     /**

--- a/test/unit/mongo/MongoTripodTablesTest.php
+++ b/test/unit/mongo/MongoTripodTablesTest.php
@@ -35,7 +35,6 @@ class MongoTripodTablesTest extends MongoTripodTestBase
     protected function setUp()
     {
         parent::setup();
-        //Mongo::setPoolSize(200);
 
         $this->tripodTransactionLog = new \Tripod\Mongo\TransactionLog();
         $this->tripodTransactionLog->purgeAllTransactions();

--- a/test/unit/mongo/MongoTripodTablesTest.php
+++ b/test/unit/mongo/MongoTripodTablesTest.php
@@ -646,7 +646,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
     public function testGenerateTableRowsTruncatesFieldsTooLargeToIndex()
     {
         $fullTitle = "Mahommah Gardo Baquaqua. Biography of Mahommah G. Baquaqua, a Native of Zoogoo, in the Interior of Africa. (A Convert to Christianity,) With a Description of That Part of the World; Including the Manners and Customs of the Inhabitants, Their Religious Notions, Form of Government, Laws, Appearance of the Country, Buildings, Agriculture, Manufactures, Shepherds and Herdsmen, Domestic Animals, Marriage Ceremonials, Funeral Services, Styles of Dress, Trade and Commerce, Modes of Warfare, System of Slavery, &amp;c., &amp;c. Mahommah&#039;s Early Life, His Education, His Capture and Slavery in Western Africa and Brazil, His Escape to the United States, from Thence to Hayti, (the City of Port Au Prince,) His Reception by the Baptist Missionary There, The Rev. W. L. Judd; His Conversion to Christianity, Baptism, and Return to This Country, His Views, Objects and Aim. Written and Revised from His Own Words, by Samuel Moore, Esq., Late Publisher of the &quot;North of England Shipping Gazette,&quot; Author of Several Popular Works, and Editor of Sundry Reform Papers.";
-        $truncatedTitle = substr($fullTitle,0,1011); // 1011 = 1024 - index name "value_title_1"
+        $truncatedTitle = substr($fullTitle,0,1007); // 1007 = 1024 - index name "value_title_1" + Randomness
         $fullTitleLength = strlen($fullTitle);
         $truncatedTitleLength = strLen($truncatedTitle);
 

--- a/test/unit/mongo/MongoTripodTestBase.php
+++ b/test/unit/mongo/MongoTripodTestBase.php
@@ -1,6 +1,7 @@
 <?php
 
 use Tripod\ITripodStat;
+use \MongoDB\BSON\UTCDateTime;
 
 set_include_path(
   get_include_path()
@@ -405,7 +406,7 @@ abstract class MongoTripodTestBase extends PHPUnit_Framework_TestCase
         $doc = array(
             '_id' => array(_ID_RESOURCE => $labeller->uri_to_alias($subject), _ID_CONTEXT => \Tripod\Mongo\Config::getInstance()->getDefaultContextAlias()),
             _LOCKED_FOR_TRANS => $transaction_id,
-            _LOCKED_FOR_TRANS_TS=>new MongoDate()
+            _LOCKED_FOR_TRANS_TS => new UTCDateTime(floor(microtime(true))*1000)
         );
         $collection->insertOne($doc, array("w" => 1));
     }

--- a/test/unit/mongo/MongoTripodTestBase.php
+++ b/test/unit/mongo/MongoTripodTestBase.php
@@ -111,12 +111,12 @@ abstract class MongoTripodTestBase extends PHPUnit_Framework_TestCase
         $config = \Tripod\Mongo\Config::getInstance();
         if($toTransactionLog == true)
         {
-            return $this->getTlogCollection()->insert($doc, array("w"=>1));
+            return $this->getTlogCollection()->insertOne($doc, array("w"=>1));
         } else {
             return $config->getCollectionForCBD(
                 $this->tripod->getStoreName(),
                 $this->tripod->getPodName()
-            )->insert($doc, array("w"=>1));
+            )->insertOne($doc, array("w"=>1));
         }
     }
 
@@ -407,7 +407,7 @@ abstract class MongoTripodTestBase extends PHPUnit_Framework_TestCase
             _LOCKED_FOR_TRANS => $transaction_id,
             _LOCKED_FOR_TRANS_TS=>new MongoDate()
         );
-        $collection->insert($doc, array("w" => 1));
+        $collection->insertOne($doc, array("w" => 1));
     }
 
     /**

--- a/test/unit/mongo/MongoTripodTestBase.php
+++ b/test/unit/mongo/MongoTripodTestBase.php
@@ -2,6 +2,7 @@
 
 use Tripod\ITripodStat;
 use \MongoDB\BSON\UTCDateTime;
+use \MongoDB\Collection;
 
 set_include_path(
   get_include_path()
@@ -122,7 +123,7 @@ abstract class MongoTripodTestBase extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return MongoCollection
+     * @return Collection
      */
     protected function getTlogCollection()
     {
@@ -133,7 +134,7 @@ abstract class MongoTripodTestBase extends PHPUnit_Framework_TestCase
 
     /**
      * @param \Tripod\Mongo\Driver $tripod
-     * @return MongoCollection
+     * @return Collection
      */
     protected function getTripodCollection(\Tripod\Mongo\Driver $tripod)
     {
@@ -148,7 +149,7 @@ abstract class MongoTripodTestBase extends PHPUnit_Framework_TestCase
 
     /**
      * @param mixed $_id
-     * @param \MongoCollection|null $collection
+     * @param Collection|null $collection
      * @param bool $fromTransactionLog
      * @return array|null
      */

--- a/test/unit/mongo/MongoTripodTestBase.php
+++ b/test/unit/mongo/MongoTripodTestBase.php
@@ -232,8 +232,8 @@ abstract class MongoTripodTestBase extends PHPUnit_Framework_TestCase
     protected function assertTransactionDate(Array $doc, $key)
     {
         $this->assertTrue(isset($doc[$key]), 'the date property: {$key} was not present in document');
-        $this->assertTrue(!empty($doc[$key]->sec),'the date property: {$key} does not have a "sec" property');
-        $this->assertTrue(!empty($doc[$key]->usec), 'the date property: {$key} does not have a "usec" property');
+        $this->assertInstanceOf('MongoDB\BSON\UTCDateTime', $doc[$key]);
+        $this->assertNotEmpty($doc[$key]->toDateTime());
     }
 
     /**
@@ -454,7 +454,7 @@ class TestTripod extends \Tripod\Mongo\Driver
      */
     public function getCollectionReadPreference()
     {
-        return $this->collection->getReadPreference();
+        return $this->collection->__debugInfo()['readPreference'];
     }
 }
 

--- a/test/unit/mongo/MongoTripodTransactionRollbackTest.php
+++ b/test/unit/mongo/MongoTripodTransactionRollbackTest.php
@@ -2,6 +2,9 @@
 require_once 'MongoTripodTestBase.php';
 /** @noinspection PhpIncludeInspection */
 require_once 'src/mongo/Driver.class.php';
+
+use \MongoDB\BSON\UTCDateTime;
+
 /**
  * This test suite was added to specifically verify behaviour of code
  * during Driver->storeChanges.
@@ -59,8 +62,8 @@ class MongoTripodTransactionRollbackTest extends MongoTripodTestBase
             'rdf:type'=>array('u'=>'acorn:Resource'),
             'dct:title'=>array(array('l'=>'Title one'),array('l'=>'Title two')),
             '_version'=>0,
-            '_cts'=> new MongoDate(strtotime("2013-03-21 00:00:00")),
-            '_uts'=> new MongoDate(strtotime("2013-03-21 00:00:00"))
+            '_cts'=> new UTCDateTime(strtotime("2013-03-21 00:00:00")*1000),
+            '_uts'=> new UTCDateTime(strtotime("2013-03-21 00:00:00")*1000)
         );
 
         $doc2 = array(
@@ -68,8 +71,8 @@ class MongoTripodTransactionRollbackTest extends MongoTripodTestBase
             'rdf:type'=>array('u'=>'acorn:Book'),
             'dct:title'=>array(array('l'=>'Title three'),array('l'=>'Title four')),
             '_version'=>0,
-            '_cts'=> new MongoDate(strtotime("2013-03-21 00:00:00")),
-            '_uts'=> new MongoDate(strtotime("2013-03-21 00:00:00"))
+            '_cts'=> new UTCDateTime(strtotime("2013-03-21 00:00:00")*1000),
+            '_uts'=> new UTCDateTime(strtotime("2013-03-21 00:00:00")*1000)
         );
         $this->addDocument($doc1);
         $this->addDocument($doc2);
@@ -211,8 +214,8 @@ class MongoTripodTransactionRollbackTest extends MongoTripodTestBase
             'rdf:type'=>array('u'=>'acorn:Resource'),
             'dct:title'=>array(array('l'=>'Title one'),array('l'=>'Title two')),
             '_version'=>0,
-            '_cts'=> new \MongoDate(strtotime("2013-03-21 00:00:00")),
-            '_uts'=> new \MongoDate(strtotime("2013-03-21 00:00:00"))
+            '_cts'=> new UTCDateTime(strtotime("2013-03-21 00:00:00")*1000),
+            '_uts'=> new UTCDateTime(strtotime("2013-03-21 00:00:00")*1000)
         );
 
         $doc2 = array(
@@ -220,8 +223,8 @@ class MongoTripodTransactionRollbackTest extends MongoTripodTestBase
             'rdf:type'=>array('u'=>'acorn:Book'),
             'dct:title'=>array(array('l'=>'Title three'),array('l'=>'Title four')),
             '_version'=>0,
-            '_cts'=> new \MongoDate(strtotime("2013-03-21 00:00:00")),
-            '_uts'=> new \MongoDate(strtotime("2013-03-21 00:00:00"))
+            '_cts'=> new UTCDateTime(strtotime("2013-03-21 00:00:00")*1000),
+            '_uts'=> new UTCDateTime(strtotime("2013-03-21 00:00:00")*1000)
         );
         $this->addDocument($doc1);
         $this->addDocument($doc2);
@@ -312,8 +315,8 @@ class MongoTripodTransactionRollbackTest extends MongoTripodTestBase
             'rdf:type'=>array('u'=>'acorn:Resource'),
             'dct:title'=>array(array('l'=>'Title one'),array('l'=>'Title two')),
             '_version'=>0,
-            '_cts'=> new MongoDate(),
-            '_uts'=> new MongoDate()
+            '_cts'=> new UTCDateTime(floor(microtime(true))*1000),
+            '_uts'=> new UTCDateTime(floor(microtime(true))*1000)
         );
 
         $doc2 = array(
@@ -321,8 +324,8 @@ class MongoTripodTransactionRollbackTest extends MongoTripodTestBase
             'rdf:type'=>array('u'=>'acorn:Book'),
             'dct:title'=>array(array('l'=>'Title three'),array('l'=>'Title four')),
             '_version'=>0,
-            '_cts'=> new MongoDate(),
-            '_uts'=> new MongoDate()
+            '_cts'=> new UTCDateTime(floor(microtime(true))*1000),
+            '_uts'=> new UTCDateTime(floor(microtime(true))*1000)
         );
         $this->addDocument($doc1);
         $this->addDocument($doc2);
@@ -435,17 +438,17 @@ class MongoTripodTransactionRollbackTest extends MongoTripodTestBase
             return false;
         else{
             try{ //Add a entry to locks collection for this subject, will throws exception if an entry already there
-                $result = $lCollection->insert(
+                $result = $lCollection->insertOne(
                     array(
                         '_id' => array(_ID_RESOURCE => $this->labeller->uri_to_alias($s), _ID_CONTEXT => $contextAlias),
                         _LOCKED_FOR_TRANS => $transaction_id,
-                        _LOCKED_FOR_TRANS_TS=>new MongoDate()
+                        _LOCKED_FOR_TRANS_TS => new UTCDateTime(floor(microtime(true))*1000)
                     ),
                     array("w" => 1)
                 );
 
-                if(!$result["ok"] || $result['err']!=NULL){
-                    throw new Exception("Failed to lock document with error message- " . $result['err']);
+                if(!$result->isAcknowledged()){
+                    throw new Exception("Failed to lock document with error message- " . $this->getLastDBError());
                 }
             }
             catch(Exception $e) { //Subject is already locked or unable to lock
@@ -464,15 +467,15 @@ class MongoTripodTransactionRollbackTest extends MongoTripodTestBase
             $document  = $this->getTripodCollection($this->tripod)->findOne(array('_id' => array(_ID_RESOURCE => $this->labeller->uri_to_alias($s), _ID_CONTEXT => $contextAlias)));
             if(empty($document)){ //if document is not there, create it
                 try{
-                    $result = $this->getTripodCollection($this->tripod)->insert(
+                    $result = $this->getTripodCollection($this->tripod)->insertOne(
                         array(
                             '_id' => array(_ID_RESOURCE => $this->labeller->uri_to_alias($s), _ID_CONTEXT => $contextAlias)
                         ),
                         array("w" => 1)
                     );
 
-                    if(!$result["ok"] || $result['err']!=NULL){
-                        throw new Exception("Failed to create new document with error message- " . $result['err']);
+                    if(!$result->isAcknowledged()){
+                        throw new Exception("Failed to create new document with error message- " . $this->getLastDBError());
                     }
                     $document  = $this->getTripodCollection($this->tripod)->findOne(array('_id' => array(_ID_RESOURCE => $this->labeller->uri_to_alias($s), _ID_CONTEXT => $contextAlias)));
                 }
@@ -490,6 +493,19 @@ class MongoTripodTransactionRollbackTest extends MongoTripodTestBase
             }
             return $document;
         }
+    }
+
+    private function getLastDBError($db = null) {
+        if (is_null($db)) {
+            $db = $this->config->getDatabase(
+                $this->storeName,
+                $this->config->getDataSourceForPod($this->storeName, $this->podName),
+                $this->readPreference
+            );
+        }
+        return $db->command([
+            'getLastError' =>  1
+        ])->toArray()[0];
     }
 }
 

--- a/test/unit/mongo/MongoTripodViewsTest.php
+++ b/test/unit/mongo/MongoTripodViewsTest.php
@@ -103,7 +103,11 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         );
         // get the view direct from mongo
 //        $result = $this->tripod->getViewForResource("http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA","v_resource_full");
-        $mongo = new MongoClient(\Tripod\Mongo\Config::getInstance()->getConnStr('tripod_php_testing'));
+        $mongo = new Client(
+            \Tripod\Mongo\Config::getInstance()->getConnStr('tripod_php_testing'),
+            [],
+            ['typeMap' => ['root' => 'array', 'document' => 'array', 'array' => 'array']]
+        );
         $actualView = $mongo->selectCollection('tripod_php_testing','views')->findOne(array('_id'=>array("r"=>'http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA',"c"=>'http://talisaspire.com/',"type"=>'v_resource_full')));
         $this->assertEquals($expectedView,$actualView);
     }
@@ -170,7 +174,11 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             )
         );
         // get the view direct from mongo
-        $mongo = new MongoClient(\Tripod\Mongo\Config::getInstance()->getConnStr('tripod_php_testing'));
+        $mongo = new Client(
+            \Tripod\Mongo\Config::getInstance()->getConnStr('tripod_php_testing'),
+            [],
+            ['typeMap' => ['root' => 'array', 'document' => 'array', 'array' => 'array']]
+        );
         $actualView = $mongo->selectCollection('tripod_php_testing','views')->findOne(array('_id'=>array("r"=>'http://talisaspire.com/resources/filter1',"c"=>'http://talisaspire.com/',"type"=>'v_resource_filter1')));
         $this->assertEquals($expectedView,$actualView);
     }
@@ -229,7 +237,11 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             )
         );
         // get the view direct from mongo
-        $mongo = new MongoClient(\Tripod\Mongo\Config::getInstance()->getConnStr('tripod_php_testing'));
+        $mongo = new Client(
+            \Tripod\Mongo\Config::getInstance()->getConnStr('tripod_php_testing'),
+            [],
+            ['typeMap' => ['root' => 'array', 'document' => 'array', 'array' => 'array']]
+        );
         $actualView = $mongo->selectCollection('tripod_php_testing','views')->findOne(
             array('_id'=>array("r"=>'http://talisaspire.com/resources/filter1',"c"=>'http://talisaspire.com/',"type"=>'v_resource_filter2'))
         );
@@ -298,7 +310,11 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             )
         );
         // get the view direct from mongo
-        $mongo = new MongoClient(\Tripod\Mongo\Config::getInstance()->getConnStr('tripod_php_testing'));
+        $mongo = new Client(
+            \Tripod\Mongo\Config::getInstance()->getConnStr('tripod_php_testing'),
+            [],
+            ['typeMap' => ['root' => 'array', 'document' => 'array', 'array' => 'array']]
+        );
         $actualView = $mongo->selectCollection('tripod_php_testing','views')->findOne(array('_id'=>array("r"=>'http://talisaspire.com/resources/filter1',"c"=>'http://talisaspire.com/',"type"=>'v_resource_filter1')));
         $this->assertEquals($expectedView,$actualView);
 
@@ -436,7 +452,11 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             )
         );
         // get the view direct from mongo
-        $mongo = new MongoClient(\Tripod\Mongo\Config::getInstance()->getConnStr('tripod_php_testing'));
+        $mongo = new Client(
+            \Tripod\Mongo\Config::getInstance()->getConnStr('tripod_php_testing'),
+            [],
+            ['typeMap' => ['root' => 'array', 'document' => 'array', 'array' => 'array']]
+        );
         $actualView = $mongo->selectCollection('tripod_php_testing','views')->findOne(array('_id'=>array("r"=>'http://talisaspire.com/resources/filter1',"c"=>'http://talisaspire.com/',"type"=>'v_resource_rdfsequence')));
 
         $this->assertEquals($expectedView,$actualView);
@@ -1941,14 +1961,6 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             ->getMock();
         $mockCursor = $this->getMock('\ArrayIterator', array('rewind'));
 
-
-
-
-
-
-//        $mockDb = $this->getMock("MongoDB", array("selectCollection"),array(new MongoClient(),"test"));
-//        $mockCursor = $this->getMock('MongoCursor', array('rewind'), array(new MongoClient(), 'test.views'));
-
         $mockCursor->expects($this->exactly(5))
             ->method('rewind')
             ->will($this->onConsecutiveCalls(
@@ -1958,9 +1970,6 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
                 $this->throwException(new \Exception('Exception thrown when cursoring to Mongo')),
                 $this->returnValue($mockCursor)));
 
-
-//        $mockColl = $this->getMock("MongoCollection", array('findOne'),array($mockDb,$this->tripod->getPodName()));
-//        $mockViewColl = $this->getMock("MongoCollection", array('findOne', 'find'), array($mockDb,VIEWS_COLLECTION));
         $mockViewColl->expects($this->once())->method('find')->will($this->returnValue($mockCursor));
 
         $mockDb->expects($this->any())->method("selectCollection")->will($this->returnValue($mockColl));

--- a/test/unit/mongo/MongoTripodViewsTest.php
+++ b/test/unit/mongo/MongoTripodViewsTest.php
@@ -464,7 +464,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
 
     public function testGenerateViewWithTTL()
     {
-        $expiryDate = new UTCDateTime(strtotime(time()+300)*1000);
+        $expiryDate = new UTCDateTime((time()+300)*1000);
         $mockTripodViews = $this->getMock('\Tripod\Mongo\Composites\Views', array('getExpirySecFromNow'), $this->viewsConstParams);
         $mockTripodViews->expects($this->once())->method('getExpirySecFromNow')->with(300)->will($this->returnValue((time()+300)));
 
@@ -556,7 +556,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
 
     public function testGenerateViewWithCountAggregate()
     {
-        $expiryDate = new UTCDateTime(strtotime(time()+300)*1000);
+        $expiryDate = new UTCDateTime((time()+300)*1000);
         /**
          * @var $mockTripodViews \Tripod\Mongo\Composites\Views
          */

--- a/test/unit/mongo/MongoTripodViewsTest.php
+++ b/test/unit/mongo/MongoTripodViewsTest.php
@@ -5,6 +5,8 @@ require_once 'src/mongo/Driver.class.php';
 require_once 'src/mongo/delegates/Views.class.php';
 
 use \Tripod\Mongo\Composites\Views;
+use \MongoDB\BSON\UTCDateTime;
+use \MongoDB\Client;
 
 class MongoTripodViewsTest extends MongoTripodTestBase {
     /**
@@ -442,7 +444,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
 
     public function testGenerateViewWithTTL()
     {
-        $expiryDate = new MongoDate(time()+300);
+        $expiryDate = new UTCDateTime(strtotime(time()+300)*1000);
         $mockTripodViews = $this->getMock('\Tripod\Mongo\Composites\Views', array('getExpirySecFromNow'), $this->viewsConstParams);
         $mockTripodViews->expects($this->once())->method('getExpirySecFromNow')->with(300)->will($this->returnValue((time()+300)));
 
@@ -534,7 +536,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
 
     public function testGenerateViewWithCountAggregate()
     {
-        $expiryDate = new MongoDate(time()+300);
+        $expiryDate = new UTCDateTime(strtotime(time()+300)*1000);
         /**
          * @var $mockTripodViews \Tripod\Mongo\Composites\Views
          */
@@ -654,9 +656,18 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         $returnedGraph = new \Tripod\ExtendedGraph();
         $returnedGraph->add_literal_triple($uri1,'http://somepred','someval');
 
-        $mockDb = $this->getMock("MongoDB", array("selectCollection"),array(new MongoClient(),"test"));
-        $mockColl = $this->getMock("MongoCollection", array("findOne"),array($mockDb,$this->tripod->getPodName()));
-        $mockViewColl = $this->getMock("MongoCollection", array("findOne"),array($mockDb,VIEWS_COLLECTION));
+        $mockDb = $this->getMockBuilder('\MongoDB\Database')
+            ->disableOriginalConstructor()
+            ->setMethods(['selectCollection'])
+            ->getMock();
+        $mockColl = $this->getMockBuilder('\MongoDB\Collection')
+            ->disableOriginalConstructor()
+            ->setMethods(['findOne'])
+            ->getMock();
+        $mockViewColl = $this->getMockBuilder('\MongoDB\Collection')
+            ->disableOriginalConstructor()
+            ->setMethods(['findOne'])
+            ->getMock();
 
         $mockDb->expects($this->any())->method("selectCollection")->will($this->returnValue($mockColl));
         $mockColl->expects($this->once())->method("findOne")->will($this->returnValue(null));
@@ -712,9 +723,18 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         $viewType = "someView";
         $context = "http://someContext";
 
-        $mockDb = $this->getMock("MongoDB", array("selectCollection"),array(new MongoClient(),"test"));
-        $mockColl = $this->getMock("MongoCollection", array("findOne"),array($mockDb,$this->tripod->getPodName()));
-        $mockViewColl = $this->getMock("MongoCollection", array("findOne"),array($mockDb,VIEWS_COLLECTION));
+        $mockDb = $this->getMockBuilder('\MongoDB\Database')
+            ->disableOriginalConstructor()
+            ->setMethods(['selectCollection'])
+            ->getMock();
+        $mockColl = $this->getMockBuilder('\MongoDB\Collection')
+            ->disableOriginalConstructor()
+            ->setMethods(['findOne'])
+            ->getMock();
+        $mockViewColl = $this->getMockBuilder('\MongoDB\Collection')
+            ->disableOriginalConstructor()
+            ->setMethods(['findOne'])
+            ->getMock();
 
         $mockDb->expects($this->any())->method("selectCollection")->will($this->returnValue($mockColl));
         $mockColl->expects($this->once())->method("findOne")->will($this->returnValue(array("_id"=>$uri1))); // the actual returned doc is not important, it just has to not be null
@@ -1781,10 +1801,20 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         $returnedGraph = new \Tripod\ExtendedGraph();
         $returnedGraph->add_literal_triple($uri1,'http://somepred','someval');
 
-        $mockDb = $this->getMock("MongoDB", array("selectCollection"),array(new MongoClient(),"test"));
-        $mockCursor = $this->getMock('MongoCursor', array(), array(new MongoClient(), 'test.views'));
-        $mockColl = $this->getMock("MongoCollection", array('findOne'),array($mockDb,$this->tripod->getPodName()));
-        $mockViewColl = $this->getMock("MongoCollection", array('findOne', 'find'), array($mockDb,VIEWS_COLLECTION));
+        $mockDb = $this->getMockBuilder('\MongoDB\Database')
+            ->disableOriginalConstructor()
+            ->setMethods(['selectCollection'])
+            ->getMock();
+        $mockColl = $this->getMockBuilder('\MongoDB\Collection')
+            ->disableOriginalConstructor()
+            ->setMethods(['findOne'])
+            ->getMock();
+        $mockViewColl = $this->getMockBuilder('\MongoDB\Collection')
+            ->disableOriginalConstructor()
+            ->setMethods(['find'])
+            ->getMock();
+        $mockCursor = $this->getMock('\ArrayIterator', array('rewind'));
+
         $mockViewColl->expects($this->once())->method('find')->will($this->returnValue($mockCursor));
 
         $mockDb->expects($this->any())->method("selectCollection")->will($this->returnValue($mockColl));
@@ -1834,16 +1864,25 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         $returnedGraph = new \Tripod\ExtendedGraph();
         $returnedGraph->add_literal_triple($uri1,'http://somepred','someval');
 
-        $mockDb = $this->getMock("MongoDB", array("selectCollection"),array(new MongoClient(),"test"));
-        $mockCursor = $this->getMock('MongoCursor', array('rewind'), array(new MongoClient(), 'test.views'));
-        $mockCursor->expects($this->exactly(30))->method('rewind')->will($this->throwException(new \MongoCursorException('Exception thrown when cursoring to Mongo')));
-        $mockColl = $this->getMock("MongoCollection", array('findOne'),array($mockDb,$this->tripod->getPodName()));
-        $mockViewColl = $this->getMock("MongoCollection", array('findOne', 'find'), array($mockDb,VIEWS_COLLECTION));
+        $mockDb = $this->getMockBuilder('\MongoDB\Database')
+            ->disableOriginalConstructor()
+            ->setMethods(['selectCollection'])
+            ->getMock();
+        $mockColl = $this->getMockBuilder('\MongoDB\Collection')
+            ->disableOriginalConstructor()
+            ->setMethods(['findOne'])
+            ->getMock();
+        $mockViewColl = $this->getMockBuilder('\MongoDB\Collection')
+            ->disableOriginalConstructor()
+            ->setMethods(['findOne', 'find'])
+            ->getMock();
+        $mockCursor = $this->getMock('\ArrayIterator', array('rewind'));
+
+        $mockCursor->expects($this->exactly(30))->method('rewind')->will($this->throwException(new \Exception('Exception thrown when cursoring to Mongo')));
         $mockViewColl->expects($this->once())->method('find')->will($this->returnValue($mockCursor));
 
         $mockDb->expects($this->any())->method("selectCollection")->will($this->returnValue($mockColl));
         $mockColl->expects($this->never())->method("findOne");
-
 
         /** @var PHPUnit_Framework_MockObject_MockObject|TripodTestConfig $mockConfig */
         $mockConfig = $this->getMock(
@@ -1874,7 +1913,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             ->method('getConfigInstance')
             ->will($this->returnValue($mockConfig));
 
-        $this->setExpectedException('\MongoCursorException', "Exception thrown when cursoring to Mongo");
+        $this->setExpectedException('\Exception', "Exception thrown when cursoring to Mongo");
         $mockTripodViews->getViewForResources(array($uri1),$viewType,$context);
     }
     public function testCursorNoExceptionThrownWhenCursorThrowsSomeExceptions()
@@ -1887,21 +1926,41 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         $returnedGraph = new \Tripod\ExtendedGraph();
         $returnedGraph->add_literal_triple($uri1,'http://somepred','someval');
 
-        $mockDb = $this->getMock("MongoDB", array("selectCollection"),array(new MongoClient(),"test"));
-        $mockCursor = $this->getMock('MongoCursor', array('rewind'), array(new MongoClient(), 'test.views'));
+
+        $mockDb = $this->getMockBuilder('\MongoDB\Database')
+            ->disableOriginalConstructor()
+            ->setMethods(['selectCollection'])
+            ->getMock();
+        $mockColl = $this->getMockBuilder('\MongoDB\Collection')
+            ->disableOriginalConstructor()
+            ->setMethods(['findOne'])
+            ->getMock();
+        $mockViewColl = $this->getMockBuilder('\MongoDB\Collection')
+            ->disableOriginalConstructor()
+            ->setMethods(['find', 'findOne'])
+            ->getMock();
+        $mockCursor = $this->getMock('\ArrayIterator', array('rewind'));
+
+
+
+
+
+
+//        $mockDb = $this->getMock("MongoDB", array("selectCollection"),array(new MongoClient(),"test"));
+//        $mockCursor = $this->getMock('MongoCursor', array('rewind'), array(new MongoClient(), 'test.views'));
 
         $mockCursor->expects($this->exactly(5))
             ->method('rewind')
             ->will($this->onConsecutiveCalls(
-                $this->throwException(new \MongoCursorException('Exception thrown when cursoring to Mongo')),
-                $this->throwException(new \MongoCursorException('Exception thrown when cursoring to Mongo')),
-                $this->throwException(new \MongoCursorException('Exception thrown when cursoring to Mongo')),
-                $this->throwException(new \MongoCursorException('Exception thrown when cursoring to Mongo')),
+                $this->throwException(new \Exception('Exception thrown when cursoring to Mongo')),
+                $this->throwException(new \Exception('Exception thrown when cursoring to Mongo')),
+                $this->throwException(new \Exception('Exception thrown when cursoring to Mongo')),
+                $this->throwException(new \Exception('Exception thrown when cursoring to Mongo')),
                 $this->returnValue($mockCursor)));
 
 
-        $mockColl = $this->getMock("MongoCollection", array('findOne'),array($mockDb,$this->tripod->getPodName()));
-        $mockViewColl = $this->getMock("MongoCollection", array('findOne', 'find'), array($mockDb,VIEWS_COLLECTION));
+//        $mockColl = $this->getMock("MongoCollection", array('findOne'),array($mockDb,$this->tripod->getPodName()));
+//        $mockViewColl = $this->getMock("MongoCollection", array('findOne', 'find'), array($mockDb,VIEWS_COLLECTION));
         $mockViewColl->expects($this->once())->method('find')->will($this->returnValue($mockCursor));
 
         $mockDb->expects($this->any())->method("selectCollection")->will($this->returnValue($mockColl));


### PR DESCRIPTION
This is to support the new mongo driver for PHP.

The PHP drivers implement a different API, so all chainable calls such as `->find()->sort()->limit()` have been replaced with another format. Read preferences have changed (how you set them), so have some of the function calls. An upgrade guide can be found here: https://mongodb.github.io/mongo-php-library/upgrade-guide/

There are some requirement changes:
- Mongo 2.6.x and above. This has changed from requiring Mongo 2.x - the reason for this is the way an `updateOne` or `replaceOne` function works with the current functionality with the new PHP mongo library. If we want to support older versions of Mongo, we'll need to change some functionality.
- PHP 5.4+. The MongoDB PHP library only works with PHP 5.4 and above - so we're tied to this. Also - we've started using some PHP 5.4 and above functionality (array notation for a start).
- Added compatibility for PHP 7.0 (7.1 has unit test failures so I haven't added that).

A preview modification for Tripod involved retrying connections when stepping down and removing servers from the repset. I've gone through the same testing process with this new branch as I did on that PR. All works as expected.
#### Todo
- [x] Decide if we're going to support BSONDocuments in MongoGraph or leave it as arrays
- [x] `db->getLastError()` does not work anymore - find a solution
- [x] Look into how to set read preferences correctly rather than how we were doing it in the old driver
- [x] Transaction log and document locking to work
- [x] Replace all instances of Mongo\* - not touched the scripts/utils yet so there are some instances.
- [x] Look into how to manage a successful connection without doing a PING command
- [x] Travis support for new mongo driver - remove the old one
- [x] Can you define a mongo version in Travis?
- [x] Check docblocks and type hinting are correct
- [x] Check for all instances of Mongo*
