### PR TITLE
Reference fix for PHP 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ php:
 services:
 - redis
 before_install:
-- sudo apt-get install -y mongodb-org=2.6.12 mongodb-org-server=2.6.12 mongodb-org-shell=2.6.12 mongodb-org-mongos=2.6.12 mongodb-org-tools=2.6.12
+- sudo apt-get install -y mongodb-org=2.6.9 mongodb-org-server=2.6.9 mongodb-org-shell=2.6.9 mongodb-org-mongos=2.6.9 mongodb-org-tools=2.6.9
 - echo "extension = mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 - sleep 15
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ php:
 services:
 - redis
 before_install:
-- sudo apt-get install -y mongodb-org=2.6.9 mongodb-org-server=2.6.9 mongodb-org-shell=2.6.9 mongodb-org-mongos=2.6.9 mongodb-org-tools=2.6.9
+- sudo apt-get install -y mongodb-org=2.6.12 mongodb-org-server=2.6.12 mongodb-org-shell=2.6.12 mongodb-org-mongos=2.6.12 mongodb-org-tools=2.6.12
 - echo "extension = mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 - sleep 15
 install:

--- a/src/classes/ExtendedGraph.class.php
+++ b/src/classes/ExtendedGraph.class.php
@@ -668,7 +668,8 @@ class ExtendedGraph
             $parser = \ARC2::getSemHTMLParser();
             $parser->parse($base, $html );
             $parser->extractRDF('rdfa');
-            $this->_add_arc2_triple_list($parser->getTriples());
+	    $triples = $parser->getTriples();
+            $this->_add_arc2_triple_list($triples);
             unset($parser);
         }
     }

--- a/src/classes/ExtendedGraph.class.php
+++ b/src/classes/ExtendedGraph.class.php
@@ -608,7 +608,8 @@ class ExtendedGraph
             /** @var \ARC2_RDFXMLParser $parser */
             $parser = \ARC2::getRDFXMLParser();
             $parser->parse($base, $rdfxml );
-            $this->_add_arc2_triple_list($parser->getTriples());
+            $triples = $parser->getTriples();
+            $this->_add_arc2_triple_list($triples);
             unset($parser);
         }
     }

--- a/src/classes/ExtendedGraph.class.php
+++ b/src/classes/ExtendedGraph.class.php
@@ -593,7 +593,8 @@ class ExtendedGraph
             if(!empty($errors)){
                 $this->parser_errors[]=$errors;
             }
-            $this->_add_arc2_triple_list($parser->getTriples());
+            $triples = $parser->getTriples();
+            $this->_add_arc2_triple_list($triples);
             unset($parser);
         }
     }

--- a/test/unit/mongo/MongoTripodConfigTest.php
+++ b/test/unit/mongo/MongoTripodConfigTest.php
@@ -150,7 +150,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
 
     public function testGetConnectionString()
     {
-        $this->assertEquals("mongodb://localhost",\Tripod\Mongo\Config::getInstance()->getConnStr("tripod_php_testing"));
+        $this->assertEquals("mongodb://localhost:27017/",\Tripod\Mongo\Config::getInstance()->getConnStr("tripod_php_testing"));
     }
 
     public function testGetConnectionStringThrowsException()
@@ -158,7 +158,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $this->setExpectedException(
             '\Tripod\Exceptions\ConfigException',
             'Database notexists does not exist in configuration');
