### PR TITLE
ENT-71: regenerate composites without clearing collection first

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+# PHP PSR-2 Coding Standards
+# http://www.php-fig.org/psr/psr-2/
+
+root = true
+
+[*.php]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea
 composer.phar
+composer.lock
 output
 vendor
 tags

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
 - sleep 15
 install:
 - composer install
-# script: ant
+script: ant
 notifications:
   hipchat:
     rooms:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ services:
 before_install:
 - wget https://raw.githubusercontent.com/docker-library/mongo/0ac2867637ef5989e4dc051efa0ae296010e58c9/2.6/Dockerfile
 - wget https://raw.githubusercontent.com/docker-library/mongo/0ac2867637ef5989e4dc051efa0ae296010e58c9/2.6/docker-entrypoint.sh
+- chmod 0777 docker-entrypoint.sh
 - docker build -t mongo/2.6.12 .
 - docker run -d -p 27017:27017 -v ~/data:/data/db mongo/2.6.12:latest
 - echo "extension = mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,12 @@ services:
 - docker
 before_install:
 - docker pull rossfsinger/mongo-2.6.12
-- docker run -d -p 27017:27017 -v ~/data:/data/db rossfsinger/mongo-2.6.12:latest
+- docker run -d -p 127.0.0.1:27017:27017 -v ~/data:/data/db rossfsinger/mongo-2.6.12:latest
 - echo "extension = mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 - sleep 15
 install:
 - composer install
-script: ant
+# script: ant
 notifications:
   hipchat:
     rooms:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ php:
 services:
 - redis
 before_install:
-- sudo apt-get install -y mongodb-org=2.6.9 mongodb-org-server=2.6.9 mongodb-org-shell=2.6.9 mongodb-org-mongos=2.6.9 mongodb-org-tools=2.6.9
+- sudo apt-get install -y mongodb-org=2.6.* mongodb-org-server=2.6.* mongodb-org-shell=2.6.* mongodb-org-mongos=2.6.* mongodb-org-tools=2.6.*
 - echo "extension = mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 - sleep 15
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ php:
 services:
 - redis
 before_install:
-- sudo apt-get install -y mongodb-org=2.6.* mongodb-org-server=2.6.* mongodb-org-shell=2.6.* mongodb-org-mongos=2.6.* mongodb-org-tools=2.6.*
+- sudo apt-get install -y mongodb-org=2.6.12 mongodb-org-server=2.6.12 mongodb-org-shell=2.6.12 mongodb-org-mongos=2.6.12 mongodb-org-tools=2.6.12
 - echo "extension = mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 - sleep 15
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,11 @@ php:
 - 5.4
 services:
 - redis
+- docker
 before_install:
-- sudo apt-get install -y mongodb-org=2.6.12 mongodb-org-server=2.6.12 mongodb-org-shell=2.6.12 mongodb-org-mongos=2.6.12 mongodb-org-tools=2.6.12
+- wget https://raw.githubusercontent.com/docker-library/mongo/0ac2867637ef5989e4dc051efa0ae296010e58c9/2.6/Dockerfile
+- docker build -t mongo/2.6.12 .
+- docker run -d -p 127.0.0.1:27017:27017 mongo/2.6.12 /bin/sh -c "mongod"
 - echo "extension = mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 - sleep 15
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 - wget https://raw.githubusercontent.com/docker-library/mongo/0ac2867637ef5989e4dc051efa0ae296010e58c9/2.6/Dockerfile
 - wget https://raw.githubusercontent.com/docker-library/mongo/0ac2867637ef5989e4dc051efa0ae296010e58c9/2.6/docker-entrypoint.sh
 - docker build -t mongo/2.6.12 .
-- docker run -d -p 127.0.0.1:27017:27017 mongo/2.6.12 /bin/sh -c "mongod"
+- docker run -d -p 27017:27017 -v ~/data:/data/db mongo
 - echo "extension = mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 - sleep 15
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 - wget https://raw.githubusercontent.com/docker-library/mongo/0ac2867637ef5989e4dc051efa0ae296010e58c9/2.6/Dockerfile
 - wget https://raw.githubusercontent.com/docker-library/mongo/0ac2867637ef5989e4dc051efa0ae296010e58c9/2.6/docker-entrypoint.sh
 - docker build -t mongo/2.6.12 .
-- docker run -d -p 27017:27017 -v ~/data:/data/db mongo:2.6.12
+- docker run -d -p 27017:27017 -v ~/data:/data/db mongo/2.6.12:latest
 - echo "extension = mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 - sleep 15
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ services:
 - docker
 before_install:
 - wget https://raw.githubusercontent.com/docker-library/mongo/0ac2867637ef5989e4dc051efa0ae296010e58c9/2.6/Dockerfile
+- wget https://raw.githubusercontent.com/docker-library/mongo/0ac2867637ef5989e4dc051efa0ae296010e58c9/2.6/docker-entrypoint.sh
 - docker build -t mongo/2.6.12 .
 - docker run -d -p 127.0.0.1:27017:27017 mongo/2.6.12 /bin/sh -c "mongod"
 - echo "extension = mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 - wget https://raw.githubusercontent.com/docker-library/mongo/0ac2867637ef5989e4dc051efa0ae296010e58c9/2.6/Dockerfile
 - wget https://raw.githubusercontent.com/docker-library/mongo/0ac2867637ef5989e4dc051efa0ae296010e58c9/2.6/docker-entrypoint.sh
 - docker build -t mongo/2.6.12 .
-- docker run -d -p 27017:27017 -v ~/data:/data/db mongo
+- docker run -d -p 27017:27017 -v ~/data:/data/db mongo:2.6.12
 - echo "extension = mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 - sleep 15
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,8 @@ services:
 - redis
 - docker
 before_install:
-- wget https://raw.githubusercontent.com/docker-library/mongo/0ac2867637ef5989e4dc051efa0ae296010e58c9/2.6/Dockerfile
-- wget https://raw.githubusercontent.com/docker-library/mongo/0ac2867637ef5989e4dc051efa0ae296010e58c9/2.6/docker-entrypoint.sh
-- chmod 0777 docker-entrypoint.sh
-- docker build -t mongo/2.6.12 .
-- docker run -d -p 27017:27017 -v ~/data:/data/db mongo/2.6.12:latest
+- docker pull rossfsinger/mongo-2.6.12
+- docker run -d -p 27017:27017 -v ~/data:/data/db rossfsinger/mongo-2.6.12:latest
 - echo "extension = mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 - sleep 15
 install:

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         }
     ],
     "require": {
+        "php" : ">=5.4",
         "semsol/arc2": "v2.2.4",
         "chrisboulton/php-resque": "dev-master#98fde571db008a8b48e73022599d1d1c07d4a7b5",
         "monolog/monolog" : "~1.13",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "semsol/arc2": "v2.2.4",
         "chrisboulton/php-resque": "dev-master#98fde571db008a8b48e73022599d1d1c07d4a7b5",
         "monolog/monolog" : "~1.13",
-        "mongodb/mongodb": "^1.0.0"
+        "mongodb/mongodb": "1.0.4"
     },
     "require-dev": {
         "phpunit/phpunit": "4.1.*"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,4 @@
+mongo:
+  image: mongo/2.6.12:latest
+  ports:
+      - "27017:27017"

--- a/src/mongo/Config.class.php
+++ b/src/mongo/Config.class.php
@@ -2055,6 +2055,19 @@ class Config
     }
 
     /**
+     * @param string $storeName
+     * @param string $readPreference
+     * @return Collection
+     */
+    public function getCollectionForJobGroups($storeName, $readPreference = ReadPreference::RP_PRIMARY_PREFERRED)
+    {
+        return $this->getMongoCollection(
+            $this->getDatabase($storeName, $this->dbConfig[$storeName]['data_source'], $readPreference),
+            OPERATION_GROUPS_COLLECTION
+        );
+    }
+
+    /**
      * @param $readPreference
      * @return Database
      * @throws \Tripod\Exceptions\ConfigException

--- a/src/mongo/JobGroup.php
+++ b/src/mongo/JobGroup.php
@@ -8,6 +8,11 @@ class JobGroup
     private $collection;
     private $storeName;
 
+    /**
+     * Constructor method
+     * @param string                        $storeName Tripod store (database) name
+     * @param string|\MongoDB\BSON\ObjectId $groupId   Optional tracking ID, will assign a new one if omitted
+     */
     public function __construct($storeName, $groupId = null)
     {
         $this->storeName = $storeName;
@@ -19,6 +24,12 @@ class JobGroup
         $this->id = $groupId;
     }
 
+    /**
+     * Update the number of jobs
+     *
+     * @param integer $count Number of jobs in group
+     * @return void
+     */
     public function setJobCount($count)
     {
         $this->getMongoCollection()->updateOne(
@@ -28,6 +39,12 @@ class JobGroup
         );
     }
 
