### PR TITLE
Non-invalidating views

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "mongodb/mongodb": "1.0.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.1.*"
+        "phpunit/phpunit": "4.1.*",
+        "squizlabs/php_codesniffer": "3.2.*"
     }
 }

--- a/src/mongo/delegates/Views.class.php
+++ b/src/mongo/delegates/Views.class.php
@@ -93,7 +93,8 @@ class Views extends CompositeBase
             $resourceAlias = $this->labeller->uri_to_alias($resource);
             // build $filter for queries to impact index
             $filter[] = [_ID_RESOURCE => $resourceAlias, _ID_CONTEXT => $contextAlias];
-            if (!empty(array_intersect($predicates, $typeKeys))) {
+            $rdfTypePredicates = array_intersect($predicates, $typeKeys);
+            if (!empty($rdfTypePredicates)) {
                 $changedTypes[] = $resourceAlias;
             }
         }

--- a/src/mongo/delegates/Views.class.php
+++ b/src/mongo/delegates/Views.class.php
@@ -11,6 +11,7 @@ use \Tripod\Mongo\Labeller;
 use \MongoDB\Driver\ReadPreference;
 use \MongoDB\Collection;
 use Tripod\Mongo\JobGroup;
+use Monolog\Logger;
 
 /**
  * Class Views
@@ -75,40 +76,65 @@ class Views extends CompositeBase
      * @param string $contextAlias
      * @return array|mixed
      */
