### PR TITLE
Cast UTCDateTime to a DateTime object for comparison

### DIFF
--- a/src/mongo/delegates/Tables.class.php
+++ b/src/mongo/delegates/Tables.class.php
@@ -927,7 +927,7 @@ class Tables extends CompositeBase
     protected function castValueType($value, $type=null)
     {
         // If value is a UTCDateTime, turn into a DateTime object in order to perform comparison
-        if ($value instanceof UTCDateTime) {
+        if ($value instanceof \MongoDB\BSON\UTCDateTime) {
             $value = $value->toDateTime();
         }
 

--- a/src/mongo/delegates/Tables.class.php
+++ b/src/mongo/delegates/Tables.class.php
@@ -926,6 +926,11 @@ class Tables extends CompositeBase
      */
     protected function castValueType($value, $type=null)
     {
+        // If value is a UTCDateTime, turn into a timestamp in order to perform comparisons
+        if ($value instanceof UTCDateTime) {
+            $value = $value->toDateTime()->getTimestamp();
+        }
+        
         switch($type)
         {
             case 'string':

--- a/src/mongo/delegates/Tables.class.php
+++ b/src/mongo/delegates/Tables.class.php
@@ -926,11 +926,11 @@ class Tables extends CompositeBase
      */
     protected function castValueType($value, $type=null)
     {
-        // If value is a UTCDateTime, turn into a timestamp in order to perform comparisons
+        // If value is a UTCDateTime, turn into a DateTime object in order to perform comparison
         if ($value instanceof UTCDateTime) {
-            $value = $value->toDateTime()->getTimestamp();
+            $value = $value->toDateTime();
         }
-        
+
         switch($type)
         {
             case 'string':

--- a/test/unit/mongo/MongoTripodTestBase.php
+++ b/test/unit/mongo/MongoTripodTestBase.php
@@ -51,6 +51,9 @@ abstract class MongoTripodTestBase extends PHPUnit_Framework_TestCase
         }
     }
 
+    protected function loadDatesDataViaTripod() {
+        $this->loadDataViaTripod('/data/dates.json');
+    }
     protected function loadResourceDataViaTripod()
     {
         $this->loadDataViaTripod('/data/resources.json');

--- a/test/unit/mongo/data/dates.json
+++ b/test/unit/mongo/data/dates.json
@@ -1,0 +1,52 @@
+[
+    {
+        "_id":
+        {
+            "r":"baseData:foo1234",
+            "c":"http://talisaspire.com/"
+        },
+        "rdf:type":
+            [
+                {
+                    "u":"bibo:Document"
+                }
+            ],
+        "dct:title" : {
+            "l" : "A document title"
+        },
+        "dct:isVersionOf" : {
+            "u" : "http://talisaspire.com/works/4d101f63c10a6"
+        },
+        "dct:updated" : {
+            "l" : "2017-02-23T14:49:02+00:00"
+        },
+        "dct:published" : {
+            "l" : "2017-02-22T14:49:02+00:00"
+        }
+    },
+    {
+        "_id":
+        {
+            "r":"baseData:foo12345",
+            "c":"http://talisaspire.com/"
+        },
+        "rdf:type":
+            [
+                {
+                    "u":"bibo:Document"
+                }
+            ],
+        "dct:title" : {
+            "l" : "A document title"
+        },
+        "dct:isVersionOf" : {
+            "u" : "http://talisaspire.com/works/4d101f63c10a6"
+        },
+        "dct:updated" : {
+            "l" : "2017-02-23T14:49:02+00:00"
+        },
+        "dct:published" : {
+            "l" : "2017-02-23T14:49:02+00:00"
+        }
+    }
+]


### PR DESCRIPTION
When using a conditional in a table spec that compares 2 date objects, the comparison fails because the 2 objects aren't in a state that can be compared. 

`UTCDateTime` cannot be compared using comparison operators `UTCDateTime`. A `DateTime` object however, can be.