+    /**
+     * Update the number of jobs by $inc.  To decrement, use a negative integer
+     *
+     * @param integer $inc Number to increment or decrement by
+     * @return integer Updated job count
+     */
     public function incrementJobCount($inc = 1)
     {
         $updateResult = $this->getMongoCollection()->findOneAndUpdate(

--- a/src/mongo/JobGroup.php
+++ b/src/mongo/JobGroup.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tripod\Mongo;
+
+class JobGroup
+{
+    private $id;
+    private $collection;
+    private $storeName;
+
+    public function __construct($storeName, $groupId = null)
+    {
+        $this->storeName = $storeName;
+        if (!$groupId) {
+            $groupId = new \MongoDB\BSON\ObjectId();
+        } elseif (!$groupId instanceof \MongoDB\BSON\ObjectId) {
+            $groupId = new \MongoDB\BSON\ObjectId($groupId);
+        }
+        $this->id = $groupId;
+    }
+
+    public function setJobCount($count)
+    {
+        $this->getMongoCollection()->updateOne(
+            ['_id' => $this->id],
+            ['$set' => ['count' => $count]],
+            ['upsert' => true]
+        );
+    }
+
+    public function incrementJobCount($inc = 1)
+    {
+        $updateResult = $this->getMongoCollection()->findOneAndUpdate(
+            ['_id' => $this->id],
+            ['$inc' => ['count' => $inc]],
+            ['upsert' => true, 'returnDocument' => MongoDB\Operation\FindOneAndUpdate::RETURN_DOCUMENT_AFTER]
+        );
+        return $updateResult['count'];
+    }
+
+    /**
+     * @return \MongoDB\BSON\ObjectId
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * For mocking
+     *
+     * @return \MongoDB\Collection
+     */
+    protected function getMongoCollection()
+    {
+        if (!isset($this->collection)) {
+            $config = Config::getInstance();
+
+            $this->collection = $config->getCollectionForJobGroups($this->storeName);
+        }
+        return $this->collection;
+    }
+}

--- a/src/mongo/JobGroup.php
+++ b/src/mongo/JobGroup.php
@@ -35,7 +35,9 @@ class JobGroup
             ['$inc' => ['count' => $inc]],
             ['upsert' => true, 'returnDocument' => \MongoDB\Operation\FindOneAndUpdate::RETURN_DOCUMENT_AFTER]
         );
-        return $updateResult['count'];
+        if (\is_array($updateResult)) {
+            return $updateResult['count'];
+        }
     }
 
     /**

--- a/src/mongo/JobGroup.php
+++ b/src/mongo/JobGroup.php
@@ -2,6 +2,8 @@
 
 namespace Tripod\Mongo;
 
+use \MongoDB\BSON\ObjectId;
+
 class JobGroup
 {
     private $id;
@@ -11,15 +13,15 @@ class JobGroup
     /**
      * Constructor method
      * @param string                        $storeName Tripod store (database) name
-     * @param string|\MongoDB\BSON\ObjectId $groupId   Optional tracking ID, will assign a new one if omitted
+     * @param string|ObjectId $groupId   Optional tracking ID, will assign a new one if omitted
      */
     public function __construct($storeName, $groupId = null)
     {
         $this->storeName = $storeName;
         if (!$groupId) {
-            $groupId = new \MongoDB\BSON\ObjectId();
-        } elseif (!$groupId instanceof \MongoDB\BSON\ObjectId) {
-            $groupId = new \MongoDB\BSON\ObjectId($groupId);
+            $groupId = new ObjectId();
+        } elseif (!$groupId instanceof ObjectId) {
+            $groupId = new ObjectId($groupId);
         }
         $this->id = $groupId;
     }
@@ -60,7 +62,7 @@ class JobGroup
     }
 
     /**
-     * @return \MongoDB\BSON\ObjectId
+     * @return ObjectId
      */
     public function getId()
     {

--- a/src/mongo/JobGroup.php
+++ b/src/mongo/JobGroup.php
@@ -33,7 +33,7 @@ class JobGroup
         $updateResult = $this->getMongoCollection()->findOneAndUpdate(
             ['_id' => $this->id],
             ['$inc' => ['count' => $inc]],
-            ['upsert' => true, 'returnDocument' => MongoDB\Operation\FindOneAndUpdate::RETURN_DOCUMENT_AFTER]
+            ['upsert' => true, 'returnDocument' => \MongoDB\Operation\FindOneAndUpdate::RETURN_DOCUMENT_AFTER]
         );
         return $updateResult['count'];
     }

--- a/src/mongo/JobGroup.php
+++ b/src/mongo/JobGroup.php
@@ -22,7 +22,7 @@ class JobGroup
     public function setJobCount($count)
     {
         $this->getMongoCollection()->updateOne(
-            ['_id' => $this->id],
+            ['_id' => $this->getId()],
             ['$set' => ['count' => $count]],
             ['upsert' => true]
         );
@@ -31,7 +31,7 @@ class JobGroup
     public function incrementJobCount($inc = 1)
     {
         $updateResult = $this->getMongoCollection()->findOneAndUpdate(
-            ['_id' => $this->id],
+            ['_id' => $this->getId()],
             ['$inc' => ['count' => $inc]],
             ['upsert' => true, 'returnDocument' => \MongoDB\Operation\FindOneAndUpdate::RETURN_DOCUMENT_AFTER]
         );

--- a/src/mongo/JobGroup.php
+++ b/src/mongo/JobGroup.php
@@ -37,6 +37,8 @@ class JobGroup
         );
         if (\is_array($updateResult)) {
             return $updateResult['count'];
+        } elseif (isset($updateResult->count)) {
+            return $updateResult->count;
         }
     }
 

--- a/src/mongo/MongoTripodConstants.php
+++ b/src/mongo/MongoTripodConstants.php
@@ -98,8 +98,6 @@ define('SUBJECT_COUNT', 'subject_count');
 define('STAT_CLASS', 'tripod');
 define('STAT_PIVOT_FIELD', 'group_by_db');
 
-define('BATCH_TRACKING_GROUP', 'BATCH_TRACKING_GROUP');
-
 //Audit types, statuses
 define('AUDIT_TYPE_REMOVE_INERT_LOCKS', 'REMOVE_INERT_LOCKS');
 define('AUDIT_STATUS_IN_PROGRESS', 'IN_PROGRESS');

--- a/src/mongo/MongoTripodConstants.php
+++ b/src/mongo/MongoTripodConstants.php
@@ -6,7 +6,7 @@ define('TABLE_ROWS_COLLECTION', 'table_rows');
 define('VIEWS_COLLECTION', 'views');
 define('LOCKS_COLLECTION', 'locks');
 define('AUDIT_MANUAL_ROLLBACKS_COLLECTION','audit_manual_rollbacks');
-define('OPERATION_GROUP_COLLECTION', 'job_groups');
+define('OPERATION_GROUPS_COLLECTION', 'job_groups');
 
 // search
 define('SEARCH_INDEX_COLLECTION', 'search');

--- a/src/mongo/MongoTripodConstants.php
+++ b/src/mongo/MongoTripodConstants.php
@@ -6,6 +6,7 @@ define('TABLE_ROWS_COLLECTION', 'table_rows');
 define('VIEWS_COLLECTION', 'views');
 define('LOCKS_COLLECTION', 'locks');
 define('AUDIT_MANUAL_ROLLBACKS_COLLECTION','audit_manual_rollbacks');
+define('OPERATION_GROUP_COLLECTION', 'job_groups');
 
 // search
 define('SEARCH_INDEX_COLLECTION', 'search');

--- a/src/mongo/MongoTripodConstants.php
+++ b/src/mongo/MongoTripodConstants.php
@@ -97,6 +97,8 @@ define('SUBJECT_COUNT', 'subject_count');
 define('STAT_CLASS', 'tripod');
 define('STAT_PIVOT_FIELD', 'group_by_db');
 
+define('BATCH_TRACKING_GROUP', 'BATCH_TRACKING_GROUP');
+
 //Audit types, statuses
 define('AUDIT_TYPE_REMOVE_INERT_LOCKS', 'REMOVE_INERT_LOCKS');
 define('AUDIT_STATUS_IN_PROGRESS', 'IN_PROGRESS');

--- a/src/mongo/delegates/SearchDocuments.class.php
+++ b/src/mongo/delegates/SearchDocuments.class.php
@@ -111,7 +111,7 @@ class SearchDocuments extends DriverBase
         $this->debugLog("Processing {$specId}");
 
         // build the document
-        $generatedDocument = array();
+        $generatedDocument = [\_CREATED_TS => new \MongoDB\BSON\UTCDateTime()];
         $this->addIdToImpactIndex($_id, $generatedDocument);
 
         $_id['type'] = $specId;

--- a/src/mongo/delegates/SearchDocuments.class.php
+++ b/src/mongo/delegates/SearchDocuments.class.php
@@ -111,7 +111,7 @@ class SearchDocuments extends DriverBase
         $this->debugLog("Processing {$specId}");
 
         // build the document
