### PR TITLE
Updated updateOne queries

### DIFF
--- a/src/mongo/delegates/Tables.class.php
+++ b/src/mongo/delegates/Tables.class.php
@@ -650,13 +650,13 @@ class Tables extends CompositeBase
     {
         try
         {
-            $collection->updateOne($generatedRow['_id'], array('$set' => $generatedRow), array('upsert' => true));
+            $collection->updateOne(array('_id' => $generatedRow['_id']), array('$set' => $generatedRow), array('upsert' => true));
         } catch (\Exception $e) {
             // We only truncate and retry the save if the \Exception contains this text.
             if (strpos($e->getMessage(),"Btree::insert: key too large to index") !== FALSE)
             {
                 $this->truncateFields($collection, $generatedRow);
-                $collection->updateOne($generatedRow['_id'], array('$set' => $generatedRow), array('upsert' => true));
+                $collection->updateOne(array('_id' => $generatedRow['_id']), array('$set' => $generatedRow), array('upsert' => true));
             }
             else
             {

--- a/src/mongo/providers/MongoSearchProvider.class.php
+++ b/src/mongo/providers/MongoSearchProvider.class.php
@@ -69,7 +69,7 @@ class MongoSearchProvider implements \Tripod\ISearchProvider
             $collection->createIndex(array('_id.type' => 1), array('background' => 1));
             $collection->createIndex(array('_id.r' => 1, '_id.c' => 1), array('background' => 1));
             $collection->createIndex(array('_impactIndex' => 1), array('background' => 1));
-            $result = $collection->insertOne($document);
+            $result = $collection->updateOne(array('_id' => $document['_id']), array('$set' => $document), array('upsert' => true));
             if (!$result->isAcknowledged()) {
                 throw new \Tripod\Exceptions\SearchException("Inserting search document not acknowledged");
             }


### PR DESCRIPTION
We are seeing some intermittent failures in both the app and in workers.

What is happening is that `updateOne` takes either an array or an object. If it's an array, it is supposed to be a filter - so `['match' => 'value']`. If it's an object, it should be an ObjectId.

However - in Tripod, our `_id` fields are arrays - so validation on the updateOne function is ok - but it won't match. By changing it to be `['_id' => $generatedRow['_id']]` we make sure the filter works as expected. 

The update to MongoSearchProvider is where we are doing an insert where we should be using an upsert.