-        $this->assertEquals("mongodb://localhost",\Tripod\Mongo\Config::getInstance()->getConnStr("notexists"));
+        $this->assertEquals("mongodb://localhost:27017/",\Tripod\Mongo\Config::getInstance()->getConnStr("notexists"));
     }
 
     public function testGetConnectionStringForReplicaSet(){
@@ -1709,7 +1709,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $mockConfig->loadConfig(json_decode(file_get_contents(dirname(__FILE__).'/data/config.json'), true));
         $mockConfig->expects($this->exactly(1))
             ->method('getMongoClient')
-            ->with('mongodb://localhost?connectTimeoutMS=20000')
+            ->with('mongodb://localhost:27017/?connectTimeoutMS=20000')
             ->will($this->returnCallback(
                 function()
                 {
@@ -1728,7 +1728,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $mockConfig->loadConfig(json_decode(file_get_contents(dirname(__FILE__).'/data/config.json'), true));
         $mockConfig->expects($this->exactly(30))
             ->method('getMongoClient')
-            ->with('mongodb://localhost?connectTimeoutMS=20000')
+            ->with('mongodb://localhost:27017/?connectTimeoutMS=20000')
             ->will($this->throwException(new ConnectionTimeoutException('Exception thrown when connecting to Mongo')));
 
         $mockConfig->getDatabase('tripod_php_testing', 'rs1', ReadPreference::RP_SECONDARY_PREFERRED);
@@ -1739,7 +1739,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $mockConfig->loadConfig(json_decode(file_get_contents(dirname(__FILE__).'/data/config.json'), true));
         $mockConfig->expects($this->exactly(5))
             ->method('getMongoClient')
-            ->with('mongodb://localhost?connectTimeoutMS=20000')
+            ->with('mongodb://localhost:27017/?connectTimeoutMS=20000')
             ->will($this->onConsecutiveCalls(
                 $this->throwException(new ConnectionTimeoutException('Exception thrown when connecting to Mongo')),
                 $this->throwException(new ConnectionTimeoutException('Exception thrown when connecting to Mongo')),

--- a/test/unit/mongo/MongoTripodDriverTest.php
+++ b/test/unit/mongo/MongoTripodDriverTest.php
@@ -840,7 +840,7 @@ class MongoTripodDriverTest extends MongoTripodTestBase
         $config["data_sources"] = array(
             "db"=>array(
                 "type"=>"mongo",
-                "connection"=>"mongodb://localhost"
+                "connection"=>"mongodb://localhost:27017/"
             ),
             "tlog"=>array(
                 "type"=>"mongo",

--- a/test/unit/mongo/data/config.json
+++ b/test/unit/mongo/data/config.json
@@ -21,12 +21,12 @@
     "data_sources" : {
         "rs1" : {
             "type" : "mongo",
-            "connection": "mongodb:\/\/localhost",
+            "connection": "mongodb:\/\/localhost:27017",
             "replicaSet": ""
         },
         "rs2" : {
             "type" : "mongo",
-            "connection": "mongodb:\/\/localhost",
+            "connection": "mongodb:\/\/localhost:27017",
             "replicaSet": ""
         }
     },

--- a/test/unit/mongo/data/config.json
+++ b/test/unit/mongo/data/config.json
@@ -21,12 +21,12 @@
     "data_sources" : {
         "rs1" : {
             "type" : "mongo",
-            "connection": "mongodb:\/\/localhost:27017",
+            "connection": "mongodb:\/\/localhost:27017/",
             "replicaSet": ""
         },
         "rs2" : {
             "type" : "mongo",
-            "connection": "mongodb:\/\/localhost:27017",
+            "connection": "mongodb:\/\/localhost:27017/",
             "replicaSet": ""
         }
     },


### PR DESCRIPTION
To avoid PHP warnings we need to convert this line:
```
$this->_add_arc2_triple_list($parser->getTriples());
```
into:
```
$triples = $parser->getTriples();
$this->_add_arc2_triple_list($triples);
```

This was done originally in the `add_turtle` method, but not others.

Other changes here are to do with test config for mongo connection strings. Without a hostname delimiter (the slash), you get this error when running the build under PHP 7.0:
```
MongoDB\Driver\Exception\InvalidArgumentException: Failed to parse MongoDB URI: 'mongodb://localhost?connectTimeoutMS=20000'. Expected end of hostname delimiter.
```

This fixes that up.