-        $generatedDocument = [\_CREATED_TS => \Tripod\Mongo\DateUtil::getMongoDate()];
+        $generatedDocument = [\_CREATED_TS => DateUtil::getMongoDate()];
         $this->addIdToImpactIndex($_id, $generatedDocument);
 
         $_id['type'] = $specId;

--- a/src/mongo/delegates/SearchDocuments.class.php
+++ b/src/mongo/delegates/SearchDocuments.class.php
@@ -111,7 +111,7 @@ class SearchDocuments extends DriverBase
         $this->debugLog("Processing {$specId}");
 
         // build the document
-        $generatedDocument = [\_CREATED_TS => new \MongoDB\BSON\UTCDateTime()];
+        $generatedDocument = [\_CREATED_TS => \Tripod\Mongo\DateUtil::getMongoDate()];
         $this->addIdToImpactIndex($_id, $generatedDocument);
 
         $_id['type'] = $specId;

--- a/src/mongo/delegates/SearchIndexer.class.php
+++ b/src/mongo/delegates/SearchIndexer.class.php
@@ -168,6 +168,7 @@ class SearchIndexer extends CompositeBase
      * @param string|null $resourceUri
      * @param string|null $context
      * @param string|null $queueName
+     * @return array|null Will return an array with a count and group id, if $queueName is sent and $resourceUri is null
      */
     public function generateSearchDocuments($searchDocumentType, $resourceUri=null, $context=null, $queueName=null)
     {
@@ -213,7 +214,7 @@ class SearchIndexer extends CompositeBase
         ));
 
         $jobOptions = [];
-        if ($queueName && !$resource) {
+        if ($queueName && !$resourceUri) {
             $jobOptions['statsConfig'] = $this->getStatsConfig();
             $jobGroup = new JobGroup($this->storeName);
             $jobOptions[ApplyOperation::TRACKING_KEY] = $jobGroup->getId()->__toString();

--- a/src/mongo/delegates/SearchIndexer.class.php
+++ b/src/mongo/delegates/SearchIndexer.class.php
@@ -11,6 +11,7 @@ use Tripod\Mongo\Config;
 use Tripod\Mongo\ImpactedSubject;
 use Tripod\Mongo\Labeller;
 use Tripod\Mongo\Jobs\ApplyOperation;
+use Tripod\Mongo\JobGroup;
 use \MongoDB\Driver\ReadPreference;
 use \MongoDB\Collection;
 

--- a/src/mongo/delegates/Tables.class.php
+++ b/src/mongo/delegates/Tables.class.php
@@ -1441,4 +1441,17 @@ class Tables extends CompositeBase
             throw new \Tripod\Exceptions\Exception("Was expecting either VALUE_URI or VALUE_LITERAL when applying regex to value - possible data corruption with: ".var_export($value,true));
         }
     }
+
+    /**
+     * Count the number of documents in the spec that match $filters
+     *
+     * @param string $tableSpec Table spec ID
+     * @param array  $filters   Query filters to get count on
+     * @return integer
+     */
+    public function count($tableSpec, array $filters = [])
+    {
+        $filters['_id.type'] = $tableSpec;
+        return $this->config->getCollectionForTable($this->storeName, $tableSpec)->count($filters);
+    }
 }

--- a/src/mongo/delegates/Tables.class.php
+++ b/src/mongo/delegates/Tables.class.php
@@ -383,7 +383,7 @@ class Tables extends CompositeBase
                 [\_CREATED_TS => ['$exists' => false]]
             ];
         }
-        $deleteResult = $this->config->getCollectionForTable($this->storeName, $tableId)
+        $deleteResult = $this->getCollectionForTableSpec($tableId)
             ->deleteMany($query);
 
         $t->stop();
@@ -1463,6 +1463,17 @@ class Tables extends CompositeBase
     public function count($tableSpec, array $filters = [])
     {
         $filters['_id.type'] = $tableSpec;
-        return $this->config->getCollectionForTable($this->storeName, $tableSpec)->count($filters);
+        return $this->getCollectionForTableSpec($tableSpec)->count($filters);
+    }
+
+    /**
+     * For mocking
+     *
+     * @param string $tableSpecId Table spec ID
+     * @return \MongoDB\Collection
+     */
+    protected function getCollectionForTableSpec($tableSpecId)
+    {
+        return $this->getConfigInstance()->getCollectionForTable($this->storeName, $tableSpecId);
     }
 }

--- a/src/mongo/delegates/Tables.class.php
+++ b/src/mongo/delegates/Tables.class.php
@@ -373,7 +373,7 @@ class Tables extends CompositeBase
         $query = ['_id.type' => $tableId];
         if ($timestamp) {
             if (!($timestamp instanceof \MongoDB\BSON\UTCDateTime)) {
-                $timestamp = new \MongoDB\BSON\UTCDateTime($timestamp);
+                $timestamp = \Tripod\Mongo\DateUtil::getMongoDate($timestamp);
             }
             $query[\_CREATED_TS] = [
                 '$or' => [
@@ -562,10 +562,10 @@ class Tables extends CompositeBase
                         _ID_CONTEXT => $doc['_id'][_ID_CONTEXT],
                         _ID_TYPE=>$tableSpec['_id']
                     ],
-                    \_CREATED_TS => new \MongoDB\BSON\UTCDateTime()
+                    \_CREATED_TS => \Tripod\Mongo\DateUtil::getMongoDate()
                 ];
                 // everything must go in the value object todo: this is a hang over from map reduce days, engineer out once we have stability on new PHP method for M/R
-                $value = array('_id'=>$doc['_id'], '_cts' => new \MongoDB\BSON\UTCDateTime());
+                $value = ['_id' => $doc['_id']];
                 $this->addIdToImpactIndex($doc['_id'], $value); // need to add the doc to the impact index to be consistent with views/search etc. this is needed for discovering impacted operations
                 $this->addFields($doc,$tableSpec,$value);
                 if (isset($tableSpec['joins'])) {

--- a/src/mongo/delegates/Tables.class.php
+++ b/src/mongo/delegates/Tables.class.php
@@ -5,9 +5,10 @@ namespace Tripod\Mongo\Composites;
 require_once TRIPOD_DIR . 'mongo/MongoTripodConstants.php';
 require_once TRIPOD_DIR . 'mongo/base/DriverBase.class.php';
 
-use Tripod\Mongo\Config;
-use Tripod\Mongo\ImpactedSubject;
-use Tripod\Mongo\Labeller;
+use \Tripod\Mongo\Jobs\ApplyOperation;
+use \Tripod\Mongo\Config;
+use \Tripod\Mongo\ImpactedSubject;
+use \Tripod\Mongo\Labeller;
 use \MongoDB\Driver\ReadPreference;
 use \MongoDB\Collection;
 

--- a/src/mongo/delegates/Tables.class.php
+++ b/src/mongo/delegates/Tables.class.php
@@ -9,6 +9,7 @@ use \Tripod\Mongo\Jobs\ApplyOperation;
 use \Tripod\Mongo\Config;
 use \Tripod\Mongo\ImpactedSubject;
 use \Tripod\Mongo\Labeller;
+use \Tripod\Mongo\JobGroup;
 use \MongoDB\Driver\ReadPreference;
 use \MongoDB\Collection;
 

--- a/src/mongo/delegates/Tables.class.php
+++ b/src/mongo/delegates/Tables.class.php
@@ -375,11 +375,9 @@ class Tables extends CompositeBase
             if (!($timestamp instanceof \MongoDB\BSON\UTCDateTime)) {
                 $timestamp = \Tripod\Mongo\DateUtil::getMongoDate($timestamp);
             }
-            $query[\_CREATED_TS] = [
-                '$or' => [
-                    ['$lt' => $timestamp],
-                    ['$exists' => false]
-                ]
+            $query['$or'] = [
+                [\_CREATED_TS => ['$lt' => $timestamp]],
+                [\_CREATED_TS => ['$exists' => false]]
             ];
         }
         $this->config->getCollectionForTable($this->storeName, $tableId)

--- a/src/mongo/delegates/Tables.class.php
+++ b/src/mongo/delegates/Tables.class.php
@@ -545,7 +545,7 @@ class Tables extends CompositeBase
             $jobOptions['statsConfig'] = $this->getStatsConfig();
             $jobGroup = new JobGroup($this->storeName);
             $jobOptions[ApplyOperation::TRACKING_KEY] = $jobGroup->getId()->__toString();
-            $jobGroup->setJobCount($count);;
+            $jobGroup->setJobCount($count);
         }
 
         foreach ($docs as $doc) {
@@ -557,10 +557,6 @@ class Tables extends CompositeBase
                     $from,
                     array($tableType)
                 );
-                if (empty($jobOptions))
-                if ($this->stat || !empty($this->statsConfig)) {
-                    $jobOptions['statsConfig'] = $this->getStatsConfig();
-                }
 
                 $this->getApplyOperation()->createJob(array($subject), $queueName, $jobOptions);
             } else {

--- a/src/mongo/delegates/Views.class.php
+++ b/src/mongo/delegates/Views.class.php
@@ -813,4 +813,16 @@ class Views extends CompositeBase
         return $this->getConfigInstance()->getCollectionForView($this->storeName, $viewSpecId);
     }
 