-    public function findImpactedComposites(Array $resourcesAndPredicates, $contextAlias)
+    public function findImpactedComposites(array $resourcesAndPredicates, $contextAlias)
     {
-        $resources = array_keys($resourcesAndPredicates);
-
         // This should never happen, but in the event that we have been passed an empty array or something
-        if(empty($resources))
-        {
-            return array();
+        if (empty($resourcesAndPredicates)) {
+            return [];
         }
 
         $contextAlias = $this->getContextAlias($contextAlias); // belt and braces
 
         // build a filter - will be used for impactIndex detection and finding direct views to re-gen
-        $filter = array();
-        foreach ($resources as $resource)
-        {
+        $filter = [];
+        $changedTypes = [];
+        $typeKeys = [RDF_TYPE, $this->labeller->uri_to_alias(RDF_TYPE)];
+        foreach ($resourcesAndPredicates as $resource => $predicates) {
             $resourceAlias = $this->labeller->uri_to_alias($resource);
             // build $filter for queries to impact index
-            $filter[] = array("r"=>$resourceAlias,"c"=>$contextAlias);
+            $filter[] = [_ID_RESOURCE => $resourceAlias, _ID_CONTEXT => $contextAlias];
+            if (!empty(array_intersect($predicates, $typeKeys))) {
+                $changedTypes[] = $resourceAlias;
+            }
         }
 
         // first re-gen views where resources appear in the impact index
-        $query = array("value."._IMPACT_INDEX=>array('$in'=>$filter));
+        $query = ['value.' . _IMPACT_INDEX => ['$in' => $filter]];
 
-        $affectedViews = array();
-        foreach($this->config->getCollectionsForViews($this->storeName) as $collection)
-        {
+        if (!empty($changedTypes)) {
+            $idQuery = [];
+            foreach ($changedTypes as $resourceAlias) {
+                $idQuery[] = ['$elemMatch' => [_ID_RESOURCE => $resourceAlias, _ID_CONTEXT => $contextAlias]];
+            }
+            if (count($idQuery) === 1) {
+                $query = ['$or' => [
+                    ['_id' => $idQuery[0]],
+                    $query
+                ]];
+            } else {
+                $query = ['$or' => [
+                    ['_id' => ['$or' => $idQuery]],
+                    $query
+                ]];
+            }
+        }
+
+        $affectedViews = [];
+        foreach ($this->config->getCollectionsForViews($this->storeName) as $collection) {
             $t = new \Tripod\Timer();
             $t->start();
-            $views = $collection->find($query, array('projection' => array("_id"=>true)));
+            $views = $collection->find($query, ['projection' => ['_id'=>true]]);
             $t->stop();
-            $this->timingLog(MONGO_FIND_IMPACTED, array('duration'=>$t->result(), 'query'=>$query, 'storeName'=>$this->storeName, 'collection'=>$collection));
-            foreach($views as $v)
-            {
+            $this->timingLog(
+                MONGO_FIND_IMPACTED,
+                [
+                    'duration' => $t->result(),
+                    'query' => $query,
+                    'storeName' => $this->storeName,
+                    'collection' => $collection
+                ]
+            );
+            foreach ($views as $v) {
                 $affectedViews[] = $v;
             }
         }
@@ -292,11 +318,13 @@ class Views extends CompositeBase
         foreach ($resources as $resource)
         {
             $resourceAlias = $this->labeller->uri_to_alias($resource);
-
+            $this->getLogger()->warning('Generating views', ['store' => $this->storeName,
+            '_id' => $resourceAlias]);
             // delete any views this resource is involved in. It's type may have changed so it's not enough just to regen it with it's new type below.
             foreach (Config::getInstance()->getViewSpecifications($this->storeName) as $type=>$spec)
             {
                 if($spec['from']==$this->podName){
+
                     $this->config->getCollectionForView($this->storeName, $type, $this->readPreference)
                         ->deleteOne(array("_id" => array("r"=>$resourceAlias,"c"=>$contextAlias,"type"=>$type)));
                 }

--- a/src/mongo/delegates/Views.class.php
+++ b/src/mongo/delegates/Views.class.php
@@ -402,7 +402,7 @@ class Views extends CompositeBase
      * @throws \Tripod\Exceptions\ViewException
      * @return array
      */
-    public function generateView($viewId,$resource=null,$context=null,$queueName=null)
+    public function generateView($viewId, $resource = null, $context = null, $queueName = null)
     {
         $contextAlias = $this->getContextAlias($context);
         $viewSpec = Config::getInstance()->getViewSpecification($this->storeName, $viewId);
@@ -479,15 +479,19 @@ class Views extends CompositeBase
                 $buildImpactIndex=true;
                 if (isset($viewSpec['ttl'])) {
                     $buildImpactIndex=false;
-                    $value[_EXPIRES] = \Tripod\Mongo\DateUtil::getMongoDate($this->getExpirySecFromNow($viewSpec['ttl']) * 1000);
+                    if (is_int($viewSpec['ttl']) && $viewSpec['ttl'] > 0) {
+                        $value[_EXPIRES] = \Tripod\Mongo\DateUtil::getMongoDate(
+                            $this->getExpirySecFromNow($viewSpec['ttl']) * 1000
+                        );
+                    }
                 } else {
                     $value[_IMPACT_INDEX] = array($doc['_id']);
                 }
 
-                $this->doJoins($doc,$viewSpec['joins'],$value,$from,$contextAlias,$buildImpactIndex);
+                $this->doJoins($doc, $viewSpec['joins'], $value, $from, $contextAlias, $buildImpactIndex);
 
                 // add top level properties
-                $value[_GRAPHS][] = $this->extractProperties($doc,$viewSpec,$from);
+                $value[_GRAPHS][] = $this->extractProperties($doc, $viewSpec, $from);
 
                 $generatedView['value'] = $value;
 
@@ -501,7 +505,7 @@ class Views extends CompositeBase
             'duration'=>$t->result(),
             'filter'=>$filter,
             'from'=>$from));
-        $this->getStat()->timer(MONGO_CREATE_VIEW.".$viewId",$t->result());
+        $this->getStat()->timer(MONGO_CREATE_VIEW.".$viewId", $t->result());
 
         $stat = ['count' => $count];
         if (isset($jobOptions[ApplyOperation::TRACKING_KEY])) {

--- a/src/mongo/delegates/Views.class.php
+++ b/src/mongo/delegates/Views.class.php
@@ -109,16 +109,9 @@ class Views extends CompositeBase
                     _ID_KEY . '.' . _ID_CONTEXT => $contextAlias
                 ];
             }
-            if (count($idQuery) === 1) {
-                $query = ['$or' => [
-                    $idQuery[0],
-                    $query
-                ]];
-            } else {
-                $query = ['$or' => [
-                    $idQuery,
-                    $query
-                ]];
+            $query['$or'] = [$query];
+            foreach ($idQuery as $id) {
+                $query['$or'][] = $id;
             }
         }
 

--- a/src/mongo/delegates/Views.class.php
+++ b/src/mongo/delegates/Views.class.php
@@ -11,7 +11,6 @@ use \Tripod\Mongo\Labeller;
 use \MongoDB\Driver\ReadPreference;
 use \MongoDB\Collection;
 use Tripod\Mongo\JobGroup;
-use Monolog\Logger;
 
 /**
  * Class Views
@@ -29,7 +28,7 @@ class Views extends CompositeBase
      * @param null $stat
      * @param string $readPreference
      */
-    function __construct($storeName, Collection $collection,$defaultContext,$stat=null,$readPreference = ReadPreference::RP_PRIMARY) // todo: $collection -> podname
+    public function __construct($storeName, Collection $collection,$defaultContext,$stat=null,$readPreference = ReadPreference::RP_PRIMARY) // todo: $collection -> podname
     {
         $this->storeName = $storeName;
         $this->labeller = new Labeller();
@@ -311,8 +310,10 @@ class Views extends CompositeBase
         foreach ($resources as $resource)
         {
             $resourceAlias = $this->labeller->uri_to_alias($resource);
-            $this->getLogger()->warning('Generating views', ['store' => $this->storeName,
-            '_id' => $resourceAlias]);
+            $this->getLogger()->warning(
+                'Generating views',
+                ['store' => $this->storeName, '_id' => $resourceAlias]
+            );
             // delete any views this resource is involved in. It's type may have changed so it's not enough just to regen it with it's new type below.
             foreach (Config::getInstance()->getViewSpecifications($this->storeName) as $type=>$spec)
             {

--- a/src/mongo/delegates/Views.class.php
+++ b/src/mongo/delegates/Views.class.php
@@ -104,16 +104,19 @@ class Views extends CompositeBase
         if (!empty($changedTypes)) {
             $idQuery = [];
             foreach ($changedTypes as $resourceAlias) {
-                $idQuery[] = ['$elemMatch' => [_ID_RESOURCE => $resourceAlias, _ID_CONTEXT => $contextAlias]];
+                $idQuery[] = [
+                    _ID_KEY . '.' . _ID_RESOURCE => $resourceAlias,
+                    _ID_KEY . '.' . _ID_CONTEXT => $contextAlias
+                ];
             }
             if (count($idQuery) === 1) {
                 $query = ['$or' => [
-                    ['_id' => $idQuery[0]],
+                    $idQuery[0],
                     $query
                 ]];
             } else {
                 $query = ['$or' => [
-                    ['_id' => ['$or' => $idQuery]],
+                    $idQuery,
                     $query
                 ]];
             }

--- a/src/mongo/delegates/Views.class.php
+++ b/src/mongo/delegates/Views.class.php
@@ -102,16 +102,12 @@ class Views extends CompositeBase
         $query = ['value.' . _IMPACT_INDEX => ['$in' => $filter]];
 
         if (!empty($changedTypes)) {
-            $idQuery = [];
+            $query = ['$or' => [$query]];
             foreach ($changedTypes as $resourceAlias) {
-                $idQuery[] = [
+                $query['$or'][] =  [
                     _ID_KEY . '.' . _ID_RESOURCE => $resourceAlias,
                     _ID_KEY . '.' . _ID_CONTEXT => $contextAlias
                 ];
-            }
-            $query['$or'] = [$query];
-            foreach ($idQuery as $id) {
-                $query['$or'][] = $id;
             }
         }
 

--- a/test/unit/mongo/MongoTripodConfigTest.php
+++ b/test/unit/mongo/MongoTripodConfigTest.php
@@ -973,23 +973,28 @@ class MongoTripodConfigTest extends MongoTripodTestBase
 
     public function testGetAllTypesInSpecifications()
     {
-        $types = $this->tripodConfig->getAllTypesInSpecifications("tripod_php_testing");
-        $this->assertEquals(11, count($types), "There should be 11 types based on the configured view, table and search specifications in config.json");
-        $expectedValues = array(
-            "acorn:Resource",
-            "acorn:ResourceForTruncating",
-            "acorn:Work",
-            "http://talisaspire.com/schema#Work2",
-            "acorn:Work2",
-            "bibo:Book",
-            "resourcelist:List",
-            "spec:User",
-            "bibo:Document",
-            "baseData:Wibble",
-            "baseData:DocWithSequence"
+        $types = $this->tripodConfig->getAllTypesInSpecifications('tripod_php_testing');
+        $this->assertEquals(
+            12,
+            count($types),
+            'There should be 11 types based on the configured view, table and search specifications in config.json'
         );
+        $expectedValues = [
+            'acorn:Resource',
+            'acorn:ResourceForTruncating',
+            'acorn:Work',
+            'http://talisaspire.com/schema#Work2',
+            'acorn:Work2',
+            'bibo:Book',
+            'resourcelist:List',
+            'spec:User',
+            'bibo:Document',
+            'baseData:Wibble',
+            'baseData:DocWithSequence',
+            'dctype:Event'
+        ];
 
-        foreach($expectedValues as $expected){
+        foreach ($expectedValues as $expected) {
             $this->assertContains($expected, $types, "List of types should have contained $expected");
         }
     }
@@ -1334,7 +1339,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $transactionColletion = $transactionMongo->selectCollection($newConfig['transaction_log']['database'], $newConfig['transaction_log']['collection']);
         $transactionCount = $transactionColletion->count();
         $transactionExampleDocument = $transactionColletion->findOne();
-        $this->assertEquals(24, $transactionCount);
+        $this->assertEquals(26, $transactionCount);
         $this->assertContains('transaction_', $transactionExampleDocument["_id"]);
     }
 

--- a/test/unit/mongo/MongoTripodConfigTest.php
+++ b/test/unit/mongo/MongoTripodConfigTest.php
@@ -977,7 +977,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $this->assertEquals(
             12,
             count($types),
-            'There should be 11 types based on the configured view, table and search specifications in config.json'
+            'There should be 12 types based on the configured view, table and search specifications in config.json'
         );
         $expectedValues = [
             'acorn:Resource',

--- a/test/unit/mongo/MongoTripodTestBase.php
+++ b/test/unit/mongo/MongoTripodTestBase.php
@@ -84,7 +84,7 @@ abstract class MongoTripodTestBase extends PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        date_default_timezone_set('Europe/London');
+        date_default_timezone_set('UTC');
 
         $config = json_decode(file_get_contents($this->getConfigLocation()), true);
         if(getenv('TRIPOD_DATASOURCE_RS1_CONFIG'))

--- a/test/unit/mongo/MongoTripodViewsTest.php
+++ b/test/unit/mongo/MongoTripodViewsTest.php
@@ -4,7 +4,6 @@ require_once 'MongoTripodTestBase.php';
 require_once 'src/mongo/Driver.class.php';
 require_once 'src/mongo/delegates/Views.class.php';
 
-use \Tripod\Mongo\Composites\Views;
 use \MongoDB\Client;
 use Tripod\ExtendedGraph;
 

--- a/test/unit/mongo/data/config.json
+++ b/test/unit/mongo/data/config.json
@@ -227,6 +227,7 @@
                     "from": "CBD_testing",
                     "type": "dctype:Event",
                     "ttl": -1,
+                    "include": ["rdf:type", "dct:created", "dct:title", "dct:references"],
                     "joins": {
                         "dct:references" : {
                             "include": ["dct:title", "dct:creator"]

--- a/test/unit/mongo/data/config.json
+++ b/test/unit/mongo/data/config.json
@@ -221,6 +221,17 @@
                             "include": ["dct:subject", "rdf:type"]
                         }
                     }
+                },
+                {
+                    "_id": "v_event_no_expiration",
+                    "from": "CBD_testing",
+                    "type": "dctype:Event",
+                    "ttl": -1,
+                    "joins": {
+                        "dct:references" : {
+                            "include": ["dct:title", "dct:creator"]
+                        }
+                    }
                 }
             ],
             "search_config": {

--- a/test/unit/mongo/data/resources.json
+++ b/test/unit/mongo/data/resources.json
@@ -845,5 +845,41 @@
                 "u":"http://talisaspire.com/schema#Work"
             }
         ]
-    }
+    },
+    {
+        "_id": {
+            "r": "http://talisaspire.com/events/1234",
+            "c": "http://talisaspire.com/"
+        },
+        "rdf:type": {
+            "u": "dctype:Event"
+        },
+        "dct:created": {
+            "l": "2018-04-09T00:00:00Z"
+        },
+        "dct:title": {
+            "l": "A significant event"
+        },
+        "dct:references": {
+            "u": "http://talisaspire.com/resources/1234"
+        }        
+    },
+    {
+        "_id": {
+            "r": "http://talisaspire.com/resources/1234",
+            "c": "http://talisaspire.com/"
+        },
+        "rdf:type": {
+            "u": "dctype:Text"
+        },
+        "dct:created": {
+            "l": "2018-04-09T00:00:00Z"
+        },
+        "dct:title": {
+            "l": "A real piece of work"
+        },
+        "dct:creator": {
+            "l": "Anne Author"
+        }        
+    }    
 ]


### PR DESCRIPTION
This change lets view spec TTLs be `-1` which essentially means they never change unless the original graph is deleted or changes its rdf type.