+    /**
+     * Count the number of documents in the spec that match $filters
+     *
+     * @param string $viewSpec View spec ID
+     * @param array  $filters  Query filters to get count on
+     * @return integer
+     */
+    public function count($viewSpec, array $filters = [])
+    {
+        $filters['_id.type'] = $viewSpec;
+        return $this->getCollectionForViewSpec($viewSpec)->count($filters);
+    }
 }

--- a/src/mongo/delegates/Views.class.php
+++ b/src/mongo/delegates/Views.class.php
@@ -378,7 +378,7 @@ class Views extends CompositeBase
         $query = ['_id.type' => $viewId];
         if ($timestamp) {
             if (!($timestamp instanceof \MongoDB\BSON\UTCDateTime)) {
-                $timestamp = new \MongoDB\BSON\UTCDateTime($timestamp);
+                $timestamp = \Tripod\Mongo\DateUtil::getMongoDate($timestamp);
             }
             $query[\_CREATED_TS] = [
                 '$or' => [
@@ -462,7 +462,7 @@ class Views extends CompositeBase
                             _ID_CONTEXT => $doc['_id'][_ID_CONTEXT],
                             _ID_TYPE=>$viewSpec['_id']
                         ],
-                        \_CREATED_TS => new \MongoDB\BSON\UTCDateTime()
+                        \_CREATED_TS => \Tripod\Mongo\DateUtil::getMongoDate()
                     ];
                     $value = array(); // everything must go in the value object todo: this is a hang over from map reduce days, engineer out once we have stability on new PHP method for M/R
 

--- a/src/mongo/delegates/Views.class.php
+++ b/src/mongo/delegates/Views.class.php
@@ -388,7 +388,7 @@ class Views extends CompositeBase
                 [\_CREATED_TS => ['$exists' => false]]
             ];
         }
-        $deleteResult = $this->config->getCollectionForView($this->storeName, $viewId)
+        $deleteResult = $this->getCollectionForViewSpec($viewId)
             ->deleteMany($query);
         return $deleteResult->getDeletedCount();
     }

--- a/src/mongo/delegates/Views.class.php
+++ b/src/mongo/delegates/Views.class.php
@@ -483,7 +483,7 @@ class Views extends CompositeBase
 
                     $generatedView['value'] = $value;
 
-                    $collection->replaceOne($generatedView['_id'], $generatedView, ['upsert' => true]);
+                    $collection->replaceOne(['_id' => $generatedView['_id']], $generatedView, ['upsert' => true]);
                 }
             }
 

--- a/src/mongo/delegates/Views.class.php
+++ b/src/mongo/delegates/Views.class.php
@@ -380,11 +380,9 @@ class Views extends CompositeBase
             if (!($timestamp instanceof \MongoDB\BSON\UTCDateTime)) {
                 $timestamp = \Tripod\Mongo\DateUtil::getMongoDate($timestamp);
             }
-            $query[\_CREATED_TS] = [
-                '$or' => [
-                    ['$lt' => $timestamp],
-                    ['$exists' => false]
-                ]
+            $query['$or'] = [
+                [\_CREATED_TS => ['$lt' => $timestamp]],
+                [\_CREATED_TS => ['$exists' => false]]
             ];
         }
         $this->config->getCollectionForView($this->storeName, $viewId)

--- a/src/mongo/delegates/Views.class.php
+++ b/src/mongo/delegates/Views.class.php
@@ -4,12 +4,12 @@ namespace Tripod\Mongo\Composites;
 
 require_once TRIPOD_DIR . 'mongo/base/DriverBase.class.php';
 
-use Tripod\Mongo\Config;
-use Tripod\Mongo\ImpactedSubject;
-use Tripod\Mongo\Labeller;
+use \Tripod\Mongo\Jobs\ApplyOperation;
+use \Tripod\Mongo\Config;
+use \Tripod\Mongo\ImpactedSubject;
+use \Tripod\Mongo\Labeller;
 use \MongoDB\Driver\ReadPreference;
 use \MongoDB\Collection;
-use Tripod\Mongo\Jobs\ApplyOperation;
 
 /**
  * Class Views

--- a/src/mongo/delegates/Views.class.php
+++ b/src/mongo/delegates/Views.class.php
@@ -9,6 +9,7 @@ use Tripod\Mongo\ImpactedSubject;
 use Tripod\Mongo\Labeller;
 use \MongoDB\Driver\ReadPreference;
 use \MongoDB\Collection;
+use Tripod\Mongo\Jobs\ApplyOperation;
 
 /**
  * Class Views
@@ -405,94 +406,101 @@ class Views extends CompositeBase
         if ($viewSpec == null) {
             $this->debugLog("Could not find a view specification for $resource with viewId '$viewId'");
             return null;
-        } else {
-            $t = new \Tripod\Timer();
-            $t->start();
-
-            $from = $this->getFromCollectionForViewSpec($viewSpec);
-            $collection = $this->config->getCollectionForView($this->storeName, $viewId);
-
-            if (!isset($viewSpec['joins'])) {
-                throw new \Tripod\Exceptions\ViewException('Could not find any joins in view specification - usecase better served with select()');
-            }
-
-            $types = array(); // this is used to filter the CBD table to speed up the view creation
-            if (is_array($viewSpec["type"])) {
-                foreach ($viewSpec["type"] as $type) {
-                    $types[] = array("rdf:type.u"=>$this->labeller->qname_to_alias($type));
-                    $types[] = array("rdf:type.u"=>$this->labeller->uri_to_alias($type));
-                }
-            } else {
-                $types[] = array("rdf:type.u"=>$this->labeller->qname_to_alias($viewSpec["type"]));
-                $types[] = array("rdf:type.u"=>$this->labeller->uri_to_alias($viewSpec["type"]));
-            }
-            $filter = array('$or'=> $types);
-            if (isset($resource)) {
-                $resourceAlias = $this->labeller->uri_to_alias($resource);
-                $filter["_id"] = array(_ID_RESOURCE=>$resourceAlias,_ID_CONTEXT=>$contextAlias);
-            }
-
-            $docs = $this->config->getCollectionForCBD($this->storeName, $from)->find($filter, array(
-                'maxTimeMS' => \Tripod\Mongo\Config::getInstance()->getMongoCursorTimeout()
-            ));
-
-            foreach ($docs as $doc) {
-                if ($queueName && !$resource) {
-                    $subject = new ImpactedSubject(
-                        $doc['_id'],
-                        OP_VIEWS,
-                        $this->storeName,
-                        $from,
-                        array($viewId)
-                    );
-
-                    $jobOptions = array();
-                    if ($this->stat || !empty($this->statsConfig)) {
-                        $jobOptions['statsConfig'] = $this->getStatsConfig();
-                    }
-
-                    $this->getApplyOperation()->createJob(array($subject), $queueName, $jobOptions);
-                } else {
-                    // Set up view meta information
-                    $generatedView = [
-                        '_id' => [
-                            _ID_RESOURCE => $doc['_id'][_ID_RESOURCE],
-                            _ID_CONTEXT => $doc['_id'][_ID_CONTEXT],
-                            _ID_TYPE=>$viewSpec['_id']
-                        ],
-                        \_CREATED_TS => \Tripod\Mongo\DateUtil::getMongoDate()
-                    ];
-                    $value = array(); // everything must go in the value object todo: this is a hang over from map reduce days, engineer out once we have stability on new PHP method for M/R
-
-                    $value[_GRAPHS] = array();
-
-                    $buildImpactIndex=true;
-                    if (isset($viewSpec['ttl'])) {
-                        $buildImpactIndex=false;
-                        $value[_EXPIRES] = \Tripod\Mongo\DateUtil::getMongoDate($this->getExpirySecFromNow($viewSpec['ttl']) * 1000);
-                    } else {
-                        $value[_IMPACT_INDEX] = array($doc['_id']);
-                    }
-
-                    $this->doJoins($doc,$viewSpec['joins'],$value,$from,$contextAlias,$buildImpactIndex);
-
-                    // add top level properties
-                    $value[_GRAPHS][] = $this->extractProperties($doc,$viewSpec,$from);
-
-                    $generatedView['value'] = $value;
-
-                    $collection->replaceOne(['_id' => $generatedView['_id']], $generatedView, ['upsert' => true]);
-                }
-            }
-
-            $t->stop();
-            $this->timingLog(MONGO_CREATE_VIEW, array(
-                'view'=>$viewSpec['type'],
-                'duration'=>$t->result(),
-                'filter'=>$filter,
-                'from'=>$from));
-            $this->getStat()->timer(MONGO_CREATE_VIEW.".$viewId",$t->result());
         }
+        $t = new \Tripod\Timer();
+        $t->start();
+
+        $from = $this->getFromCollectionForViewSpec($viewSpec);
+        $collection = $this->config->getCollectionForView($this->storeName, $viewId);
+
+        if (!isset($viewSpec['joins'])) {
+            throw new \Tripod\Exceptions\ViewException('Could not find any joins in view specification - usecase better served with select()');
+        }
+
+        $types = array(); // this is used to filter the CBD table to speed up the view creation
+        if (is_array($viewSpec["type"])) {
+            foreach ($viewSpec["type"] as $type) {
+                $types[] = array("rdf:type.u"=>$this->labeller->qname_to_alias($type));
+                $types[] = array("rdf:type.u"=>$this->labeller->uri_to_alias($type));
+            }
+        } else {
+            $types[] = array("rdf:type.u"=>$this->labeller->qname_to_alias($viewSpec["type"]));
+            $types[] = array("rdf:type.u"=>$this->labeller->uri_to_alias($viewSpec["type"]));
+        }
+        $filter = array('$or'=> $types);
+        if (isset($resource)) {
+            $resourceAlias = $this->labeller->uri_to_alias($resource);
+            $filter["_id"] = array(_ID_RESOURCE=>$resourceAlias,_ID_CONTEXT=>$contextAlias);
+        }
+
+        $docs = $this->config->getCollectionForCBD($this->storeName, $from)->find($filter, array(
+            'maxTimeMS' => \Tripod\Mongo\Config::getInstance()->getMongoCursorTimeout()
+        ));
+
+        $jobOptions = [];
+        if ($queueName && !$resource && ($this->stat || !empty($this->statsConfig))) {
+            $jobOptions['statsConfig'] = $this->getStatsConfig();
+            $jobOptions[ApplyOperation::TRACKING_KEY] = \uniqid();
+        }
+        $count = 0;
+        foreach ($docs as $doc) {
+            $count++;
+            if ($queueName && !$resource) {
+                $subject = new ImpactedSubject(
+                    $doc['_id'],
+                    OP_VIEWS,
+                    $this->storeName,
+                    $from,
+                    array($viewId)
+                );
+
+                $this->getApplyOperation()->createJob(array($subject), $queueName, $jobOptions);
+            } else {
+                // Set up view meta information
+                $generatedView = [
+                    '_id' => [
+                        _ID_RESOURCE => $doc['_id'][_ID_RESOURCE],
+                        _ID_CONTEXT => $doc['_id'][_ID_CONTEXT],
+                        _ID_TYPE=>$viewSpec['_id']
+                    ],
+                    \_CREATED_TS => \Tripod\Mongo\DateUtil::getMongoDate()
+                ];
+                $value = array(); // everything must go in the value object todo: this is a hang over from map reduce days, engineer out once we have stability on new PHP method for M/R
+
+                $value[_GRAPHS] = array();
+
+                $buildImpactIndex=true;
+                if (isset($viewSpec['ttl'])) {
+                    $buildImpactIndex=false;
+                    $value[_EXPIRES] = \Tripod\Mongo\DateUtil::getMongoDate($this->getExpirySecFromNow($viewSpec['ttl']) * 1000);
+                } else {
+                    $value[_IMPACT_INDEX] = array($doc['_id']);
+                }
+
+                $this->doJoins($doc,$viewSpec['joins'],$value,$from,$contextAlias,$buildImpactIndex);
+
+                // add top level properties
+                $value[_GRAPHS][] = $this->extractProperties($doc,$viewSpec,$from);
+
+                $generatedView['value'] = $value;
+
+                $collection->replaceOne(['_id' => $generatedView['_id']], $generatedView, ['upsert' => true]);
+            }
+        }
+
+        $t->stop();
+        $this->timingLog(MONGO_CREATE_VIEW, array(
+            'view'=>$viewSpec['type'],
+            'duration'=>$t->result(),
+            'filter'=>$filter,
+            'from'=>$from));
+        $this->getStat()->timer(MONGO_CREATE_VIEW.".$viewId",$t->result());
+
+        $stat = ['count' => $count];
+        if (isset($jobOptions[ApplyOperation::TRACKING_KEY])) {
+            $stat[ApplyOperation::TRACKING_KEY] = $jobOptions[ApplyOperation::TRACKING_KEY];
+        }
+        return $stat;
     }
 
     /**

--- a/src/mongo/delegates/Views.class.php
+++ b/src/mongo/delegates/Views.class.php
@@ -483,7 +483,7 @@ class Views extends CompositeBase
 
                     $generatedView['value'] = $value;
 
-                    $collection->replaceOne($id, $generatedView, ['upsert' => true]);
+                    $collection->replaceOne($generatedView['_id'], $generatedView, ['upsert' => true]);
                 }
             }
 

--- a/src/mongo/jobs/ApplyOperation.class.php
+++ b/src/mongo/jobs/ApplyOperation.class.php
@@ -57,7 +57,7 @@ class ApplyOperation extends JobBase {
             $this->getStat()->timer(MONGO_QUEUE_APPLY_OPERATION_SUCCESS,$timer->result());
 
             if (isset($this->args[self::TRACKING_KEY])) {
-                $jobGroup = new JobGroup($this->args[self::TRACKING_KEY]);
+                $jobGroup = new JobGroup($this->args['storeName'], $this->args[self::TRACKING_KEY]);
                 $jobCount = $jobGroup->incrementJobCount(-1);
                 if ($jobCount <= 0) {
                     // @todo Replace this with ObjectId->getTimestamp() if we upgrade Mongo driver to 1.2

--- a/src/mongo/jobs/ApplyOperation.class.php
+++ b/src/mongo/jobs/ApplyOperation.class.php
@@ -74,7 +74,7 @@ class ApplyOperation extends JobBase {
                         }
                         $this->infoLog(
                             '[JobGroupId ' . $jobGroup->getId()->__toString() . '] composite cleanup for ' .
-                            $this->args['operation'] . ' removed ' . $count . ' stale composite documents'
+                            $subject['operation'] . ' removed ' . $count . ' stale composite documents'
                         );
                     }
                 }

--- a/src/mongo/jobs/ApplyOperation.class.php
+++ b/src/mongo/jobs/ApplyOperation.class.php
@@ -56,7 +56,7 @@ class ApplyOperation extends JobBase {
 
             if (isset($this->args[self::TRACKING_KEY])) {
                 $this->getStat()->increment(
-                    \MONGO_QUEUE_APPLY_OPERATION . '.' . $subject['operation'] . '.' . $this->args[self::TRACKING_KEY]
+                    BATCH_TRACKING_GROUP . '.' . $subject['operation'] . '.' . $this->args[self::TRACKING_KEY]
                 );
             }
 

--- a/src/mongo/jobs/ApplyOperation.class.php
+++ b/src/mongo/jobs/ApplyOperation.class.php
@@ -51,6 +51,12 @@ class ApplyOperation extends JobBase {
                 // stat time taken to perform operation for the given subject
                 $this->getStat()->timer(MONGO_QUEUE_APPLY_OPERATION.'.'.$subject['operation'], $opTimer->result());
 
+                /**
+                 * ApplyOperation jobs can either apply to a single resource (e.g. 'create composite for the given
+                 * resource uri) or for a specification id (i.e. regenerate all of the composites defined by the
+                 * specification).  For the latter, we need to keep track of how many jobs have run so we can clean
+                 * up any stale composite documents when completed.  The TRACKING_KEY value will be the JobGroup id.
+                 */
                 if (isset($this->args[self::TRACKING_KEY])) {
                     $jobGroup = $this->getJobGroup($subject['storeName'], $this->args[self::TRACKING_KEY]);
                     $jobCount = $jobGroup->incrementJobCount(-1);

--- a/src/mongo/providers/MongoSearchProvider.class.php
+++ b/src/mongo/providers/MongoSearchProvider.class.php
@@ -372,4 +372,17 @@ class MongoSearchProvider implements \Tripod\ISearchProvider
     {
         return Config::getInstance()->getSearchDocumentSpecification($this->storeName, $typeId);
     }
+
+    /**
+     * Count the number of documents in the spec that match $filters
+     *
+     * @param string $searchSpec Search spec ID
+     * @param array  $filters    Query filters to get count on
+     * @return integer
+     */
+    public function count($searchSpec, array $filters = [])
+    {
+        $filters['_id.type'] = $searchSpec;
+        return $this->config->getCollectionForSearchDocument($this->storeName, $searchSpec)->count($filters);
+    }
 }

--- a/src/mongo/providers/MongoSearchProvider.class.php
+++ b/src/mongo/providers/MongoSearchProvider.class.php
@@ -357,7 +357,7 @@ class MongoSearchProvider implements \Tripod\ISearchProvider
                 [\_CREATED_TS => ['$exists' => false]]
             ];
         }
-        $deleteResponse = $this->config->getCollectionForSearchDocument($this->storeName, $typeId)
+        $deleteResponse = $this->getCollectionForSearchSpec($typeId)
             ->deleteMany($query);
         return $deleteResponse->getDeletedCount();
     }
@@ -382,6 +382,17 @@ class MongoSearchProvider implements \Tripod\ISearchProvider
     public function count($searchSpec, array $filters = [])
     {
         $filters['_id.type'] = $searchSpec;
-        return $this->config->getCollectionForSearchDocument($this->storeName, $searchSpec)->count($filters);
+        return $this->getCollectionForSearchSpec($searchSpec)->count($filters);
+    }
+
+    /**
+     * For mocking
+     *
+     * @param string $searchSpecId Search spec ID
+     * @return \MongoDB\Collection
+     */
+    protected function getCollectionForSearchSpec($searchSpecId)
+    {
+        return $this->config->getCollectionForSearchDocument($this->storeName, $searchSpecId);
     }
 }

--- a/src/mongo/providers/MongoSearchProvider.class.php
+++ b/src/mongo/providers/MongoSearchProvider.class.php
@@ -352,11 +352,9 @@ class MongoSearchProvider implements \Tripod\ISearchProvider
             if (!($timestamp instanceof \MongoDB\BSON\UTCDateTime)) {
                 $timestamp = new \MongoDB\BSON\UTCDateTime($timestamp);
             }
-            $query[\_CREATED_TS] = [
-                '$or' => [
-                    ['$lt' => $timestamp],
-                    ['$exists' => false]
-                ]
+            $query['$or'] = [
+                [\_CREATED_TS => ['$lt' => $timestamp]],
+                [\_CREATED_TS => ['$exists' => false]]
             ];
         }
         return $this->config->getCollectionForSearchDocument($this->storeName, $typeId)

--- a/src/mongo/providers/MongoSearchProvider.class.php
+++ b/src/mongo/providers/MongoSearchProvider.class.php
@@ -338,7 +338,7 @@ class MongoSearchProvider implements \Tripod\ISearchProvider
      * If type id is not specified this method will throw an exception.
      * @param string                         $typeId    Search type id
      * @param \MongoDB\BSON\UTCDateTime|null $timestamp Optional timestamp to delete all search docs that are older than
-     * @return integer                                  The number of search documnts deleted
+     * @return integer                                  The number of search documents deleted
      * @throws \Tripod\Exceptions\Exception if there was an error performing the operation
      */
     public function deleteSearchDocumentsByTypeId($typeId, $timestamp = null)

--- a/src/mongo/providers/MongoSearchProvider.class.php
+++ b/src/mongo/providers/MongoSearchProvider.class.php
@@ -338,7 +338,7 @@ class MongoSearchProvider implements \Tripod\ISearchProvider
      * If type id is not specified this method will throw an exception.
      * @param string                         $typeId    Search type id
      * @param \MongoDB\BSON\UTCDateTime|null $timestamp Optional timestamp to delete all search docs that are older than
-     * @return bool|array  response returned by mongo
+     * @return integer                                  The number of search documnts deleted
      * @throws \Tripod\Exceptions\Exception if there was an error performing the operation
      */
     public function deleteSearchDocumentsByTypeId($typeId, $timestamp = null)
@@ -357,8 +357,9 @@ class MongoSearchProvider implements \Tripod\ISearchProvider
                 [\_CREATED_TS => ['$exists' => false]]
             ];
         }
-        return $this->config->getCollectionForSearchDocument($this->storeName, $typeId)
+        $deleteResponse = $this->config->getCollectionForSearchDocument($this->storeName, $typeId)
             ->deleteMany($query);
+        return $deleteResponse->getDeletedCount();
     }
 
     /**

--- a/src/mongo/util/IndexUtils.class.php
+++ b/src/mongo/util/IndexUtils.class.php
@@ -68,11 +68,12 @@ class IndexUtils
                 $collection = $config->getCollectionForView($storeName, $viewId);
                 if($collection)
                 {
-                    $indexes = array(
-                        array(_ID_KEY.'.'._ID_RESOURCE => 1, _ID_KEY.'.'._ID_CONTEXT => 1, _ID_KEY.'.'._ID_TYPE => 1),
-                        array(_ID_KEY.'.'._ID_TYPE => 1),
-                        array('value.'._IMPACT_INDEX => 1)
-                    );
+                    $indexes = [
+                        [_ID_KEY.'.'._ID_RESOURCE => 1, _ID_KEY.'.'._ID_CONTEXT => 1, _ID_KEY.'.'._ID_TYPE => 1],
+                        [_ID_KEY.'.'._ID_TYPE => 1],
+                        ['value.'._IMPACT_INDEX => 1],
+                        [\_CREATED_TS => 1]
+                    ];
                     if(isset($spec['ensureIndexes']))
                     {
                         $indexes = array_merge($indexes, $spec['ensureIndexes']);
@@ -99,11 +100,12 @@ class IndexUtils
                 $collection = $config->getCollectionForTable($storeName, $tableId);
                 if($collection)
                 {
-                    $indexes = array(
-                        array(_ID_KEY.'.'._ID_RESOURCE => 1, _ID_KEY.'.'._ID_CONTEXT => 1, _ID_KEY.'.'._ID_TYPE => 1),
-                        array(_ID_KEY.'.'._ID_TYPE => 1),
-                        array('value.'._IMPACT_INDEX => 1)
-                    );
+                    $indexes = [
+                        [_ID_KEY.'.'._ID_RESOURCE => 1, _ID_KEY.'.'._ID_CONTEXT => 1, _ID_KEY.'.'._ID_TYPE => 1],
+                        [_ID_KEY.'.'._ID_TYPE => 1],
+                        ['value.'._IMPACT_INDEX => 1],
+                        [\_CREATED_TS => 1]
+                    ];
                     if(isset($spec['ensureIndexes']))
                     {
                         $indexes = array_merge($indexes, $spec['ensureIndexes']);
@@ -130,11 +132,12 @@ class IndexUtils
                 $collection = $config->getCollectionForSearchDocument($storeName, $searchId);
                 if($collection)
                 {
-                    $indexes = array(
-                        array(_ID_KEY.'.'._ID_RESOURCE => 1, _ID_KEY.'.'._ID_CONTEXT => 1),
-                        array(_ID_KEY.'.'._ID_TYPE => 1),
-                        array(_IMPACT_INDEX => 1)
-                    );
+                    $indexes = [
+                        [_ID_KEY.'.'._ID_RESOURCE => 1, _ID_KEY.'.'._ID_CONTEXT => 1],
+                        [_ID_KEY.'.'._ID_TYPE => 1],
+                        [_IMPACT_INDEX => 1],
+                        [\_CREATED_TS => 1]
+                    ];
 
                     if($reindex)
                     {

--- a/src/tripod.inc.php
+++ b/src/tripod.inc.php
@@ -31,6 +31,7 @@ require_once TRIPOD_DIR . 'IDriver.php';
 require_once TRIPOD_DIR.'classes/ChangeSet.class.php';
 require_once TRIPOD_DIR.'classes/Labeller.class.php';
 require_once TRIPOD_DIR . '/mongo/Driver.class.php';
+require_once TRIPOD_DIR . '/mongo/JobGroup.php';
 
 require_once TRIPOD_DIR.'/mongo/base/JobBase.class.php';
 require_once TRIPOD_DIR . '/mongo/jobs/DiscoverImpactedSubjects.class.php';

--- a/test/unit/mongo/ApplyOperationTest.php
+++ b/test/unit/mongo/ApplyOperationTest.php
@@ -275,8 +275,7 @@ class ApplyOperationTest extends MongoTripodTestBase
             ->method('createImpactedSubject')
             ->will($this->returnValue($subject));
 
-        // $applyOperation->expects($this->exactly(3))
-        $applyOperation->expects($this->any())
+        $applyOperation->expects($this->exactly(3))
             ->method('getStat')
             ->will($this->returnValue($statMock));
 

--- a/test/unit/mongo/IndexUtilsTest.php
+++ b/test/unit/mongo/IndexUtilsTest.php
@@ -410,13 +410,14 @@ class IndexUtilsTest extends MongoTripodTestBase
         // params that we know.
         // a) one custom index is created based on the view specification
         // b) three internal indexes are always created
-        $mockCollection->expects($this->exactly(4))
+        $mockCollection->expects($this->exactly(5))
             ->method('createIndex')
             ->withConsecutive(
                 array(array(_ID_KEY.'.'._ID_RESOURCE => 1, _ID_KEY.'.'._ID_CONTEXT => 1, _ID_KEY.'.'._ID_TYPE => 1), array('background'=>$background)),
                 array(array(_ID_KEY.'.'._ID_TYPE => 1), array('background' => $background)),
                 array(array('value.'._IMPACT_INDEX => 1), array('background' => $background)),
-                array(array('rdf:type.u' => 1), array('background' => $background))
+                [['_cts' => 1], ['background' => $background]],
+                [['rdf:type.u' => 1, '_cts' => 1], ['background' => $background]]
             );
     }
 
@@ -430,13 +431,14 @@ class IndexUtilsTest extends MongoTripodTestBase
         // params that we know.
         // a) one custom index is created based on the view specification
         // b) three internal indexes are always created
-        $mockCollection->expects($this->exactly(4))
+        $mockCollection->expects($this->exactly(5))
             ->method('createIndex')
             ->withConsecutive(
                 array(array(_ID_KEY.'.'._ID_RESOURCE => 1, _ID_KEY.'.'._ID_CONTEXT => 1, _ID_KEY.'.'._ID_TYPE => 1), array('background'=>$background)),
                 array(array(_ID_KEY.'.'._ID_TYPE => 1), array('background' => $background)),
                 array(array('value.'._IMPACT_INDEX => 1), array('background' => $background)),
-                array(array('rdf:type.u' => 1), array('background'=>$background))
+                [['_cts' => 1], ['background' => $background]],
+                [['rdf:type.u' => 1], ['background' => $background]]
             );
     }
 
@@ -449,12 +451,13 @@ class IndexUtilsTest extends MongoTripodTestBase
         // create index is called 3 times, each time with a different set of
         // params that we know.
         // for search docs only internal indexes are created
-        $mockCollection->expects($this->exactly(3))
+        $mockCollection->expects($this->exactly(4))
             ->method('createIndex')
             ->withConsecutive(
                 array(array(_ID_KEY.'.'._ID_RESOURCE => 1, _ID_KEY.'.'._ID_CONTEXT => 1), array('background' => $background)),
                 array(array(_ID_KEY.'.'._ID_TYPE => 1), array('background' => $background)),
-                array(array(_IMPACT_INDEX => 1), array('background' => $background))
+                array(array(_IMPACT_INDEX => 1), array('background' => $background)),
+                [['_cts' => 1], ['background' => $background]]
             );
 
     }

--- a/test/unit/mongo/IndexUtilsTest.php
+++ b/test/unit/mongo/IndexUtilsTest.php
@@ -526,7 +526,7 @@ class IndexUtilsTest extends MongoTripodTestBase
                     array(
                         "_id" => "v_testview",
                         "ensureIndexes" => array(
-                            array("rdf:type.u"=>1)
+                            array("rdf:type.u"=>1, '_cts' => 1)
                         ),
                         "from" => "CBD_testing",
                         "type" => "temp:TestType",

--- a/test/unit/mongo/MongoSearchProviderTest.php
+++ b/test/unit/mongo/MongoSearchProviderTest.php
@@ -632,7 +632,7 @@ class MongoSearchProviderTest extends MongoTripodTestBase
            ->setConstructorArgs(['CBD_testing', 'tripod_php_testing'])
             ->getMock();
 
-        $filters = ['_cts' => ['$lte' => new \MongoDB\BSON\UTCDateTime()]];
+        $filters = ['_cts' => ['$lte' => new \MongoDB\BSON\UTCDateTime(null)]];
         $query = array_merge(['_id.type' => 'i_search_list'], $filters);
         $collection = $this->getMockBuilder('\MongoDB\Collection')
             ->disableOriginalConstructor()
@@ -701,7 +701,7 @@ class MongoSearchProviderTest extends MongoTripodTestBase
 
     public function testDeleteSearchDocumentsBySearchIdWithTimestamp()
     {
-        $timestamp = new \MongoDB\BSON\UTCDateTime();
+        $timestamp = new \MongoDB\BSON\UTCDateTime(null);
 
         $query = [
             '_id.type' => 'i_search_list',

--- a/test/unit/mongo/MongoSearchProviderTest.php
+++ b/test/unit/mongo/MongoSearchProviderTest.php
@@ -598,6 +598,160 @@ class MongoSearchProviderTest extends MongoTripodTestBase
     	$this->assertEquals(1, $newSearchDocumentCount, "Should have 1 search documents since there is one search document with 'i_search_list' type that does not match delete type.");
     }
 
+    public function testCountSearchDocuments()
+    {
+        $tripod = $this->getMockBuilder('\Tripod\Mongo\Driver')
+            ->setConstructorArgs(['CBD_testing', 'tripod_php_testing'])
+            ->getMock();
+
+        $collection = $this->getMockBuilder('\MongoDB\Collection')
+            ->disableOriginalConstructor()
+            ->setMethods(['count'])
+            ->getMock();
+        $search = $this->getMockBuilder('\Tripod\Mongo\MongoSearchProvider')
+            ->setMethods(['getCollectionForSearchSpec'])
+            ->setConstructorArgs([$tripod])
+            ->getMock();
+
+        $search->expects($this->once())
+            ->method('getCollectionForSearchSpec')
+            ->with('i_search_list')
+            ->will($this->returnValue($collection));
+
+        $collection->expects($this->once())
+            ->method('count')
+            ->with(['_id.type' => 'i_search_list'])
+            ->will($this->returnValue(21));
+
+        $this->assertEquals(21, $search->count('i_search_list'));
+    }
+
+    public function testCountSearchDocumentsWithFilters()
+    {
+        $tripod = $this->getMockBuilder('\Tripod\Mongo\Driver')
+           ->setConstructorArgs(['CBD_testing', 'tripod_php_testing'])
+            ->getMock();
+
+        $filters = ['_cts' => ['$lte' => new \MongoDB\BSON\UTCDateTime()]];
+        $query = array_merge(['_id.type' => 'i_search_list'], $filters);
+        $collection = $this->getMockBuilder('\MongoDB\Collection')
+            ->disableOriginalConstructor()
+            ->setMethods(['count'])
+            ->getMock();
+        $search = $this->getMockBuilder('\Tripod\Mongo\MongoSearchProvider')
+            ->setMethods(['getCollectionForSearchSpec'])
+            ->setConstructorArgs([$tripod])
+            ->getMock();
+
+        $search->expects($this->once())
+            ->method('getCollectionForSearchSpec')
+            ->with('i_search_list')
+            ->will($this->returnValue($collection));
+
+        $collection->expects($this->once())
+            ->method('count')
+            ->with($query)
+            ->will($this->returnValue(89));
+
+        $this->assertEquals(89, $search->count('i_search_list', $filters));
+    }
+
+    public function testDeleteSearchDocumentsBySearchId()
+    {
+        $tripod = $this->getMockBuilder('\Tripod\Mongo\Driver')
+            ->setConstructorArgs(['CBD_testing', 'tripod_php_testing'])
+            ->getMock();
+
+        $collection = $this->getMockBuilder('\MongoDB\Collection')
+            ->disableOriginalConstructor()
+            ->setMethods(['deleteMany'])
+            ->getMock();
+
+        $deleteResult = $this->getMockBuilder('MongoDB\DeleteResult')
+            ->setMethods(['getDeletedCount'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $deleteResult->expects($this->once())
+            ->method('getDeletedCount')
+            ->will($this->returnValue(9));
+
+        $search = $this->getMockBuilder('\Tripod\Mongo\MongoSearchProvider')
+            ->setMethods(['getCollectionForSearchSpec', 'getSearchDocumentSpecification'])
+            ->setConstructorArgs([$tripod])
+            ->getMock();
+
+        $search->expects($this->once())
+            ->method('getSearchDocumentSpecification')
+            ->with('i_search_list')
+            ->will($this->returnValue(['_id' => 'i_search_list']));
+
+        $search->expects($this->once())
+            ->method('getCollectionForSearchSpec')
+            ->with('i_search_list')
+            ->will($this->returnValue($collection));
+
+        $collection->expects($this->once())
+            ->method('deleteMany')
+            ->with(['_id.type' => 'i_search_list'])
+            ->will($this->returnValue($deleteResult));
+
+        $this->assertEquals(9, $search->deleteSearchDocumentsByTypeId('i_search_list'));
+    }
+
+    public function testDeleteSearchDocumentsBySearchIdWithTimestamp()
+    {
+        $timestamp = new \MongoDB\BSON\UTCDateTime();
+
+        $query = [
+            '_id.type' => 'i_search_list',
+            '$or' => [
+                [\_CREATED_TS => ['$lt' => $timestamp]],
+                [\_CREATED_TS => ['$exists' => false]]
+            ]
+        ];
+
+        $tripod = $this->getMockBuilder('\Tripod\Mongo\Driver')
+            ->setConstructorArgs(['CBD_testing', 'tripod_php_testing'])
+            ->getMock();
+
+        $collection = $this->getMockBuilder('\MongoDB\Collection')
+            ->disableOriginalConstructor()
+            ->setMethods(['deleteMany'])
+            ->getMock();
+
+        $deleteResult = $this->getMockBuilder('MongoDB\DeleteResult')
+            ->setMethods(['getDeletedCount'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $deleteResult->expects($this->once())
+            ->method('getDeletedCount')
+            ->will($this->returnValue(9));
+
+        $search = $this->getMockBuilder('\Tripod\Mongo\MongoSearchProvider')
+            ->setMethods(['getCollectionForSearchSpec', 'getSearchDocumentSpecification'])
+            ->setConstructorArgs([$tripod])
+            ->getMock();
+
+        $search->expects($this->once())
+            ->method('getSearchDocumentSpecification')
+            ->with('i_search_list')
+            ->will($this->returnValue(['_id' => 'i_search_list']));
+
+        $search->expects($this->once())
+            ->method('getCollectionForSearchSpec')
+            ->with('i_search_list')
+            ->will($this->returnValue($collection));
+
+        $collection->expects($this->once())
+            ->method('deleteMany')
+            ->with($query)
+            ->will($this->returnValue($deleteResult));
+
+        $this->assertEquals(9, $search->deleteSearchDocumentsByTypeId('i_search_list', $timestamp));
+    }
+
     /**
      * @param \Tripod\Mongo\Driver $tripod
      * @param array $specs

--- a/test/unit/mongo/MongoTripodTablesTest.php
+++ b/test/unit/mongo/MongoTripodTablesTest.php
@@ -1659,7 +1659,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
 
     public function testCountTablesWithFilters()
     {
-        $filters = ['_cts' => ['$lte' => new \MongoDB\BSON\UTCDateTime()]];
+        $filters = ['_cts' => ['$lte' => new \MongoDB\BSON\UTCDateTime(null)]];
         $query = array_merge(['_id.type' => 't_source_count'], $filters);
         $collection = $this->getMockBuilder('\MongoDB\Collection')
             ->disableOriginalConstructor()
@@ -1719,7 +1719,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
 
     public function testDeleteTableRowsByTableIdWithTimestamp()
     {
-        $timestamp = new \MongoDB\BSON\UTCDateTime();
+        $timestamp = new \MongoDB\BSON\UTCDateTime(null);
 
         $query = [
             '_id.type' => 't_source_count',

--- a/test/unit/mongo/MongoTripodViewsTest.php
+++ b/test/unit/mongo/MongoTripodViewsTest.php
@@ -390,7 +390,6 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         );
 
         $updatedView = $mongo->selectCollection('tripod_php_testing','views')->findOne(array('_id'=>array("r"=>'http://talisaspire.com/resources/filter1',"c"=>'http://talisaspire.com/',"type"=>'v_resource_filter1')));
-        $this->assertEquals($expectedUpdatedView,$updatedView);
         $this->assertEquals($expectedUpdatedView['_id'], $updatedView['_id']);
         $this->assertEquals($expectedUpdatedView['value'], $updatedView['value']);
         $this->assertInstanceOf('\MongoDB\BSON\UTCDateTime', $updatedView['_cts']);

--- a/test/unit/mongo/MongoTripodViewsTest.php
+++ b/test/unit/mongo/MongoTripodViewsTest.php
@@ -108,7 +108,9 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             ['typeMap' => ['root' => 'array', 'document' => 'array', 'array' => 'array']]
         );
         $actualView = $mongo->selectCollection('tripod_php_testing','views')->findOne(array('_id'=>array("r"=>'http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA',"c"=>'http://talisaspire.com/',"type"=>'v_resource_full')));
-        $this->assertEquals($expectedView,$actualView);
+        $this->assertEquals($expectedView['_id'], $actualView['_id']);
+        $this->assertEquals($expectedView['value'], $actualView['value']);
+        $this->assertInstanceOf('\MongoDB\BSON\UTCDateTime', $actualView['_cts']);
     }
 
     /**
@@ -179,7 +181,9 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             ['typeMap' => ['root' => 'array', 'document' => 'array', 'array' => 'array']]
         );
         $actualView = $mongo->selectCollection('tripod_php_testing','views')->findOne(array('_id'=>array("r"=>'http://talisaspire.com/resources/filter1',"c"=>'http://talisaspire.com/',"type"=>'v_resource_filter1')));
-        $this->assertEquals($expectedView,$actualView);
+        $this->assertEquals($expectedView['_id'], $actualView['_id']);
+        $this->assertEquals($expectedView['value'], $actualView['value']);
+        $this->assertInstanceOf('\MongoDB\BSON\UTCDateTime', $actualView['_cts']);
     }
 
     /**
@@ -244,7 +248,9 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         $actualView = $mongo->selectCollection('tripod_php_testing','views')->findOne(
             array('_id'=>array("r"=>'http://talisaspire.com/resources/filter1',"c"=>'http://talisaspire.com/',"type"=>'v_resource_filter2'))
         );
-        $this->assertEquals($expectedView,$actualView);
+        $this->assertEquals($expectedView['_id'], $actualView['_id']);
+        $this->assertEquals($expectedView['value'], $actualView['value']);
+        $this->assertInstanceOf('\MongoDB\BSON\UTCDateTime', $actualView['_cts']);
     }
 
     /**
@@ -315,7 +321,9 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             ['typeMap' => ['root' => 'array', 'document' => 'array', 'array' => 'array']]
         );
         $actualView = $mongo->selectCollection('tripod_php_testing','views')->findOne(array('_id'=>array("r"=>'http://talisaspire.com/resources/filter1',"c"=>'http://talisaspire.com/',"type"=>'v_resource_filter1')));
-        $this->assertEquals($expectedView,$actualView);
+        $this->assertEquals($expectedView['_id'], $actualView['_id']);
+        $this->assertEquals($expectedView['value'], $actualView['value']);
+        $this->assertInstanceOf('\MongoDB\BSON\UTCDateTime', $actualView['_cts']);
 
         // Modify http://talisaspire.com/works/filter1 so that it is a Chapter (included in the view) not a Book (excluded from the view)
         $oldGraph = new \Tripod\ExtendedGraph();
@@ -383,6 +391,9 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
 
         $updatedView = $mongo->selectCollection('tripod_php_testing','views')->findOne(array('_id'=>array("r"=>'http://talisaspire.com/resources/filter1',"c"=>'http://talisaspire.com/',"type"=>'v_resource_filter1')));
         $this->assertEquals($expectedUpdatedView,$updatedView);
+        $this->assertEquals($expectedUpdatedView['_id'], $updatedView['_id']);
+        $this->assertEquals($expectedUpdatedView['value'], $updatedView['value']);
+        $this->assertInstanceOf('\MongoDB\BSON\UTCDateTime', $updatedView['_cts']);
     }
 
     /**
@@ -458,7 +469,9 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         );
         $actualView = $mongo->selectCollection('tripod_php_testing','views')->findOne(array('_id'=>array("r"=>'http://talisaspire.com/resources/filter1',"c"=>'http://talisaspire.com/',"type"=>'v_resource_rdfsequence')));
 
-        $this->assertEquals($expectedView,$actualView);
+        $this->assertEquals($expectedView['_id'], $actualView['_id']);
+        $this->assertEquals($expectedView['value'], $actualView['value']);
+        $this->assertInstanceOf('\MongoDB\BSON\UTCDateTime', $actualView['_cts']);
     }
 
     public function testGenerateViewWithTTL()
@@ -504,7 +517,9 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         );
         // get the view direct from mongo
         $actualView = \Tripod\Mongo\Config::getInstance()->getCollectionForView('tripod_php_testing', 'v_resource_full_ttl')->findOne(array('_id'=>array("r"=>'http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA',"c"=>'http://talisaspire.com/',"type"=>'v_resource_full_ttl')));
-        $this->assertEquals($expectedView,$actualView);
+        $this->assertEquals($expectedView['_id'], $actualView['_id']);
+        $this->assertEquals($expectedView['value'], $actualView['value']);
+        $this->assertInstanceOf('\MongoDB\BSON\UTCDateTime', $actualView['_cts']);
     }
 
     /**
@@ -609,7 +624,9 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         );
 
         $actualView = \Tripod\Mongo\Config::getInstance()->getCollectionForView('tripod_php_testing', 'v_counts')->findOne(array('_id'=>array("r"=>'http://talisaspire.com/works/4d101f63c10a6',"c"=>"http://talisaspire.com/","type"=>'v_counts')));
-        $this->assertEquals($expectedView,$actualView);
+        $this->assertEquals($expectedView['_id'], $actualView['_id']);
+        $this->assertEquals($expectedView['value'], $actualView['value']);
+        $this->assertInstanceOf('\MongoDB\BSON\UTCDateTime', $actualView['_cts']);
     }
 
     public function testGetViewWithNamespaces()

--- a/test/unit/mongo/MongoTripodViewsTest.php
+++ b/test/unit/mongo/MongoTripodViewsTest.php
@@ -2051,7 +2051,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
 
     public function testCountViewsWithFilters()
     {
-        $filters = ['_cts' => ['$lte' => new \MongoDB\BSON\UTCDateTime()]];
+        $filters = ['_cts' => ['$lte' => new \MongoDB\BSON\UTCDateTime(null)]];
         $query = array_merge(['_id.type' => 'v_some_spec'], $filters);
         $collection = $this->getMockBuilder('\MongoDB\Collection')
             ->disableOriginalConstructor()
@@ -2111,7 +2111,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
 
     public function testDeleteViewsByViewIdWithTimestamp()
     {
-        $timestamp = new \MongoDB\BSON\UTCDateTime();
+        $timestamp = new \MongoDB\BSON\UTCDateTime(null);
 
         $query = [
             '_id.type' => 'v_resource_full',


### PR DESCRIPTION
This adds the ability to track 'bulk' apply operations jobs (e.g. regenerate all views, table rows, etc.) and, when complete, delete any stale composite documents that have an earlier (or missing) timestamp from when the bulk job started.

This does so by adding a `_cts` (i.e. 'Created timestamp') field on the composites.