### PR TITLE
Remove config from job payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Quickstart
 ```php
 require_once("tripod.inc.php");
 
-\Tripod\Mongo\Config::setConfig($conf); // set the config, usually read in as JSON from a file
+\Tripod\Config::setConfig($conf); // set the config, usually read in as JSON from a file
 
 $tripod = new Driver(
   "CBD_users", // pod (read: MongoDB collection) we're working with

--- a/composer.json
+++ b/composer.json
@@ -27,5 +27,8 @@
     "require-dev": {
         "phpunit/phpunit": "4.1.*",
         "squizlabs/php_codesniffer": "3.2.*"
-    }
+    },    
+    "autoload": {
+        "classmap": ["src/"]
+    }    
 }

--- a/docs/config.md
+++ b/docs/config.md
@@ -5,7 +5,7 @@ Tripod config is typically defined as a JSON file or stream which is added to th
 
 ```php
 $conf = json_decode(file_get_contents('tripod_config.json');
-\Tripod\Mongo\Config::setConfig($conf); // set the config, usually read in as JSON from a file
+\Tripod\Config::setConfig($conf); // set the config, usually read in as JSON from a file
 ```
 
 Namespaces

--- a/scripts/mongo/BSONToQuads.php
+++ b/scripts/mongo/BSONToQuads.php
@@ -13,7 +13,7 @@ if ($argc!=2)
 
 array_shift($argv);
 $config = json_decode(file_get_contents($argv[0]), true);
-\Tripod\Mongo\Config::setConfig($config);
+\Tripod\Config::setConfig($config);
 
 $tu = new \Tripod\Mongo\TriplesUtil();
 

--- a/scripts/mongo/BSONToTriples.php
+++ b/scripts/mongo/BSONToTriples.php
@@ -11,7 +11,7 @@ if ($argc!=2)
 }
 array_shift($argv);
 $config = json_decode(file_get_contents($argv[0]), true);
-\Tripod\Mongo\Config::setConfig($config);
+\Tripod\Config::setConfig($config);
 
 $tu = new \Tripod\Mongo\TriplesUtil();
 

--- a/scripts/mongo/createSearchDocuments.php
+++ b/scripts/mongo/createSearchDocuments.php
@@ -58,10 +58,10 @@ require_once dirname(dirname(dirname(__FILE__))) . '/src/tripod.inc.php';
  */
 function generateSearchDocuments($id, $specId, $storeName, $stat = null, $queue = null)
 {
-    $spec = \Tripod\Mongo\Config::getInstance()->getSearchDocumentSpecification($storeName, $specId);
+    $spec = \Tripod\Config::getInstance()->getSearchDocumentSpecification($storeName, $specId);
     if (array_key_exists("from",$spec))
     {
-        \Tripod\Mongo\Config::getInstance()->setMongoCursorTimeout(-1);
+        \Tripod\Config::getInstance()->setMongoCursorTimeout(-1);
 
         print "Generating $specId";
         $tripod = new \Tripod\Mongo\Driver($spec['from'], $storeName, array('stat'=>$stat));
@@ -82,7 +82,7 @@ function generateSearchDocuments($id, $specId, $storeName, $stat = null, $queue 
 $t = new \Tripod\Timer();
 $t->start();
 
-\Tripod\Mongo\Config::setConfig(json_decode(file_get_contents($configLocation),true));
+\Tripod\Config::setConfig(json_decode(file_get_contents($configLocation),true));
 
 if(isset($options['s']) || isset($options['storename']))
 {
@@ -120,7 +120,7 @@ if(isset($options['a']) || isset($options['async']))
     }
     else
     {
-        $queue = \Tripod\Mongo\Config::getInstance()->getApplyQueueName();
+        $queue = \Tripod\Config::getInstance()->getApplyQueueName();
     }
 }
 
@@ -137,7 +137,7 @@ if ($specId)
 }
 else
 {
-    foreach(\Tripod\Mongo\Config::getInstance()->getSearchDocumentSpecifications($storeName) as $searchSpec)
+    foreach(\Tripod\Config::getInstance()->getSearchDocumentSpecifications($storeName) as $searchSpec)
     {
         generateSearchDocuments($id, $searchSpec['_id'], $storeName, $stat, $queue);
     }

--- a/scripts/mongo/createTables.php
+++ b/scripts/mongo/createTables.php
@@ -59,10 +59,10 @@ require_once dirname(dirname(dirname(__FILE__))) . '/src/tripod.inc.php';
  */
 function generateTables($id, $tableId, $storeName, $stat = null, $queue = null)
 {
-    $tableSpec = \Tripod\Mongo\Config::getInstance()->getTableSpecification($storeName, $tableId);
+    $tableSpec = \Tripod\Config::getInstance()->getTableSpecification($storeName, $tableId);
     if (array_key_exists("from",$tableSpec))
     {
-        \Tripod\Mongo\Config::getInstance()->setMongoCursorTimeout(-1);
+        \Tripod\Config::getInstance()->setMongoCursorTimeout(-1);
 
         print "Generating $tableId";
         $tripod = new \Tripod\Mongo\Driver($tableSpec['from'], $storeName, array('stat'=>$stat));
@@ -83,7 +83,7 @@ function generateTables($id, $tableId, $storeName, $stat = null, $queue = null)
 $t = new \Tripod\Timer();
 $t->start();
 
-\Tripod\Mongo\Config::setConfig(json_decode(file_get_contents($configLocation),true));
+\Tripod\Config::setConfig(json_decode(file_get_contents($configLocation),true));
 
 if(isset($options['s']) || isset($options['storename']))
 {
@@ -121,7 +121,7 @@ if(isset($options['a']) || isset($options['async']))
     }
     else
     {
-        $queue = \Tripod\Mongo\Config::getInstance()->getApplyQueueName();
+        $queue = \Tripod\Config::getInstance()->getApplyQueueName();
     }
 }
 
@@ -138,7 +138,7 @@ if ($tableId)
 }
 else
 {
-    foreach(\Tripod\Mongo\Config::getInstance()->getTableSpecifications($storeName) as $tableSpec)
+    foreach(\Tripod\Config::getInstance()->getTableSpecifications($storeName) as $tableSpec)
     {
         generateTables($id, $tableSpec['_id'], $storeName, $stat, $queue);
     }

--- a/scripts/mongo/createViews.php
+++ b/scripts/mongo/createViews.php
@@ -59,10 +59,10 @@ require_once dirname(dirname(dirname(__FILE__))) . '/src/tripod.inc.php';
  */
 function generateViews($id, $viewId, $storeName, $stat, $queue)
 {
-    $viewSpec = \Tripod\Mongo\Config::getInstance()->getViewSpecification($storeName, $viewId);
+    $viewSpec = \Tripod\Config::getInstance()->getViewSpecification($storeName, $viewId);
     if (array_key_exists("from",$viewSpec))
     {
-        \Tripod\Mongo\Config::getInstance()->setMongoCursorTimeout(-1);
+        \Tripod\Config::getInstance()->setMongoCursorTimeout(-1);
 
         print "Generating $viewId";
         $tripod = new \Tripod\Mongo\Driver($viewSpec['from'], $storeName, array('stat'=>$stat));
@@ -83,7 +83,7 @@ function generateViews($id, $viewId, $storeName, $stat, $queue)
 $t = new \Tripod\Timer();
 $t->start();
 
-\Tripod\Mongo\Config::setConfig(json_decode(file_get_contents($configLocation),true));
+\Tripod\Config::setConfig(json_decode(file_get_contents($configLocation),true));
 
 if(isset($options['s']) || isset($options['storename']))
 {
@@ -121,7 +121,7 @@ if(isset($options['a']) || isset($options['async']))
     }
     else
     {
-        $queue = \Tripod\Mongo\Config::getInstance()->getApplyQueueName();
+        $queue = \Tripod\Config::getInstance()->getApplyQueueName();
     }
 }
 
@@ -138,7 +138,7 @@ if ($viewId)
 }
 else
 {
-    foreach(\Tripod\Mongo\Config::getInstance()->getViewSpecifications($storeName) as $viewSpec)
+    foreach(\Tripod\Config::getInstance()->getViewSpecifications($storeName) as $viewSpec)
     {
         generateViews($id, $viewSpec['_id'], $storeName, $stat, $queue);
     }

--- a/scripts/mongo/detectNamespaces.php
+++ b/scripts/mongo/detectNamespaces.php
@@ -34,7 +34,7 @@ $config = array(
     ),
 );
 
-\Tripod\Mongo\Config::setConfig($config);
+\Tripod\Config::setConfig($config);
 
 
 $util = new \Tripod\Mongo\TriplesUtil();
@@ -85,7 +85,7 @@ while (($line = fgets(STDIN)) !== false) {
                 $newNsConfig[$prefix] = $n;
                 echo "\nFound ns $n suggest prefix $prefix";
                 $config["namespaces"] = array_merge($config["namespaces"],$newNsConfig);
-                \Tripod\Mongo\Config::setConfig($config);
+                \Tripod\Config::setConfig($config);
             }
         }
         $ns = $util->extractMissingObjectNs($triples);
@@ -111,7 +111,7 @@ while (($line = fgets(STDIN)) !== false) {
                     $newNsConfig[$prefix] = $n;
                     echo "\nFound object ns $n occurs > 500 times, suggest prefix $prefix";
                     $config["namespaces"] = array_merge($config["namespaces"],$newNsConfig);
-                    \Tripod\Mongo\Config::setConfig($config);
+                    \Tripod\Config::setConfig($config);
                 }
             }
         }

--- a/scripts/mongo/ensureIndexes.php
+++ b/scripts/mongo/ensureIndexes.php
@@ -10,13 +10,13 @@ if ($argc!=2&&$argc!=3&&$argc!=4)
 }
 array_shift($argv);
 
-\Tripod\Mongo\Config::setConfig(json_decode(file_get_contents($argv[0]),true));
+\Tripod\Config::setConfig(json_decode(file_get_contents($argv[0]),true));
 
 $storeName = (isset($argv[1])) ? $argv[1] : null;
 $forceReindex = (isset($argv[2])&&($argv[2]=="true")) ? true : false;
 $background = (isset($argv[3])&&($argv[3]=="false")) ? false : true;
 
-\Tripod\Mongo\Config::getInstance()->setMongoCursorTimeout(-1);
+\Tripod\Config::getInstance()->setMongoCursorTimeout(-1);
 
 $ei = new \Tripod\Mongo\Jobs\EnsureIndexes();
 

--- a/scripts/mongo/loadTriples.php
+++ b/scripts/mongo/loadTriples.php
@@ -36,7 +36,7 @@ array_shift($argv);
 
 $storeName = $argv[0];
 $podName = $argv[1];
-\Tripod\Mongo\Config::setConfig(json_decode(file_get_contents($argv[2]),true));
+\Tripod\Config::setConfig(json_decode(file_get_contents($argv[2]),true));
 
 $i=0;
 $currentSubject = "";

--- a/scripts/mongo/triplesToBSON.php
+++ b/scripts/mongo/triplesToBSON.php
@@ -11,7 +11,7 @@ if ($argc!=2)
 array_shift($argv);
 
 $config = json_decode(file_get_contents($argv[0]), true);
-\Tripod\Mongo\Config::setConfig($config);
+\Tripod\Config::setConfig($config);
 
 $currentSubject = "";
 $triples = array();
@@ -32,7 +32,7 @@ while (($line = fgets(STDIN)) !== false) {
 
     if ($currentSubject!=$subject) // once subject changes, we have all triples for that subject, flush to Mongo
     {
-        print(json_encode($tu->getTArrayAbout($currentSubject,$triples,\Tripod\Mongo\Config::getInstance()->getDefaultContextAlias()))."\n");
+        print(json_encode($tu->getTArrayAbout($currentSubject,$triples,\Tripod\Config::getInstance()->getDefaultContextAlias()))."\n");
         $currentSubject=$subject; // reset current subject to next subject
         $triples = array(); // reset triples
     }
@@ -41,7 +41,7 @@ while (($line = fgets(STDIN)) !== false) {
 }
 
 // last doc
-print(json_encode($tu->getTArrayAbout($currentSubject,$triples,\Tripod\Mongo\Config::getInstance()->getDefaultContextAlias()))."\n");
+print(json_encode($tu->getTArrayAbout($currentSubject,$triples,\Tripod\Config::getInstance()->getDefaultContextAlias()))."\n");
 
 ?>
 

--- a/scripts/mongo/validateConfig.php
+++ b/scripts/mongo/validateConfig.php
@@ -35,10 +35,10 @@ require_once dirname(dirname(dirname(__FILE__))).'/src/tripod.inc.php';
 
 \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
 
-\Tripod\Mongo\Config::setConfig(json_decode(file_get_contents($configLocation),true));
+\Tripod\Config::setConfig(json_decode(file_get_contents($configLocation),true));
 
 try {
-    \Tripod\Mongo\Config::getInstance();
+    \Tripod\Config::getInstance();
 
     echo "\nConfig OK\n";
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tripod;
+
+class Config implements ITripodConfig
+{
+    /**
+     * @var Config
+     */
+    private static $instance;
+
+    /**
+     * @var array
+     */
+    private static $config = [];
+
+    /**
+     * Config should not be instantiated directly: use Config::getInstance()
+     */
+    private function __construct()
+    {
+    }
+
+    /**
+     * Since this is a singleton class, use this method to create a new config instance.
+     * @uses Config::setConfig() Configuration must be set prior to calling this method. To generate a completely new object, set a new config
+     * @codeCoverageIgnore
+     * @throws \Tripod\Exceptions\ConfigException
+     * @return ITripodConfig
+     */
+    public static function getInstance()
+    {
+        if (!isset(self::$config)) {
+            throw new \Tripod\Exceptions\ConfigException("Call Config::setConfig() first");
+        }
+        if (!isset(self::$instance)) {
+            self::$instance = TripodConfigFactory::create(self::$config);
+        }
+        return self::$instance;
+    }
+
+    /**
+     * Loads the Tripod config into the instance
+     *
+     * @return void
+     */
+    public static function setConfig(array $config)
+    {
+        self::$config = $config;
+        self::$instance = null; // this will force a reload next time getInstance() is called
+    }
+
+    /**
+     * Returns the Tripod config array
+     *
+     * @return array
+     */
+    public static function getConfig()
+    {
+        return self::$config;
+    }
+
+    /**
+     * This method was added to allow us to test the getInstance() method
+     * @codeCoverageIgnore
+     */
+    public static function destroy()
+    {
+        self::$instance = null;
+        self::$config = null;
+    }
+}

--- a/src/ITripodConfig.php
+++ b/src/ITripodConfig.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tripod;
+
+interface ITripodConfig
+{
+    /**
+     * Tripod Config instances are singletons, this method gets the existing or instantiates a new one.
+     *
+     * @return ITripodConfig
+     */
+    public static function getInstance();
+
+    /**
+     * Loads the Tripod config into the instance
+     *
+     * @return void
+     */
+    public static function setConfig(array $config);
+}

--- a/src/ITripodConfig.php
+++ b/src/ITripodConfig.php
@@ -17,4 +17,11 @@ interface ITripodConfig
      * @return void
      */
     public static function setConfig(array $config);
+
+    /**
+     * Returns the Tripod config array
+     *
+     * @return array
+     */
+    public static function getConfig();
 }

--- a/src/ITripodConfigSerializer.php
+++ b/src/ITripodConfigSerializer.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tripod;
+
+interface ITripodConfigSerializer
+{
+
+    /**
+     * This should return an array that self::deserialize() can roundtrip into an Tripod Config object
+     *
+     * @return void
+     */
+    public function serialize();
+
+    /**
+     * When given a valid config, returns a Tripod Config object
+     *
+     * @param array $config
+     * @return \Tripod\ITripodConfig
+     */
+    public static function deserialize(array $config);
+}

--- a/src/TripodConfigFactory.php
+++ b/src/TripodConfigFactory.php
@@ -15,11 +15,13 @@ class TripodConfigFactory
      */
     public static function create(array $config)
     {
+        if (\Tripod\Config::getConfig() !== $config) {
+            \Tripod\Config::setConfig($config);
+        }
         if (isset($config['class']) && class_exists($config['class'])) {
             $tripodConfig = call_user_func(array($config['class'], 'deserialize'), $config);
         } else {
-            Config::setConfig($config);
-            $tripodConfig = Config::getInstance();
+            $tripodConfig = Config::deserialize($config);
         }
         return $tripodConfig;
     }

--- a/src/TripodConfigFactory.php
+++ b/src/TripodConfigFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tripod;
+
+use \Tripod\Mongo\Config;
+
+class TripodConfigFactory
+{
+    /**
+     * Factory method to get a Tripod\ITripodConfig instance from either a config array, or a serialized
+     * ITripodConfigSerializer instance
+     *
+     * @param array $config The Tripod config or serialized ITripodConfigSerializer array
+     * @return \Tripod\ITripodConfig
+     */
+    public static function create(array $config)
+    {
+        if (isset($config['class']) && class_exists($config['class'])) {
+            $tripodConfig = call_user_func(array($config['class'], 'deserialize'), $config);
+        } else {
+            Config::setConfig($config);
+            $tripodConfig = Config::getInstance();
+        }
+        return $tripodConfig;
+    }
+}

--- a/src/TripodConfigFactory.php
+++ b/src/TripodConfigFactory.php
@@ -2,8 +2,6 @@
 
 namespace Tripod;
 
-use \Tripod\Mongo\Config;
-
 class TripodConfigFactory
 {
     /**
@@ -21,7 +19,7 @@ class TripodConfigFactory
         if (isset($config['class']) && class_exists($config['class'])) {
             $tripodConfig = call_user_func(array($config['class'], 'deserialize'), $config);
         } else {
-            $tripodConfig = Config::deserialize($config);
+            $tripodConfig = \Tripod\Mongo\Config::deserialize($config);
         }
         return $tripodConfig;
     }

--- a/src/mongo/Config.class.php
+++ b/src/mongo/Config.class.php
@@ -16,7 +16,7 @@ use \Tripod\ITripodConfigSerializer;
 /**
  * Holds the global configuration for Tripod
  */
-class Config implements ITripodConfigSerializer
+class Config implements IConfigInstance
 {
 
     /**
@@ -1131,7 +1131,7 @@ class Config implements ITripodConfigSerializer
     /**
      * Returns a list of the configured indexes grouped by collection
      * @param string $storeName
-     * @return mixed
+     * @return array
      */
     public function getIndexesGroupedByCollection($storeName)
     {
@@ -1189,7 +1189,8 @@ class Config implements ITripodConfigSerializer
      * @param string $storeName The database name to use.
      * @param string $collName The collection in the database.
      * @param string $qName Either the qname to get the values for or empty for all cardinality values.
-     * @return mixed If no qname is specified then returns an array of cardinality options, otherwise returns the cardinality value for the given qname.
+     * @return array|int If no qname is specified then returns an array of cardinality options,
+     *                   otherwise returns the cardinality value for the given qname.
      */
     public function getCardinality($storeName,$collName,$qName=null)
     {

--- a/src/mongo/Config.class.php
+++ b/src/mongo/Config.class.php
@@ -10,10 +10,13 @@ use \MongoDB\Driver\Command;
 use \MongoDB\Driver\Manager;
 use \MongoDB\Driver\Exception\ConnectionTimeoutException;
 
+use \Tripod\ITripodConfig;
+use \Tripod\ITripodConfigSerializer;
+
 /**
  * Holds the global configuration for Tripod
  */
-class Config
+class Config implements ITripodConfig, ITripodConfigSerializer
 {
     /**
      * @var Config
@@ -2175,5 +2178,33 @@ class Config
             self::$logger = $log;
         }
         return self::$logger;
+    }
+
+    /**
+     * Sets the Tripod config
+     *
+     * @param array $config
+     * @return void
+     */
+    public static function deserialize(array $config)
+    {
+        if (isset($config['class']) && isset($config['config'])) {
+            self::setConfig($config['config']);
+        } else {
+            self::setConfig($config);
+        }
+    }
+
+    /**
+     * Serializes the config into an array that can be passed to jobs, etc.
+     *
+     * @return array
+     */
+    public function serialize()
+    {
+        return [
+            'class' => get_class(),
+            'config' => self::getConfig()
+        ];
     }
 }

--- a/src/mongo/Driver.class.php
+++ b/src/mongo/Driver.class.php
@@ -74,7 +74,7 @@ class Driver extends DriverBase implements \Tripod\IDriver
 
         $this->podName = $podName;
         $this->storeName = $storeName;
-        $this->config = $this->getTripodConfigInstance();
+        $this->config = $this->getConfigInstance();
 
         $this->labeller = $this->getLabeller();
 
@@ -648,17 +648,6 @@ class Driver extends DriverBase implements \Tripod\IDriver
                 throw new Exception("Unrecognised type $eventType whilst registering event hook");
         }
     }
-
-
-    /**
-     * For mocking
-     * @return Config
-     */
-    protected function getTripodConfigInstance()
-    {
-        return Config::getInstance();
-    }
-
 
     /**
      * Returns the composite that can perform the supported operation

--- a/src/mongo/IConfigInstance.php
+++ b/src/mongo/IConfigInstance.php
@@ -1,0 +1,308 @@
+<?php
+
+namespace Tripod\Mongo;
+
+use \MongoDB\Database;
+use \MongoDB\Collection;
+use \MongoDB\Driver\ReadPreference;
+
+interface IConfigInstance extends \Tripod\ITripodConfigSerializer
+{
+    /**
+     * @return int
+     */
+    public function getMongoCursorTimeout();
+
+    /**
+     * @param int $mongoCursorTimeout Timeout in ms
+     */
+    public function setMongoCursorTimeout($mongoCursorTimeout);
+
+    /**
+     * Returns an array of associated predicates in a table or search document specification
+     * Note: will not return viewSpec predicates
+     *
+     * @param string $storename Store name
+     * @param string $specId    Composite spec id
+     * @return array
+     */
+    public function getDefinedPredicatesInSpec($storename, $specId);
+
+    /**
+     * Returns an alias curie of the default context (i.e. graph name)
+     *
+     * @return string
+     */
+    public function getDefaultContextAlias();
+
+    /**
+     * Returns a list of the configured indexes grouped by collection
+     * @param string $storeName Store name
+     * @return array
+     */
+    public function getIndexesGroupedByCollection($storeName);
+
+    /**
+     * Get the cardinality values for a DB/Collection.
+     *
+     * @param string $storeName The database name to use.
+     * @param string $collName The collection in the database.
+     * @param string $qName Either the qname to get the values for or empty for all cardinality values.
+     * @return array|int If no qname is specified then returns an array of cardinality options,
+     *                   otherwise returns the cardinality value for the given qname.
+     */
+    public function getCardinality($storeName, $collName, $qName = null);
+
+    /**
+     * Returns a boolean reflecting whether or not the database and collection are defined in the config
+     * @param string $storeName Store name
+     * @param string $pod       Pod name
+     * @return bool
+     */
+    public function isPodWithinStore($storeName, $pod);
+
+    /**
+     * Returns an array of collection configurations for the supplied database name
+     * @param string $storeName Store name
+     * @return array
+     */
+    public function getPods($storeName);
+
+    /**
+     * Return the view specification document for the supplied id, if it exists
+     * @param string $storeName Store name
+     * @param string $vid       View spec ID
+     * @return array|null
+     */
+    public function getViewSpecification($storeName, $vid);
+
+    /**
+     * Returns the search document specification for the supplied id, if it exists
+     * @param string $storeName Store name
+     * @param string $sid       Search document spec ID
+     * @return array|null
+     */
+    public function getSearchDocumentSpecification($storeName, $sid);
+
+    /**
+     * Returns an array of all search document specifications, or specification ids
+     *
+     * @param string $storeName Store name
+     * @param string|null $type When supplied, will only return search document specifications that are triggered by this rdf:type
+     * @param bool $justReturnSpecId default is false. If true will only return an array of specification _id's, otherwise returns the array of specification documents
+     * @return array
+     */
+    public function getSearchDocumentSpecifications($storeName, $type = null, $justReturnSpecId = false);
+
+    /**
+     * Returns the requested table specification, if it exists
+     *
+     * @param string $storeName Store name
+     * @param string $tid       Table spec ID
+     * @return array|null
+     */
+    public function getTableSpecification($storeName, $tid);
+
+    /**
+     * Returns all defined table specifications
+     *
+     * @param string $storeName Store name
+     * @return array
+     */
+    public function getTableSpecifications($storeName);
+
+    /**
+     * Returns all defined view specification
+     *
+     * @param string $storeName Store name
+     * @return array
+     */
+    public function getViewSpecifications($storeName);
+
+    /**
+     * Returns a unique list of every rdf type configured in the view spec ['type'] restriction
+     * @param string      $storeName Store name
+     * @param string|null $pod       Pod name
+     * @return array
+     */
+    public function getTypesInViewSpecifications($storeName, $pod = null);
+
+    /**
+     * Returns a unique list of every rdf type configured in the table spec ['type'] restriction
+     * @param string      $storeName Store name
+     * @param string|null $pod       Pod name
+     * @return array
+     */
+    public function getTypesInTableSpecifications($storeName, $pod = null);
+
+    /**
+     * Returns a unique list of every rdf type configured in the search doc spec ['type'] restriction
+     * @param string      $storeName Store name
+     * @param string|null $pod       Pod name
+     * @return array
+     */
+    public function getTypesInSearchSpecifications($storeName, $pod = null);
+
+    /**
+     * Returns an array of database names
+     *
+     * @return array
+     */
+    public function getDbs();
+
+    /**
+     * Returns an array of defined namespaces
+     * @return array
+     */
+    public function getNamespaces();
+
+    /**
+     * @param string $storeName Store name
+     * @return string|null
+     */
+    public function getSearchProviderClassName($storeName);
+
+    /**
+     * @param string      $storeName      Store (database) name
+     * @param string|null $dataSource     Database server identifier
+     * @param string      $readPreference Mongo read preference
+     * @throws \Tripod\Exceptions\ConfigException
+     * @return Database
+     */
+    public function getDatabase($storeName, $dataSource = null, $readPreference = ReadPreference::RP_PRIMARY_PREFERRED);
+
+    /**
+     * @param string $storeName      Store (database) name
+     * @param string $podName        Pod (collection) name
+     * @param string $readPreference Mongo read preference
+     * @throws \Tripod\Exceptions\ConfigException
+     * @return Collection
+     */
+    public function getCollectionForCBD($storeName, $podName, $readPreference = ReadPreference::RP_PRIMARY_PREFERRED);
+
+    /**
+     * @param string $storeName      Store (database) name
+     * @param string $viewId         View spec ID
+     * @param string $readPreference Mongo read preference
+     * @throws \Tripod\Exceptions\ConfigException
+     * @return Collection
+     */
+    public function getCollectionForView($storeName, $viewId, $readPreference = ReadPreference::RP_PRIMARY_PREFERRED);
+
+    /**
+     * @param string $storeName        Store (database) name
+     * @param string $searchDocumentId Search document spec ID
+     * @param string $readPreference   Mongo read preference
+     * @throws \Tripod\Exceptions\ConfigException
+     * @return Collection
+     */
+    public function getCollectionForSearchDocument(
+        $storeName,
+        $searchDocumentId,
+        $readPreference = ReadPreference::RP_PRIMARY_PREFERRED
+    );
+
+    /**
+     * @param string $storeName      Store (database) name
+     * @param string $tableId        Table spec ID
+     * @param string $readPreference Mongo read preference
+     * @throws \Tripod\Exceptions\ConfigException
+     * @return Collection
+     */
+    public function getCollectionForTable($storeName, $tableId, $readPreference = ReadPreference::RP_PRIMARY_PREFERRED);
+
+    /**
+     * @param string $storeName      Store (database) name
+     * @param array  $tables         Array of table spec IDs
+     * @param string $readPreference Mongo read preference
+     * @throws \Tripod\Exceptions\ConfigException
+     * @return Collection[]
+     */
+    public function getCollectionsForTables(
+        $storeName,
+        array $tables = [],
+        $readPreference = ReadPreference::RP_PRIMARY_PREFERRED
+    );
+
+    /**
+     * @param string $storeName      Store (database) name
+     * @param array  $views          Array of view spec IDs
+     * @param string $readPreference Mongo read preference
+     * @throws \Tripod\Exceptions\ConfigException
+     * @return Collection[]
+     */
+    public function getCollectionsForViews(
+        $storeName,
+        array $views = [],
+        $readPreference = ReadPreference::RP_PRIMARY_PREFERRED
+    );
+
+    /**
+     * @param string $storeName      Store (database) name
+     * @param array  $searchSpecIds  Array of search document spec IDs
+     * @param string $readPreference Mongo read preference
+     * @throws \Tripod\Exceptions\ConfigException
+     * @return Collection[]
+     */
+    public function getCollectionsForSearch(
+        $storeName,
+        array $searchSpecIds = [],
+        $readPreference = ReadPreference::RP_PRIMARY_PREFERRED
+    );
+
+    /**
+     * @param string $storeName      Store (database) name
+     * @param string $readPreference Mongo read preference
+     * @return Collection
+     */
+    public function getCollectionForTTLCache($storeName, $readPreference = ReadPreference::RP_PRIMARY_PREFERRED);
+
+    /**
+     * @param string $storeName      Store (database) name
+     * @param string $readPreference Mongo read preference
+     * @return Collection
+     */
+    public function getCollectionForManualRollbackAudit(
+        $storeName,
+        $readPreference = ReadPreference::RP_PRIMARY_PREFERRED
+    );
+
+    /**
+     * @param string $storeName      Store (database) name
+     * @param string $readPreference Mongo read preference
+     * @return Collection
+     */
+    public function getCollectionForJobGroups($storeName, $readPreference = ReadPreference::RP_PRIMARY_PREFERRED);
+
+    /**
+     * @param $readPreference Mongo read preference
+     * @return Database
+     * @throws \Tripod\Exceptions\ConfigException
+     */
+    public function getTransactionLogDatabase($readPreference = ReadPreference::RP_PRIMARY_PREFERRED);
+
+    /**
+     * @return string
+     */
+    public static function getDiscoverQueueName();
+
+    /**
+     * @return string
+     */
+    public static function getApplyQueueName();
+
+    /**
+     * @return string
+     */
+    public static function getEnsureIndexesQueueName();
+
+    /**
+     * @return string
+     */
+    public static function getResqueServer();
+
+    /**
+     * @return \Psr\Log\LoggerInterface;
+     */
+    public static function getLogger();
+}

--- a/src/mongo/JobGroup.php
+++ b/src/mongo/JobGroup.php
@@ -77,7 +77,7 @@ class JobGroup
     protected function getMongoCollection()
     {
         if (!isset($this->collection)) {
-            $config = Config::getInstance();
+            $config = \Tripod\Config::getInstance();
 
             $this->collection = $config->getCollectionForJobGroups($this->storeName);
         }

--- a/src/mongo/Labeller.class.php
+++ b/src/mongo/Labeller.class.php
@@ -2,16 +2,12 @@
 
 namespace Tripod\Mongo;
 
-/** @noinspection PhpIncludeInspection */
-require_once TRIPOD_DIR.'classes/Labeller.class.php';
-require_once TRIPOD_DIR . 'exceptions/LabellerException.class.php';
-
 /**
  * Class Labeller
  * @package Tripod\Mongo
  */
-class Labeller extends \Tripod\Labeller {
-
+class Labeller extends \Tripod\Labeller
+{
     /**
      * Constructor
      */
@@ -24,7 +20,7 @@ class Labeller extends \Tripod\Labeller {
             'owl' => 'http://www.w3.org/2002/07/owl#',
             'cs' => 'http://purl.org/vocab/changeset/schema#',
         );
-        $config = Config::getInstance();
+        $config = \Tripod\Config::getInstance();
         $ns = $config->getNamespaces();
         foreach ($ns as $prefix=>$uri)
         {

--- a/src/mongo/MongoGraph.class.php
+++ b/src/mongo/MongoGraph.class.php
@@ -2,11 +2,7 @@
 
 namespace Tripod\Mongo;
 
-require_once TRIPOD_DIR.'classes/ExtendedGraph.class.php';
 require_once TRIPOD_DIR.'mongo/MongoTripodConstants.php';
-require_once TRIPOD_DIR . 'mongo/Config.class.php';
-require_once TRIPOD_DIR . 'mongo/Labeller.class.php';
-require_once TRIPOD_DIR . 'mongo/serializers/NQuadSerializer.class.php';
 
 /**
  * Class MongoGraph

--- a/src/mongo/base/DriverBase.class.php
+++ b/src/mongo/base/DriverBase.class.php
@@ -122,7 +122,7 @@ abstract class DriverBase
     protected $labeller;
 
     /**
-     * @var Config
+     * @var IConfigInstance
      */
     protected $config = null;
 
@@ -427,7 +427,7 @@ abstract class DriverBase
 
     /**
      * For mocking
-     * @return Config
+     * @return IConfigInstance
      */
     protected function getConfigInstance()
     {

--- a/src/mongo/base/DriverBase.class.php
+++ b/src/mongo/base/DriverBase.class.php
@@ -139,10 +139,10 @@ abstract class DriverBase
      * @param string|null $context
      * @return mixed
      */
-    protected function getContextAlias($context=null)
+    protected function getContextAlias($context = null)
     {
         $contextAlias = $this->labeller->uri_to_alias((empty($context)) ? $this->defaultContext : $context);
-        return (empty($contextAlias)) ? Config::getInstance()->getDefaultContextAlias() : $contextAlias;
+        return (empty($contextAlias)) ? $this->getConfigInstance()->getDefaultContextAlias() : $contextAlias;
     }
 
     /**
@@ -431,7 +431,7 @@ abstract class DriverBase
      */
     protected function getConfigInstance()
     {
-        return Config::getInstance();
+        return \Tripod\Config::getInstance();
     }
 
     /**

--- a/src/mongo/base/JobBase.class.php
+++ b/src/mongo/base/JobBase.class.php
@@ -104,7 +104,7 @@ abstract class JobBase extends \Tripod\Mongo\DriverBase
     {
         /** @var JobBase $failedJob */
         $failedJob = $job->getInstance();
-        $failedJob->errorLog('Caught exception in '. get_class(self) . ': ' . $e->getMessage());
+        $failedJob->errorLog('Caught exception in '. get_called_class() . ': ' . $e->getMessage());
         $failedJob->getStat()->increment($failedJob->getStatFailureIncrementKey());
         throw $e;
     }

--- a/src/mongo/base/JobBase.class.php
+++ b/src/mongo/base/JobBase.class.php
@@ -58,10 +58,10 @@ abstract class JobBase extends \Tripod\Mongo\DriverBase
 
     /**
      * Called in every job prior to perform()
-     *
+     * @param \Resque_Job The queued job
      * @return void
      */
-    public function beforePerform(\Resque_Job $job)
+    public static function beforePerform(\Resque_Job $job)
     {
         $job->getInstance()->validateArgs();
     }
@@ -96,15 +96,16 @@ abstract class JobBase extends \Tripod\Mongo\DriverBase
     /**
      * Resque event when a job failures
      *
-     * @param \Exception $e Exception
+     * @param \Exception  $e   Exception
+     * @param \Resque_Job $job The failed job
      * @return void
      */
-    public function onFailure(\Exception $e)
+    public static function onFailure(\Exception $e, \Resque_Job $job)
     {
-        $this->getStat()->increment($this->getStatFailureIncrementKey());
-        $this->errorLog(
-            'Caught exception in '. get_class($this) . ': ' . $e->getMessage()
-        );
+        /** @var JobBase $failedJob */
+        $failedJob = $job->getInstance();
+        $failedJob->errorLog('Caught exception in '. get_class($this) . ': ' . $e->getMessage());
+        $failedJob->getStat()->increment($failedJob->getStatFailureIncrementKey());
         throw $e;
     }
 

--- a/src/mongo/base/JobBase.class.php
+++ b/src/mongo/base/JobBase.class.php
@@ -205,7 +205,7 @@ abstract class JobBase extends \Tripod\Mongo\DriverBase
         // @see https://github.com/chrisboulton/php-resque/issues/228, when this PR is merged we can stop tracking the status in this way
         try {
             if (isset($data[self::TRIPOD_CONFIG_GENERATOR])) {
-                $data[self::TRIPOD_CONFIG_GENERATOR] = $this->cacheConfig($data[self::TRIPOD_CONFIG_KEY]);
+                $data[self::TRIPOD_CONFIG_GENERATOR] = $this->serializeConfig($data[self::TRIPOD_CONFIG_GENERATOR]);
             }
             $token = $this->enqueue($queueName, $class, $data);
             if (!$this->getJobStatus($token)) {

--- a/src/mongo/base/JobBase.class.php
+++ b/src/mongo/base/JobBase.class.php
@@ -104,7 +104,7 @@ abstract class JobBase extends \Tripod\Mongo\DriverBase
     {
         /** @var JobBase $failedJob */
         $failedJob = $job->getInstance();
-        $failedJob->errorLog('Caught exception in '. get_class($this) . ': ' . $e->getMessage());
+        $failedJob->errorLog('Caught exception in '. get_class(self) . ': ' . $e->getMessage());
         $failedJob->getStat()->increment($failedJob->getStatFailureIncrementKey());
         throw $e;
     }

--- a/src/mongo/delegates/SearchDocuments.class.php
+++ b/src/mongo/delegates/SearchDocuments.class.php
@@ -78,7 +78,7 @@ class SearchDocuments extends DriverBase
                     'r'=>$this->labeller->uri_to_alias($resource),
                     'c'=>$this->labeller->uri_to_alias($context));
 
-                if (Config::getInstance()->getCollectionForCBD($this->storeName, $irFrom)->findOne($indexRules['condition']))
+                if ($this->getConfigInstance()->getCollectionForCBD($this->storeName, $irFrom)->findOne($indexRules['condition']))
                 {
                     // match found, add this spec id to those that should be generated
                    $proceedWithGeneration = true;
@@ -101,7 +101,7 @@ class SearchDocuments extends DriverBase
             'c'=>$this->labeller->uri_to_alias($context)
         );
 
-        $sourceDocument = Config::getInstance()->getCollectionForCBD($this->storeName, $from)->findOne(array('_id'=>$_id));
+        $sourceDocument = $this->getConfigInstance()->getCollectionForCBD($this->storeName, $from)->findOne(array('_id'=>$_id));
 
         if(empty($sourceDocument)){
             $this->debugLog("Source document not found for $resource, cannot proceed generating $specId search document");
@@ -156,7 +156,7 @@ class SearchDocuments extends DriverBase
 
         foreach($rdfTypes as $rdfType)
         {
-            $specs = Config::getInstance()->getSearchDocumentSpecifications($this->storeName, $rdfType);
+            $specs = $this->getConfigInstance()->getSearchDocumentSpecifications($this->storeName, $rdfType);
 
             if(empty($specs)) continue; // no point doing anything else if there is no spec for the type
 
@@ -180,7 +180,7 @@ class SearchDocuments extends DriverBase
     {
         // expand sequences before proceeding
         $this->expandSequence($joins, $source);
-        $config = Config::getInstance();
+        $config = $this->getConfigInstance();
         foreach($joins as $predicate=>$rules){
             if(isset($source[$predicate])){
                 $joinUris = array();
@@ -289,7 +289,7 @@ class SearchDocuments extends DriverBase
      */
     protected function getSearchDocumentSpecification($specId)
     {
-        return Config::getInstance()->getSearchDocumentSpecification($this->storeName, $specId);
+        return $this->getConfigInstance()->getSearchDocumentSpecification($this->storeName, $specId);
     }
 
     /**

--- a/src/mongo/delegates/SearchDocuments.class.php
+++ b/src/mongo/delegates/SearchDocuments.class.php
@@ -203,7 +203,7 @@ class SearchDocuments extends DriverBase
                 );
 
                 $cursor = $collection->find(array('_id'=>array('$in'=>$joinUris)), array(
-                    'maxTimeMS' => \Tripod\Mongo\Config::getInstance()->getMongoCursorTimeout()
+                    'maxTimeMS' => $this->getConfigInstance()->getMongoCursorTimeout()
                 ));
 
                 // add to impact index

--- a/src/mongo/delegates/SearchIndexer.class.php
+++ b/src/mongo/delegates/SearchIndexer.class.php
@@ -7,7 +7,6 @@ require_once TRIPOD_DIR . 'mongo/delegates/SearchDocuments.class.php';
 require_once TRIPOD_DIR . 'mongo/providers/MongoSearchProvider.class.php';
 require_once TRIPOD_DIR . 'exceptions/SearchException.class.php';
 
-use Tripod\Mongo\Config;
 use Tripod\Mongo\ImpactedSubject;
 use Tripod\Mongo\Labeller;
 use Tripod\Mongo\Jobs\ApplyOperation;
@@ -44,10 +43,10 @@ class SearchIndexer extends CompositeBase
         $this->podName = $tripod->podName;
         $this->labeller = new Labeller();
         $this->stat = $tripod->getStat();
-        $this->config = Config::getInstance();
+        $this->config = $this->getConfigInstance();
         $provider = $this->config->getSearchProviderClassName($this->tripod->getStoreName());
 
-        if(class_exists($provider)){
+        if (class_exists($provider)) {
             $this->configuredProvider = new $provider($this->tripod);
         } else {
             throw new \Tripod\Exceptions\SearchException("Did not recognise Search Provider, or could not find class: $provider");
@@ -158,8 +157,10 @@ class SearchIndexer extends CompositeBase
             }
         }
 
-        foreach($documentsToIndex as $document) {
-            if(!empty($document)) $searchProvider->indexDocument($document);
+        foreach ($documentsToIndex as $document) {
+            if (!empty($document)) {
+                $searchProvider->indexDocument($document);
+            }
         }
     }
 
@@ -170,16 +171,19 @@ class SearchIndexer extends CompositeBase
      * @param string|null $queueName
      * @return array|null Will return an array with a count and group id, if $queueName is sent and $resourceUri is null
      */
-    public function generateSearchDocuments($searchDocumentType, $resourceUri=null, $context=null, $queueName=null)
-    {
+    public function generateSearchDocuments(
+        $searchDocumentType,
+        $resourceUri = null,
+        $context = null,
+        $queueName = null
+    ) {
         $t = new \Tripod\Timer();
         $t->start();
         // default the context
         $contextAlias = $this->getContextAlias($context);
-        $spec = \Tripod\Mongo\Config::getInstance()->getSearchDocumentSpecification($this->getStoreName(), $searchDocumentType);
+        $spec = $this->getConfigInstance()->getSearchDocumentSpecification($this->getStoreName(), $searchDocumentType);
 
-        if($resourceUri)
-        {
+        if ($resourceUri) {
             $this->generateAndIndexSearchDocuments($resourceUri, $contextAlias, $spec['from'], $searchDocumentType);
             return;
         }

--- a/src/mongo/delegates/TransactionLog.class.php
+++ b/src/mongo/delegates/TransactionLog.class.php
@@ -1,7 +1,6 @@
 <?php
 
 namespace Tripod\Mongo;
-require_once TRIPOD_DIR . 'mongo/Config.class.php';
 
 use \MongoDB\InsertOneResult;
 use \MongoDB\UpdateOneResult;
@@ -22,7 +21,7 @@ class TransactionLog
      */
     public function __construct()
     {
-        $config = Config::getInstance();
+        $config = \Tripod\Config::getInstance();
         $this->config = $config->getTransactionLogConfig();
         $this->transaction_db = $config->getTransactionLogDatabase();
         $this->transaction_collection = $this->transaction_db->selectCollection($this->config['collection']);

--- a/src/mongo/delegates/Updates.class.php
+++ b/src/mongo/delegates/Updates.class.php
@@ -867,7 +867,8 @@ class Updates extends DriverBase
                 $data[OP_QUEUE] = $this->queueName;
                 $queueName = $this->queueName;
             } else {
-                $queueName =  $this->getConfigInstance()::getDiscoverQueueName();
+                $configInstance = $this->getConfigInstance();
+                $queueName =  $configInstance::getDiscoverQueueName();
             }
 
             $this->getDiscoverImpactedSubjects()->createJob($data, $queueName);

--- a/src/mongo/delegates/Updates.class.php
+++ b/src/mongo/delegates/Updates.class.php
@@ -9,14 +9,14 @@ use \MongoDB\Database;
 use \MongoDB\Collection;
 use \MongoDB\Operation\FindOneAndUpdate;
 use \MongoDB\BSON\ObjectId;
-
-require_once TRIPOD_DIR . 'mongo/Config.class.php';
+use Tripod\Mongo\Jobs\DiscoverImpactedSubjects;
 
 /**
  * Class Updates
  * @package Tripod\Mongo
  */
-class Updates extends DriverBase {
+class Updates extends DriverBase
+{
 
     /**
      * $var TransactionLog
@@ -167,11 +167,10 @@ class Updates extends DriverBase {
         ));
 
         $this->setReadPreferenceToPrimary();
-        try{
+        try {
             $contextAlias = $this->getContextAlias($context);
 
-            if (!Config::getInstance()->isPodWithinStore($this->getStoreName(),$this->getPodName()))
-            {
+            if (!$this->getConfigInstance()->isPodWithinStore($this->getStoreName(), $this->getPodName())) {
                 throw new \Tripod\Exceptions\Exception("database:collection " . $this->getStoreName() . ":" . $this->getPodName(). " is not referenced within config, so cannot be written to");
             }
 
@@ -304,7 +303,7 @@ class Updates extends DriverBase {
      */
     protected function validateGraphCardinality(\Tripod\ExtendedGraph $graph)
     {
-        $config = Config::getInstance();
+        $config = $this->getConfigInstance();
         $cardinality = $config->getCardinality($this->getStoreName(), $this->getPodName());
         $namespaces = $config->getNamespaces();
         $graphSubjects = $graph->get_subjects();
@@ -851,29 +850,24 @@ class Updates extends DriverBase {
      * @param array $subjectsAndPredicatesOfChange
      * @param string $contextAlias
      */
-    protected function queueASyncOperations(Array $subjectsAndPredicatesOfChange,$contextAlias)
+    protected function queueASyncOperations(array $subjectsAndPredicatesOfChange, $contextAlias)
     {
         $operations = $this->getAsyncOperations();
         if (!empty($operations)) {
-            $data = array(
-                "changes" => $subjectsAndPredicatesOfChange,
-                "operations" => $operations,
-                "tripodConfig" => Config::getConfig(),
-                "storeName" => $this->storeName,
-                "podName" => $this->podName,
-                "contextAlias" => $contextAlias,
-                "statsConfig"=>$this->getStatsConfig()
-            );
+            $data = [
+                'changes' => $subjectsAndPredicatesOfChange,
+                'operations' => $operations,
+                'storeName' => $this->storeName,
+                'podName' => $this->podName,
+                'contextAlias' => $contextAlias,
+                'statsConfig' => $this->getStatsConfig()
+            ];
 
-
-            if(isset($this->queueName))
-            {
+            if (isset($this->queueName)) {
                 $data[OP_QUEUE] = $this->queueName;
                 $queueName = $this->queueName;
-            }
-            else
-            {
-                $queueName =  Config::getDiscoverQueueName();
+            } else {
+                $queueName =  $this->getConfigInstance()::getDiscoverQueueName();
             }
 
             $this->getDiscoverImpactedSubjects()->createJob($data, $queueName);
@@ -886,8 +880,7 @@ class Updates extends DriverBase {
      */
     protected function getDiscoverImpactedSubjects()
     {
-        if(!isset($this->discoverImpactedSubjects))
-        {
+        if (!isset($this->discoverImpactedSubjects)) {
             $this->discoverImpactedSubjects = new \Tripod\Mongo\Jobs\DiscoverImpactedSubjects();
         }
         return $this->discoverImpactedSubjects;
@@ -1217,15 +1210,6 @@ class Updates extends DriverBase {
     }
 
     /**
-     * For mocking
-     * @return Config
-     */
-    protected function getConfigInstance()
-    {
-        return Config::getInstance();
-    }
-
-    /**
      * @return ObjectId
      */
     protected function generateIdForNewMongoDocument()
@@ -1357,7 +1341,7 @@ class Updates extends DriverBase {
     protected function getContextAlias($context=null)
     {
         $contextAlias = $this->labeller->uri_to_alias((empty($context)) ? $this->defaultContext : $context);
-        return (empty($contextAlias)) ? Config::getInstance()->getDefaultContextAlias() : $contextAlias;
+        return (empty($contextAlias)) ? $this->getConfigInstance()->getDefaultContextAlias() : $contextAlias;
     }
 
     /**

--- a/src/mongo/jobs/ApplyOperation.class.php
+++ b/src/mongo/jobs/ApplyOperation.class.php
@@ -36,7 +36,9 @@ class ApplyOperation extends JobBase {
             }
 
             // set the config to what is received
-            \Tripod\Mongo\Config::setConfig($this->args[self::TRIPOD_CONFIG_KEY]);
+            \Tripod\Mongo\Config::setConfig(
+                $this->getConfig($this->args[self::TRIPOD_CONFIG_KEY])
+            );
 
             $this->getStat()->increment(MONGO_QUEUE_APPLY_OPERATION_JOB . '.' . SUBJECT_COUNT, count($this->args[self::SUBJECTS_KEY]));
 

--- a/src/mongo/jobs/ApplyOperation.class.php
+++ b/src/mongo/jobs/ApplyOperation.class.php
@@ -4,6 +4,7 @@ namespace Tripod\Mongo\Jobs;
 
 use Tripod\Mongo\JobGroup;
 use Tripod\Mongo\Driver;
+use Tripod\ITripodConfigSerializer;
 
 /**
  * Class ApplyOperation
@@ -104,10 +105,11 @@ class ApplyOperation extends JobBase
      */
     public function createJob(array $subjects, $queueName = null, $otherData = [])
     {
+        $configInstance = $this->getConfigInstance();
         if (!$queueName) {
-            $queueName = \Tripod\Mongo\Config::getApplyQueueName();
-        } elseif (strpos($queueName, \Tripod\Mongo\Config::getApplyQueueName()) === false) {
-            $queueName = \Tripod\Mongo\Config::getApplyQueueName() . '::' . $queueName;
+            $queueName = $configInstance::getApplyQueueName();
+        } elseif (strpos($queueName, $configInstance::getApplyQueueName()) === false) {
+            $queueName = $configInstance::getApplyQueueName() . '::' . $queueName;
         }
 
         $data = [
@@ -117,8 +119,12 @@ class ApplyOperation extends JobBase
                 },
                 $subjects
             ),
-            self::TRIPOD_CONFIG_KEY=>\Tripod\Mongo\Config::getConfig()
         ];
+
+        $data = array_merge(
+            $this->generateConfigJobArgs(),
+            $data
+        );
 
         $this->submitJob($queueName, get_class($this), array_merge($otherData, $data));
     }

--- a/src/mongo/jobs/ApplyOperation.class.php
+++ b/src/mongo/jobs/ApplyOperation.class.php
@@ -24,66 +24,77 @@ class ApplyOperation extends JobBase
      */
     public function perform()
     {
-        try {
-            $this->getStat()->increment(
-                MONGO_QUEUE_APPLY_OPERATION_JOB . '.' . SUBJECT_COUNT,
-                count($this->args[self::SUBJECTS_KEY])
-            );
+        $this->getStat()->increment(
+            MONGO_QUEUE_APPLY_OPERATION_JOB . '.' . SUBJECT_COUNT,
+            count($this->args[self::SUBJECTS_KEY])
+        );
 
-            foreach ($this->args[self::SUBJECTS_KEY] as $subject) {
-                $opTimer = new \Tripod\Timer();
-                $opTimer->start();
+        foreach ($this->args[self::SUBJECTS_KEY] as $subject) {
+            $opTimer = new \Tripod\Timer();
+            $opTimer->start();
 
-                $impactedSubject = $this->createImpactedSubject($subject);
-                $impactedSubject->update();
+            $impactedSubject = $this->createImpactedSubject($subject);
+            $impactedSubject->update();
 
-                $opTimer->stop();
-                // stat time taken to perform operation for the given subject
-                $this->getStat()->timer(MONGO_QUEUE_APPLY_OPERATION.'.'.$subject['operation'], $opTimer->result());
+            $opTimer->stop();
+            // stat time taken to perform operation for the given subject
+            $this->getStat()->timer(MONGO_QUEUE_APPLY_OPERATION.'.'.$subject['operation'], $opTimer->result());
 
-                /**
-                 * ApplyOperation jobs can either apply to a single resource (e.g. 'create composite for the given
-                 * resource uri) or for a specification id (i.e. regenerate all of the composites defined by the
-                 * specification).  For the latter, we need to keep track of how many jobs have run so we can clean
-                 * up any stale composite documents when completed.  The TRACKING_KEY value will be the JobGroup id.
-                 */
-                if (isset($this->args[self::TRACKING_KEY])) {
-                    $jobGroup = $this->getJobGroup($subject['storeName'], $this->args[self::TRACKING_KEY]);
-                    $jobCount = $jobGroup->incrementJobCount(-1);
-                    if ($jobCount <= 0) {
-                        // @todo Replace this with ObjectId->getTimestamp() if we upgrade Mongo driver to 1.2
-                        $timestamp = new \MongoDB\BSON\UTCDateTime(hexdec(substr($jobGroup->getId(), 0, 8)) * 1000);
-                        $tripod = $this->getTripod($subject['storeName'], $subject['podName']);
-                        $count = 0;
-                        foreach ($subject['specTypes'] as $specId) {
-                            switch ($subject['operation']) {
-                                case \OP_VIEWS:
-                                    $count += $tripod->getComposite(\OP_VIEWS)->deleteViewsByViewId($specId, $timestamp);
-                                    break;
-                                case \OP_TABLES:
-                                    $count += $tripod->getComposite(\OP_TABLES)->deleteTableRowsByTableId($specId, $timestamp);
-                                    break;
-                                case \OP_SEARCH:
-                                    $searchProvider = $this->getSearchProvider($tripod);
-                                    $count += $searchProvider->deleteSearchDocumentsByTypeId($specId, $timestamp);
-                                    break;
-                            }
+            /**
+             * ApplyOperation jobs can either apply to a single resource (e.g. 'create composite for the given
+             * resource uri) or for a specification id (i.e. regenerate all of the composites defined by the
+             * specification).  For the latter, we need to keep track of how many jobs have run so we can clean
+             * up any stale composite documents when completed.  The TRACKING_KEY value will be the JobGroup id.
+             */
+            if (isset($this->args[self::TRACKING_KEY])) {
+                $jobGroup = $this->getJobGroup($subject['storeName'], $this->args[self::TRACKING_KEY]);
+                $jobCount = $jobGroup->incrementJobCount(-1);
+                if ($jobCount <= 0) {
+                    // @todo Replace this with ObjectId->getTimestamp() if we upgrade Mongo driver to 1.2
+                    $timestamp = new \MongoDB\BSON\UTCDateTime(hexdec(substr($jobGroup->getId(), 0, 8)) * 1000);
+                    $tripod = $this->getTripod($subject['storeName'], $subject['podName']);
+                    $count = 0;
+                    foreach ($subject['specTypes'] as $specId) {
+                        switch ($subject['operation']) {
+                            case \OP_VIEWS:
+                                $count += $tripod->getComposite(\OP_VIEWS)->deleteViewsByViewId($specId, $timestamp);
+                                break;
+                            case \OP_TABLES:
+                                $count += $tripod->getComposite(\OP_TABLES)->deleteTableRowsByTableId($specId, $timestamp);
+                                break;
+                            case \OP_SEARCH:
+                                $searchProvider = $this->getSearchProvider($tripod);
+                                $count += $searchProvider->deleteSearchDocumentsByTypeId($specId, $timestamp);
+                                break;
                         }
-                        $this->infoLog(
-                            '[JobGroupId ' . $jobGroup->getId()->__toString() . '] composite cleanup for ' .
-                            $subject['operation'] . ' removed ' . $count . ' stale composite documents'
-                        );
                     }
+                    $this->infoLog(
+                        '[JobGroupId ' . $jobGroup->getId()->__toString() . '] composite cleanup for ' .
+                        $subject['operation'] . ' removed ' . $count . ' stale composite documents'
+                    );
                 }
             }
-
-            // stat time taken to process job, from time it was picked up
-            $this->getStat()->timer(MONGO_QUEUE_APPLY_OPERATION_SUCCESS, $this->timer->result());
-        } catch (\Exception $e) {
-            $this->getStat()->increment(MONGO_QUEUE_APPLY_OPERATION_FAIL);
-            $this->errorLog("Caught exception in ".get_class($this).": ".$e->getMessage());
-            throw $e;
         }
+    }
+
+    /**
+     * Stat string for successful job timer
+     *
+     * @return string
+     */
+    protected function getStatTimerSuccessKey()
+    {
+        return MONGO_QUEUE_APPLY_OPERATION_SUCCESS;
+    }
+
+    /**
+     * Stat string for failed job increment
+     *
+     * @return string
+     */
+    protected function getStatFailureIncrementKey()
+    {
+        return MONGO_QUEUE_APPLY_OPERATION_FAIL;
     }
 
     /**

--- a/src/mongo/jobs/DiscoverImpactedSubjects.class.php
+++ b/src/mongo/jobs/DiscoverImpactedSubjects.class.php
@@ -125,14 +125,9 @@ class DiscoverImpactedSubjects extends JobBase
         }
     }
 
-    /**
-     * Runs after job completes
-     *
-     * @return void
-     */
-    public function afterPerform()
+    public function tearDown()
     {
-        parent::afterPerform();
+        parent::tearDown();
         $this->getStat()->increment(MONGO_QUEUE_DISCOVER_JOB . '.' . SUBJECT_COUNT, $this->subjectCount);
     }
 

--- a/src/mongo/jobs/DiscoverImpactedSubjects.class.php
+++ b/src/mongo/jobs/DiscoverImpactedSubjects.class.php
@@ -42,7 +42,9 @@ class DiscoverImpactedSubjects extends JobBase {
             $this->validateArgs();
 
             // set the config to what is received
-            \Tripod\Mongo\Config::setConfig($this->args[self::TRIPOD_CONFIG_KEY]);
+            \Tripod\Mongo\Config::setConfig(
+                $this->getConfig($this->args[self::TRIPOD_CONFIG_KEY])
+            );
 
             $statsConfig = array();
             if(isset($this->args['statsConfig']))

--- a/src/mongo/jobs/EnsureIndexes.class.php
+++ b/src/mongo/jobs/EnsureIndexes.class.php
@@ -60,20 +60,20 @@ class EnsureIndexes extends JobBase
      */
     public function createJob($storeName, $reindex, $background, $queueName = null)
     {
+        $configInstance = $this->getConfigInstance();
         if (!$queueName) {
-            $queueName = \Tripod\Mongo\Config::getEnsureIndexesQueueName();
-        } elseif (strpos($queueName, \Tripod\Mongo\Config::getEnsureIndexesQueueName()) === false) {
-            $queueName = \Tripod\Mongo\Config::getEnsureIndexesQueueName() . '::' . $queueName;
+            $queueName = $configInstance::getEnsureIndexesQueueName();
+        } elseif (strpos($queueName, $configInstance::getEnsureIndexesQueueName()) === false) {
+            $queueName = $configInstance::getEnsureIndexesQueueName() . '::' . $queueName;
         }
 
-        $data = array(
+        $data = [
             self::STORENAME_KEY => $storeName,
             self::REINDEX_KEY => $reindex,
-            self::BACKGROUND_KEY => $background,
-            self::TRIPOD_CONFIG_KEY => \Tripod\Mongo\Config::getConfig()
-        );
+            self::BACKGROUND_KEY => $background
+        ];
 
-        $this->submitJob($queueName, get_class($this), $data);
+        $this->submitJob($queueName, get_class($this), array_merge($data, $this->generateConfigJobArgs()));
     }
 
     /**

--- a/src/mongo/jobs/EnsureIndexes.class.php
+++ b/src/mongo/jobs/EnsureIndexes.class.php
@@ -27,7 +27,9 @@ class EnsureIndexes extends JobBase {
 
             $this->validateArgs();
 
-            \Tripod\Mongo\Config::setConfig($this->args[self::TRIPOD_CONFIG_KEY]);
+            \Tripod\Mongo\Config::setConfig(
+                $this->getConfig($this->args[self::TRIPOD_CONFIG_KEY])
+            );
             $this->debugLog('Ensuring indexes for tenant=' . $this->args[self::STORENAME_KEY]. ', reindex=' . $this->args[self::REINDEX_KEY] . ', background=' . $this->args[self::BACKGROUND_KEY]);
 
             $this->getIndexUtils()->ensureIndexes(

--- a/src/mongo/jobs/EnsureIndexes.class.php
+++ b/src/mongo/jobs/EnsureIndexes.class.php
@@ -22,22 +22,33 @@ class EnsureIndexes extends JobBase
      */
     public function perform()
     {
-        try {
-            $this->debugLog('Ensuring indexes for tenant=' . $this->args[self::STORENAME_KEY]. ', reindex=' . $this->args[self::REINDEX_KEY] . ', background=' . $this->args[self::BACKGROUND_KEY]);
+        $this->debugLog('Ensuring indexes for tenant=' . $this->args[self::STORENAME_KEY]. ', reindex=' . $this->args[self::REINDEX_KEY] . ', background=' . $this->args[self::BACKGROUND_KEY]);
 
-            $this->getIndexUtils()->ensureIndexes(
-                $this->args[self::REINDEX_KEY],
-                $this->args[self::STORENAME_KEY],
-                $this->args[self::BACKGROUND_KEY]
-            );
+        $this->getIndexUtils()->ensureIndexes(
+            $this->args[self::REINDEX_KEY],
+            $this->args[self::STORENAME_KEY],
+            $this->args[self::BACKGROUND_KEY]
+        );
+    }
 
-            // stat time taken to process job, from time it was picked up
-            $this->getStat()->timer(MONGO_QUEUE_ENSURE_INDEXES_SUCCESS, $this->timer->result());
-        } catch (\Exception $e) {
-            $this->getStat()->increment(MONGO_QUEUE_ENSURE_INDEXES_FAIL);
-            $this->errorLog("Caught exception in ".get_class($this).": ".$e->getMessage());
-            throw $e;
-        }
+    /**
+     * Stat string for successful job timer
+     *
+     * @return string
+     */
+    protected function getStatTimerSuccessKey()
+    {
+        return MONGO_QUEUE_ENSURE_INDEXES_SUCCESS;
+    }
+
+    /**
+     * Stat string for failed job increment
+     *
+     * @return string
+     */
+    protected function getStatFailureIncrementKey()
+    {
+        return MONGO_QUEUE_ENSURE_INDEXES_FAIL;
     }
 
     /**

--- a/src/mongo/providers/MongoSearchProvider.class.php
+++ b/src/mongo/providers/MongoSearchProvider.class.php
@@ -2,10 +2,7 @@
 
 namespace Tripod\Mongo;
 
-require_once TRIPOD_DIR.'mongo/MongoTripodConstants.php';
-require_once TRIPOD_DIR . 'mongo/delegates/SearchDocuments.class.php';
-require_once TRIPOD_DIR . 'mongo/providers/ISearchProvider.php';
-require_once TRIPOD_DIR.'classes/Timer.class.php';
+require_once TRIPOD_DIR . 'mongo/MongoTripodConstants.php';
 
 use \MongoDB\BSON\Regex;
 
@@ -45,7 +42,7 @@ class MongoSearchProvider implements \Tripod\ISearchProvider
         $this->tripod = $tripod;
         $this->storeName = $tripod->getStoreName();
         $this->labeller = new Labeller();
-        $this->config = Config::getInstance();
+        $this->config = \Tripod\Config::getInstance();
     }
 
     /**
@@ -369,7 +366,7 @@ class MongoSearchProvider implements \Tripod\ISearchProvider
      */
     protected function getSearchDocumentSpecification($typeId)
     {
-        return Config::getInstance()->getSearchDocumentSpecification($this->storeName, $typeId);
+        return $this->config->getSearchDocumentSpecification($this->storeName, $typeId);
     }
 
     /**

--- a/src/mongo/util/IndexUtils.class.php
+++ b/src/mongo/util/IndexUtils.class.php
@@ -2,8 +2,6 @@
 
 namespace Tripod\Mongo;
 
-require_once(TRIPOD_DIR . "mongo/Config.class.php");
-
 /**
  * Class IndexUtils
  * @package Tripod\Mongo
@@ -164,6 +162,6 @@ class IndexUtils
      */
     protected function getConfig()
     {
-        return Config::getInstance();
+        return \Tripod\Config::getInstance();
     }
 }

--- a/src/mongo/util/TriplesUtil.class.php
+++ b/src/mongo/util/TriplesUtil.class.php
@@ -12,8 +12,6 @@ use \MongoDB\Collection;
  * Class to help working with triples and Tripod
  */
 
-require_once(TRIPOD_DIR.'mongo/MongoGraph.class.php');
-
 /**
  * Class TriplesUtil
  * @package Tripod\Mongo
@@ -95,15 +93,12 @@ class TriplesUtil
      */
     public function loadTriplesAbout($subject,Array $triples,$storeName,$podName,$context=null,$allowableTypes=null)
     {
-        $context = ($context==null) ? Config::getInstance()->getDefaultContextAlias() : $this->labeller->uri_to_alias($context);
-        if (array_key_exists($podName,$this->collections))
-        {
+        $context = ($context==null) ? \Tripod\Config::getInstance()->getDefaultContextAlias() : $this->labeller->uri_to_alias($context);
+        if (array_key_exists($podName, $this->collections)) {
             $collection = $this->collections[$podName];
-        }
-        else
-        {
+        } else {
             $m = new Client(
-                Config::getInstance()->getConnStr($storeName),
+                \Tripod\Config::getInstance()->getConnStr($storeName),
                 [],
                 ['typeMap' => ['root' => 'array', 'document' => 'array', 'array' => 'array']]
             );
@@ -162,7 +157,7 @@ class TriplesUtil
      */
     public function bsonizeTriplesAbout($subject,Array $triples,$context=null)
     {
-        $context = ($context==null) ? Config::getInstance()->getDefaultContextAlias() : $this->labeller->uri_to_alias($context);
+        $context = ($context==null) ? \Tripod\Config::getInstance()->getDefaultContextAlias() : $this->labeller->uri_to_alias($context);
         $graph = new MongoGraph();
         foreach ($triples as $triple)
         {

--- a/src/tripod.inc.php
+++ b/src/tripod.inc.php
@@ -6,6 +6,8 @@ if (!defined('TRIPOD_DIR')) {
     define('TRIPOD_DIR', dirname(__FILE__) . '/' );
 }
 
+require_once TRIPOD_DIR . '/mongo/MongoTripodConstants.php';
+
 \Resque::setBackend(\Tripod\Mongo\Config::getResqueServer());
 
 define('RDF_TYPE', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type');

--- a/src/tripod.inc.php
+++ b/src/tripod.inc.php
@@ -2,47 +2,9 @@
 
 //todo: this file is mis-named. It has mongo specifics
 
-if(!defined('TRIPOD_DIR')) define('TRIPOD_DIR', dirname(__FILE__) . '/' );
-
-require_once TRIPOD_DIR.'classes/Timer.class.php';
-require_once TRIPOD_DIR.'ITripodStat.php';
-require_once TRIPOD_DIR . 'TripodStatFactory.class.php';
-require_once TRIPOD_DIR.'classes/StatsD.class.php';
-require_once TRIPOD_DIR . 'exceptions/Exception.class.php';
-require_once TRIPOD_DIR . 'exceptions/SearchException.class.php';
-require_once TRIPOD_DIR . 'exceptions/CardinalityException.class.php';
-require_once TRIPOD_DIR . 'exceptions/ConfigException.class.php';
-require_once TRIPOD_DIR . 'exceptions/LabellerException.class.php';
-require_once TRIPOD_DIR . 'exceptions/ViewException.class.php';
-require_once TRIPOD_DIR . 'exceptions/JobException.class.php';
-require_once TRIPOD_DIR.'mongo/MongoTripodConstants.php';
-require_once TRIPOD_DIR.'mongo/MongoGraph.class.php';
-require_once TRIPOD_DIR.'mongo/ImpactedSubject.class.php';
-require_once TRIPOD_DIR . 'mongo/base/DriverBase.class.php';
-require_once TRIPOD_DIR.'mongo/IComposite.php';
-require_once TRIPOD_DIR.'mongo/base/CompositeBase.class.php';
-require_once TRIPOD_DIR . 'mongo/delegates/TransactionLog.class.php';
-require_once TRIPOD_DIR . 'mongo/delegates/Updates.class.php';
-require_once TRIPOD_DIR . 'mongo/delegates/Views.class.php';
-require_once TRIPOD_DIR . 'mongo/delegates/Tables.class.php';
-require_once TRIPOD_DIR . 'mongo/delegates/SearchIndexer.class.php';
-require_once TRIPOD_DIR . 'IEventHook.php';
-require_once TRIPOD_DIR . 'IDriver.php';
-require_once TRIPOD_DIR.'classes/ChangeSet.class.php';
-require_once TRIPOD_DIR.'classes/Labeller.class.php';
-require_once TRIPOD_DIR . '/mongo/Driver.class.php';
-require_once TRIPOD_DIR . '/mongo/JobGroup.php';
-
-require_once TRIPOD_DIR.'/mongo/base/JobBase.class.php';
-require_once TRIPOD_DIR . '/mongo/jobs/DiscoverImpactedSubjects.class.php';
-require_once TRIPOD_DIR.'/mongo/jobs/ApplyOperation.class.php';
-require_once TRIPOD_DIR.'/mongo/jobs/EnsureIndexes.class.php';
-
-require_once TRIPOD_DIR . '/mongo/util/IndexUtils.class.php';
-require_once TRIPOD_DIR . '/mongo/util/TriplesUtil.class.php';
-require_once TRIPOD_DIR . '/mongo/util/DateUtil.class.php';
-
-require_once TRIPOD_DIR . '/mongo/serializers/NQuadSerializer.class.php';
+if (!defined('TRIPOD_DIR')) {
+    define('TRIPOD_DIR', dirname(__FILE__) . '/' );
+}
 
 \Resque::setBackend(\Tripod\Mongo\Config::getResqueServer());
 

--- a/test/performance/mongo/MongoTripodConfigTest.php
+++ b/test/performance/mongo/MongoTripodConfigTest.php
@@ -56,8 +56,8 @@ class MongoTripodConfigTest extends MongoTripodPerformanceTestBase
 
         //Let's try to create 1000 objects to see how much time they take.
         for($i =0; $i < self::BENCHMARK_OBJECT_CREATE_ITERATIONS; $i++) {
-            \Tripod\Mongo\Config::setConfig($this->config);
-            $instance = \Tripod\Mongo\Config::getInstance();
+            \Tripod\Config::setConfig($this->config);
+            $instance = \Tripod\Config::getInstance();
         }
 
         $testEndTime = microtime();

--- a/test/performance/mongo/MongoTripodPerformanceTestBase.php
+++ b/test/performance/mongo/MongoTripodPerformanceTestBase.php
@@ -1,11 +1,6 @@
 <?php
-set_include_path(
-    get_include_path()
-        . PATH_SEPARATOR . dirname(dirname(dirname(dirname(__FILE__))))
-        . PATH_SEPARATOR . dirname(dirname(dirname(dirname(__FILE__)))).'/lib'
-        . PATH_SEPARATOR . dirname(dirname(dirname(dirname(__FILE__)))).'/src');
-
-require_once('tripod.inc.php');
+require_once dirname(__FILE__) . '/../../../vendor/autoload.php';
+require_once dirname(__FILE__) . '/../../../src/tripod.inc.php';
 require_once dirname(__FILE__).'/../../unit/mongo/MongoTripodTestBase.php';
 
 

--- a/test/rest-interface/index.php
+++ b/test/rest-interface/index.php
@@ -31,11 +31,11 @@ $app->group('/1', function() use ($app, $tripodOptions) {
     {
         $app->get('/views/:viewId/:encodedFqUri', function($storeName, $viewSpecId, $encodedFqUri) use ($app, $tripodOptions)
         {
-            \Tripod\Mongo\Config::setConfig(json_decode(file_get_contents('./config/tripod-config-'.$storeName .'.json'), true));
+            \Tripod\Config::setConfig(json_decode(file_get_contents('./config/tripod-config-'.$storeName .'.json'), true));
             $i = 0;
             do
             {
-                $viewSpec = \Tripod\Mongo\Config::getInstance()->getViewSpecification($storeName, $viewSpecId);
+                $viewSpec = \Tripod\Config::getInstance()->getViewSpecification($storeName, $viewSpecId);
                 $podName = isset($viewSpec['from']) ? $viewSpec['from'] : null;
                 $tripodOptions['statsConfig'] = getStat($app, $tripodOptions);
                 $tripod = new \Tripod\Mongo\Driver($podName, $storeName, $tripodOptions);
@@ -71,7 +71,7 @@ $app->group('/1', function() use ($app, $tripodOptions) {
         {
             $app->group('/graph', function() use ($app, $tripodOptions) {
                 $app->get('/:encodedFqUri', function($storeName, $podName, $encodedFqUri) use ($app, $tripodOptions) {
-                    \Tripod\Mongo\Config::setConfig(json_decode(file_get_contents('./config/tripod-config-'.$storeName .'.json'), true));
+                    \Tripod\Config::setConfig(json_decode(file_get_contents('./config/tripod-config-'.$storeName .'.json'), true));
                     $tripodOptions['statsConfig'] = getStat($app, $tripodOptions);
 
                     $contentType = $app->request()->getMediaType();
@@ -129,7 +129,7 @@ $app->group('/1', function() use ($app, $tripodOptions) {
 
             $app->group('/change', function() use ($app, $tripodOptions) {
                 $app->post('/', function($storeName, $podName) use ($app, $tripodOptions) {
-                  \Tripod\Mongo\Config::setConfig(json_decode(file_get_contents('./config/tripod-config-'.$storeName .'.json'), true));
+                  \Tripod\Config::setConfig(json_decode(file_get_contents('./config/tripod-config-'.$storeName .'.json'), true));
                     $app->response()->setStatus(500);
                     $tripodOptions['statsConfig'] = getStat($app, $tripodOptions);
                     $tripod = new \Tripod\Mongo\Driver($podName, $storeName, $tripodOptions);

--- a/test/unit/mongo/ApplyOperationTest.php
+++ b/test/unit/mongo/ApplyOperationTest.php
@@ -25,7 +25,7 @@ class ApplyOperationTest extends MongoTripodTestBase
             'Exception',
             'Argument tripodConfig or tripodConfigGenerator was not present in supplied job args for job Tripod\Mongo\Jobs\ApplyOperation'
         );
-        $job->beforePerform();
+        $this->performJob($job);
     }
 
     public function testMandatoryArgSubject()
@@ -36,7 +36,7 @@ class ApplyOperationTest extends MongoTripodTestBase
         $job->args = $this->args;
         $job->job->payload['id'] = uniqid();
         $this->setExpectedException('Exception', "Argument subjects was not present in supplied job args for job Tripod\Mongo\Jobs\ApplyOperation");
-        $job->beforePerform();
+        $this->performJob($job);
     }
 
     public function testApplyViewOperation()

--- a/test/unit/mongo/ApplyOperationTest.php
+++ b/test/unit/mongo/ApplyOperationTest.php
@@ -2,16 +2,13 @@
 
 use Tripod\Mongo\Jobs\ApplyOperation;
 
-require_once 'MongoTripodTestBase.php';
-require_once 'PerformJob.php';
+require_once 'ResqueJobTestBase.php';
 
 /**
  * Class ApplyOperationTest
  */
-class ApplyOperationTest extends MongoTripodTestBase
+class ApplyOperationTest extends ResqueJobTestBase
 {
-    use PerformJob;
-
     protected $args = array();
 
     public function testMandatoryArgTripodConfig()
@@ -79,7 +76,7 @@ class ApplyOperationTest extends MongoTripodTestBase
             ->setMethods(array('update'))
             ->setConstructorArgs(array(
                 'tripod_php_testing',
-                \Tripod\Mongo\Config::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing'),
+                \Tripod\Config::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing'),
                 'http://talisapire.com/'
             ))->getMock();
 
@@ -170,7 +167,7 @@ class ApplyOperationTest extends MongoTripodTestBase
             ->setConstructorArgs(
                 [
                     'tripod_php_testing',
-                    \Tripod\Mongo\Config::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing'),
+                    \Tripod\Config::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing'),
                     'http://talisapire.com/'
                 ]
             )->getMock();
@@ -272,7 +269,7 @@ class ApplyOperationTest extends MongoTripodTestBase
             ->setConstructorArgs(
                 [
                     'tripod_php_testing',
-                    \Tripod\Mongo\Config::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing'),
+                    \Tripod\Config::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing'),
                     'http://talisapire.com/'
                 ]
             )->getMock();
@@ -378,7 +375,7 @@ class ApplyOperationTest extends MongoTripodTestBase
             ->setMethods(array('update'))
             ->setConstructorArgs(array(
                 'tripod_php_testing',
-                \Tripod\Mongo\Config::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing'),
+                \Tripod\Config::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing'),
                 'http://talisapire.com/'
             ))->getMock();
 
@@ -471,7 +468,7 @@ class ApplyOperationTest extends MongoTripodTestBase
             ->setConstructorArgs(
                 [
                     'tripod_php_testing',
-                    \Tripod\Mongo\Config::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing'),
+                    \Tripod\Config::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing'),
                     'http://talisapire.com/'
                 ]
             )->getMock();
@@ -576,7 +573,7 @@ class ApplyOperationTest extends MongoTripodTestBase
             ->setConstructorArgs(
                 [
                     'tripod_php_testing',
-                    \Tripod\Mongo\Config::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing'),
+                    \Tripod\Config::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing'),
                     'http://talisapire.com/'
                 ]
             )->getMock();
@@ -931,7 +928,7 @@ class ApplyOperationTest extends MongoTripodTestBase
 
         $jobData = array(
             'subjects'=>array($impactedSubject->toArray()),
-            'tripodConfig'=>\Tripod\Mongo\Config::getConfig(),
+            'tripodConfig'=>\Tripod\Config::getConfig(),
         );
 
         /** @var \Tripod\Mongo\Jobs\ApplyOperation|PHPUnit_Framework_MockObject_MockObject $applyOperation */
@@ -1035,7 +1032,7 @@ class ApplyOperationTest extends MongoTripodTestBase
 
         $jobData = array(
             'subjects'=>array($impactedSubject->toArray()),
-            'tripodConfig'=>\Tripod\Mongo\Config::getConfig(),
+            'tripodConfig'=>\Tripod\Config::getConfig(),
         );
 
         /** @var \Tripod\Mongo\Jobs\ApplyOperation|PHPUnit_Framework_MockObject_MockObject $applyOperation */
@@ -1074,7 +1071,7 @@ class ApplyOperationTest extends MongoTripodTestBase
         );
 
         $this->args = array(
-            'tripodConfig' => \Tripod\Mongo\Config::getConfig(),
+            'tripodConfig' => \Tripod\Config::getConfig(),
             'subjects'=> [$subject->toArray()],
             'statsConfig' => $this->getStatsDConfig()
         );

--- a/test/unit/mongo/ApplyOperationTest.php
+++ b/test/unit/mongo/ApplyOperationTest.php
@@ -3,12 +3,15 @@
 use Tripod\Mongo\Jobs\ApplyOperation;
 
 require_once 'MongoTripodTestBase.php';
+require_once 'PerformJob.php';
 
 /**
  * Class ApplyOperationTest
  */
 class ApplyOperationTest extends MongoTripodTestBase
 {
+    use PerformJob;
+
     protected $args = array();
 
     public function testMandatoryArgTripodConfig()
@@ -18,8 +21,11 @@ class ApplyOperationTest extends MongoTripodTestBase
         $job = new \Tripod\Mongo\Jobs\ApplyOperation();
         $job->args = $this->args;
         $job->job->payload['id'] = uniqid();
-        $this->setExpectedException('Exception', "Argument tripodConfig was not present in supplied job args for job Tripod\Mongo\Jobs\ApplyOperation");
-        $job->perform();
+        $this->setExpectedException(
+            'Exception',
+            'Argument tripodConfig or tripodConfigGenerator was not present in supplied job args for job Tripod\Mongo\Jobs\ApplyOperation'
+        );
+        $job->beforePerform();
     }
 
     public function testMandatoryArgSubject()
@@ -30,7 +36,7 @@ class ApplyOperationTest extends MongoTripodTestBase
         $job->args = $this->args;
         $job->job->payload['id'] = uniqid();
         $this->setExpectedException('Exception', "Argument subjects was not present in supplied job args for job Tripod\Mongo\Jobs\ApplyOperation");
-        $job->perform();
+        $job->beforePerform();
     }
 
     public function testApplyViewOperation()
@@ -108,7 +114,7 @@ class ApplyOperationTest extends MongoTripodTestBase
             ->method('update')
             ->with($subject);
 
-        $applyOperation->perform();
+        $this->performJob($applyOperation);
     }
 
     public function testApplyViewOperationDecrementsJobGroupForBatchOperations()
@@ -209,7 +215,7 @@ class ApplyOperationTest extends MongoTripodTestBase
             ->with($subject);
 
         $views->expects($this->never())->method('deleteViewsByViewId');
-        $applyOperation->perform();
+        $this->performJob($applyOperation);
     }
 
     public function testApplyViewOperationCleanupIfAllGroupJobsComplete()
@@ -317,7 +323,7 @@ class ApplyOperationTest extends MongoTripodTestBase
             ->with('v_foo_bar', $timestamp)
             ->will($this->returnValue(3));
 
-        $applyOperation->perform();
+        $this->performJob($applyOperation);
     }
 
     public function testApplyTableOperation()
@@ -408,7 +414,7 @@ class ApplyOperationTest extends MongoTripodTestBase
             ->method('update')
             ->with($subject);
 
-        $applyOperation->perform();
+        $this->performJob($applyOperation);
     }
 
     public function testApplyTableOperationDecrementsJobGroupForBatchOperations()
@@ -512,7 +518,7 @@ class ApplyOperationTest extends MongoTripodTestBase
         $tables->expects($this->never())
             ->method('deleteTableRowsByTableId');
 
-        $applyOperation->perform();
+        $this->performJob($applyOperation);
     }
 
     public function testApplyTableOperationCleanupIfAllGroupJobsComplete()
@@ -621,7 +627,7 @@ class ApplyOperationTest extends MongoTripodTestBase
             ->with('t_resource', $timestamp)
             ->will($this->returnValue(4));
 
-        $applyOperation->perform();
+        $this->performJob($applyOperation);
     }
 
     public function testApplySearchOperation()
@@ -697,7 +703,7 @@ class ApplyOperationTest extends MongoTripodTestBase
             ->method('update')
             ->with($subject);
 
-        $applyOperation->perform();
+        $this->performJob($applyOperation);
     }
 
     public function testApplySearchOperationDecrementsJobGroupForBatchOperations()
@@ -794,7 +800,7 @@ class ApplyOperationTest extends MongoTripodTestBase
             ->method('update')
             ->with($subject);
 
-        $applyOperation->perform();
+        $this->performJob($applyOperation);
     }
 
     public function testApplySearchOperationCleanupIfAllGroupJobsComplete()
@@ -910,7 +916,7 @@ class ApplyOperationTest extends MongoTripodTestBase
             ->with('i_search_resource', $timestamp)
             ->will($this->returnValue(8));
 
-        $applyOperation->perform();
+        $this->performJob($applyOperation);
     }
 
     public function testCreateJobDefaultQueue()

--- a/test/unit/mongo/ConfigGeneratorTest.php
+++ b/test/unit/mongo/ConfigGeneratorTest.php
@@ -5,14 +5,18 @@ require_once 'TestConfigGenerator.php';
 
 class ConfigGeneratorTest extends MongoTripodTestBase
 {
+    private $config = [];
+
+    public function setUp()
+    {
+        $this->config = [
+            'class' => 'TestConfigGenerator',
+            'filename' => dirname(__FILE__) . '/data/config.json'
+        ];
+        \Tripod\Config::setConfig($this->config);
+    }
     public function testCreateFromConfig()
     {
-        \Tripod\Config::setConfig(
-            [
-                'class' => 'TestConfigGenerator',
-                'filename' => dirname(__FILE__) . '/data/config.json'
-            ]
-        );
         /** @var TestConfigGenerator $instance */
         $instance = \Tripod\Config::getInstance();
         $this->assertInstanceOf('TestConfigGenerator', $instance);
@@ -26,14 +30,70 @@ class ConfigGeneratorTest extends MongoTripodTestBase
 
     public function testSerializeConfig()
     {
-        $config = [
-            'class' => 'TestConfigGenerator',
-            'filename' => dirname(__FILE__) . '/data/config.json'
-        ];
-        \Tripod\Config::setConfig($config);
-
         /** @var TestConfigGenerator $instance */
         $instance = \Tripod\Config::getInstance();
-        $this->assertEquals($config, $instance->serialize());
+        $this->assertEquals($this->config, $instance->serialize());
+    }
+
+    public function testConfigGeneratorsSerializedInDiscoverJobs()
+    {
+        $originalGraph = new \Tripod\ExtendedGraph();
+        $originalGraph->add_resource_triple('http://example.com/1', RDF_TYPE, RDFS_CLASS);
+
+        $newGraph = new \Tripod\ExtendedGraph();
+        $newGraph->add_resource_triple('http://example.com/1', RDF_TYPE, OWL_CLASS);
+        $subjectsAndPredicatesOfChange = ['http://example.com/1' => [RDF_TYPE]];
+
+        /** @var \Tripod\Mongo\Driver|PHPUnit_Framework_MockObject_MockObject $tripod */
+        $tripod = $this->getMockBuilder('\Tripod\Mongo\Driver')
+            ->setMethods(['getDataUpdater'])
+            ->setConstructorArgs(
+                ['CBD_testing', 'tripod_php_testing']
+            )
+            ->getMock();
+
+        /** @var \Tripod\Mongo\Updates|PHPUnit_Framework_MockObject_MockObject $updates */
+        $updates = $this->getMockBuilder('\Tripod\Mongo\Updates')
+            ->setMethods(
+                [
+                    'applyHooks',
+                    'storeChanges',
+                    'setReadPreferenceToPrimary',
+                    'processSyncOperations',
+                    'getDiscoverImpactedSubjects',
+                    'resetOriginalReadPreference'
+                ]
+            )
+            ->setConstructorArgs([$tripod])
+            ->getMock();
+
+        /** @var \Tripod\Mongo\Jobs\DiscoverImpactedSubjects|PHPUnit_Framework_MockObject_MockObject $discoverJob */
+        $discoverJob = $this->getMockBuilder('\Tripod\Mongo\Jobs\DiscoverImpactedSubjects')
+            ->setMethods(['createJob'])
+            ->getMock();
+
+        $tripod->expects($this->once())->method('getDataUpdater')->will($this->returnValue($updates));
+        $updates->expects($this->once())->method('getDiscoverImpactedSubjects')->will($this->returnValue($discoverJob));
+
+        $updates->expects($this->once())->method('storeChanges')->will(
+            $this->returnValue(
+                ['transaction_id' => uniqid(), 'subjectsAndPredicatesOfChange' => $subjectsAndPredicatesOfChange]
+            )
+        );
+
+        $discoverJob->expects($this->once())->method('createJob')
+            ->with([
+                'changes' => $subjectsAndPredicatesOfChange,
+                'operations' => [OP_TABLES, OP_SEARCH],
+                'storeName' => 'tripod_php_testing',
+                'podName' => 'CBD_testing',
+                'contextAlias' => 'http://talisaspire.com/',
+                'statsConfig' => []
+            ]);
+
+        $tripod->saveChanges(
+            $originalGraph,
+            $newGraph
+        );
     }
 }

--- a/test/unit/mongo/ConfigGeneratorTest.php
+++ b/test/unit/mongo/ConfigGeneratorTest.php
@@ -1,0 +1,39 @@
+<?php
+
+require_once 'MongoTripodTestBase.php';
+require_once 'TestConfigGenerator.php';
+
+class ConfigGeneratorTest extends MongoTripodTestBase
+{
+    public function testCreateFromConfig()
+    {
+        \Tripod\Config::setConfig(
+            [
+                'class' => 'TestConfigGenerator',
+                'filename' => dirname(__FILE__) . '/data/config.json'
+            ]
+        );
+        /** @var TestConfigGenerator $instance */
+        $instance = \Tripod\Config::getInstance();
+        $this->assertInstanceOf('TestConfigGenerator', $instance);
+        $this->assertInstanceOf('\Tripod\Mongo\Config', $instance);
+        $this->assertInstanceOf('\Tripod\ITripodConfigSerializer', $instance);
+        $this->assertEquals(
+            ['CBD_testing', 'CBD_testing_2'],
+            $instance->getPods('tripod_php_testing')
+        );
+    }
+
+    public function testSerializeConfig()
+    {
+        $config = [
+            'class' => 'TestConfigGenerator',
+            'filename' => dirname(__FILE__) . '/data/config.json'
+        ];
+        \Tripod\Config::setConfig($config);
+
+        /** @var TestConfigGenerator $instance */
+        $instance = \Tripod\Config::getInstance();
+        $this->assertEquals($config, $instance->serialize());
+    }
+}

--- a/test/unit/mongo/DateUtilTest.php
+++ b/test/unit/mongo/DateUtilTest.php
@@ -7,7 +7,7 @@ class DateUtilTest extends MongoTripodTestBase
 {
     public function testGetMongoDateWithNoParam()
     {
-        $config = \Tripod\Mongo\Config::getInstance();
+        $config = \Tripod\Config::getInstance();
         $updatedAt = (new \Tripod\Mongo\DateUtil())->getMongoDate();
 
         $_id = array(
@@ -32,7 +32,7 @@ class DateUtilTest extends MongoTripodTestBase
     }
     public function testGetMongoDateWithParam()
     {
-        $config = \Tripod\Mongo\Config::getInstance();
+        $config = \Tripod\Config::getInstance();
         $updatedAt = (new \Tripod\Mongo\DateUtil())->getMongoDate();
 
         $_id = array(

--- a/test/unit/mongo/DiscoverImpactedSubjectsTest.php
+++ b/test/unit/mongo/DiscoverImpactedSubjectsTest.php
@@ -1,76 +1,85 @@
 <?php
 
 require_once 'MongoTripodTestBase.php';
+require_once 'PerformJob.php';
+
+use \Tripod\Mongo\Jobs\DiscoverImpactedSubjects;
+
 /**
  * Class DiscoverImpactedSubjectsTest
  */
 class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
 {
+    use PerformJob;
+
     protected $args = array();
     public function testMandatoryArgTripodConfig()
     {
         $this->setArgs();
         unset($this->args['tripodConfig']);
-        $job = new \Tripod\Mongo\Jobs\DiscoverImpactedSubjects();
+        $job = new DiscoverImpactedSubjects();
         $job->args = $this->args;
         $job->job->payload['id'] = uniqid();
-        $this->setExpectedException('Exception', "Argument tripodConfig was not present in supplied job args for job Tripod\Mongo\Jobs\DiscoverImpactedSubjects");
-        $job->perform();
+        $this->setExpectedException(
+            'Exception',
+            'Argument tripodConfig or tripodConfigGenerator was not present in supplied job args for job Tripod\Mongo\Jobs\DiscoverImpactedSubjects'
+        );
+        $job->beforePerform();
     }
 
     public function testMandatoryArgStoreName()
     {
         $this->setArgs();
         unset($this->args['storeName']);
-        $job = new \Tripod\Mongo\Jobs\DiscoverImpactedSubjects();
+        $job = new DiscoverImpactedSubjects();
         $job->args = $this->args;
         $job->job->payload['id'] = uniqid();
         $this->setExpectedException('Exception', "Argument storeName was not present in supplied job args for job Tripod\Mongo\Jobs\DiscoverImpactedSubjects");
-        $job->perform();
+        $job->beforePerform();
     }
 
     public function testMandatoryArgPodName()
     {
         $this->setArgs();
         unset($this->args['podName']);
-        $job = new \Tripod\Mongo\Jobs\DiscoverImpactedSubjects();
+        $job = new DiscoverImpactedSubjects();
         $job->args = $this->args;
         $job->job->payload['id'] = uniqid();
         $this->setExpectedException('Exception', "Argument podName was not present in supplied job args for job Tripod\Mongo\Jobs\DiscoverImpactedSubjects");
-        $job->perform();
+        $job->beforePerform();
     }
 
     public function testMandatoryArgChanges()
     {
         $this->setArgs();
         unset($this->args['changes']);
-        $job = new \Tripod\Mongo\Jobs\DiscoverImpactedSubjects();
+        $job = new DiscoverImpactedSubjects();
         $job->args = $this->args;
         $job->job->payload['id'] = uniqid();
         $this->setExpectedException('Exception', "Argument changes was not present in supplied job args for job Tripod\Mongo\Jobs\DiscoverImpactedSubjects");
-        $job->perform();
+        $job->beforePerform();
     }
 
     public function testMandatoryArgOperations()
     {
         $this->setArgs();
         unset($this->args['operations']);
-        $job = new \Tripod\Mongo\Jobs\DiscoverImpactedSubjects();
+        $job = new DiscoverImpactedSubjects();
         $job->args = $this->args;
         $job->job->payload['id'] = uniqid();
         $this->setExpectedException('Exception', "Argument operations was not present in supplied job args for job Tripod\Mongo\Jobs\DiscoverImpactedSubjects");
-        $job->perform();
+        $job->beforePerform();
     }
 
     public function testMandatoryArgContextAlias()
     {
         $this->setArgs();
         unset($this->args['contextAlias']);
-        $job = new \Tripod\Mongo\Jobs\DiscoverImpactedSubjects();
+        $job = new DiscoverImpactedSubjects();
         $job->args = $this->args;
         $job->job->payload['id'] = uniqid();
         $this->setExpectedException('Exception', "Argument contextAlias was not present in supplied job args for job Tripod\Mongo\Jobs\DiscoverImpactedSubjects");
-        $job->perform();
+        $job->beforePerform();
     }
 
     public function testSubmitApplyOperationsJob()
@@ -119,6 +128,7 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
                 )
             ));
 
+        /** @var DiscoverImpactedSubjects|PHPUnit_Framework_MockObject_MockObject $discoverImpactedSubjects  */
         $discoverImpactedSubjects = $this->getMockBuilder('\Tripod\Mongo\Jobs\DiscoverImpactedSubjects')
             ->setMethods(array('getTripod', 'getApplyOperation', 'getStat'))
             ->getMock();
@@ -230,7 +240,7 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
             ->method('increment')
             ->with(MONGO_QUEUE_DISCOVER_JOB . '.' . SUBJECT_COUNT, 3);
 
-        $discoverImpactedSubjects->perform();
+        $this->performJob($discoverImpactedSubjects);
     }
 
     public function testCreateJobDefaultQueue()
@@ -251,7 +261,7 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
             'contextAlias'=>'http://talisaspire.com/'
         );
 
-        /** @var \Tripod\Mongo\Jobs\DiscoverImpactedSubjects|PHPUnit_Framework_MockObject_MockObject $discoverImpactedSubjects */
+        /** @var DiscoverImpactedSubjects|PHPUnit_Framework_MockObject_MockObject $discoverImpactedSubjects */
         $discoverImpactedSubjects = $this->getMockBuilder('\Tripod\Mongo\Jobs\DiscoverImpactedSubjects')
             ->setMethods(array('submitJob'))
             ->setMockClassName('MockDiscoverImpactedSubjects')
@@ -288,7 +298,7 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
 
         $queueName = \Tripod\Mongo\Config::getDiscoverQueueName() . '::TRIPOD_TESTING_QUEUE_' . uniqid();
 
-        /** @var \Tripod\Mongo\Jobs\DiscoverImpactedSubjects|PHPUnit_Framework_MockObject_MockObject $discoverImpactedSubjects */
+        /** @var DiscoverImpactedSubjects|PHPUnit_Framework_MockObject_MockObject $discoverImpactedSubjects */
         $discoverImpactedSubjects = $this->getMockBuilder('\Tripod\Mongo\Jobs\DiscoverImpactedSubjects')
             ->setMethods(array('submitJob'))
             ->setMockClassName('MockDiscoverImpactedSubjects')
@@ -307,7 +317,7 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
 
     public function testManualQueueNamePersistsThroughJob()
     {
-        /** @var \Tripod\Mongo\Jobs\DiscoverImpactedSubjects|PHPUnit_Framework_MockObject_MockObject $discoverImpactedSubjects */
+        /** @var DiscoverImpactedSubjects|PHPUnit_Framework_MockObject_MockObject $discoverImpactedSubjects */
         $discoverImpactedSubjects = $this->getMockBuilder('\Tripod\Mongo\Jobs\DiscoverImpactedSubjects')
             ->setMethods(array('getTripod', 'getApplyOperation'))
             ->getMock();
@@ -423,7 +433,7 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
                 )
             );
 
-        $discoverImpactedSubjects->perform();
+        $this->performJob($discoverImpactedSubjects);
     }
 
     public function testDiscoverOperationWillSubmitApplyOperationForDistinctQueues()
@@ -510,7 +520,7 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
 
         \Tripod\Mongo\Config::setConfig($config);
 
-        /** @var \Tripod\Mongo\Jobs\DiscoverImpactedSubjects|PHPUnit_Framework_MockObject_MockObject $discoverImpactedSubjects */
+        /** @var DiscoverImpactedSubjects|PHPUnit_Framework_MockObject_MockObject $discoverImpactedSubjects */
         $discoverImpactedSubjects = $this->getMockBuilder('\Tripod\Mongo\Jobs\DiscoverImpactedSubjects')
             ->setMethods(array('getTripod', 'getApplyOperation'))
             ->getMock();
@@ -657,7 +667,7 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
                 )
             );
 
-        $discoverImpactedSubjects->perform();
+        $this->performJob($discoverImpactedSubjects);
     }
 
     public function testManuallySpecifiedQueueWillOverrideQueuesDefinedInConfig()
@@ -744,7 +754,7 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
 
         \Tripod\Mongo\Config::setConfig($config);
 
-        /** @var \Tripod\Mongo\Jobs\DiscoverImpactedSubjects|PHPUnit_Framework_MockObject_MockObject $discoverImpactedSubjects */
+        /** @var DiscoverImpactedSubjects|PHPUnit_Framework_MockObject_MockObject $discoverImpactedSubjects */
         $discoverImpactedSubjects = $this->getMockBuilder('\Tripod\Mongo\Jobs\DiscoverImpactedSubjects')
             ->setMethods(array('getTripod', 'getApplyOperation'))
             ->getMock();
@@ -825,8 +835,7 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
                 )
             );
 
-
-        $discoverImpactedSubjects->perform();
+        $this->performJob($discoverImpactedSubjects);
     }
 
     protected function setArgs()

--- a/test/unit/mongo/DiscoverImpactedSubjectsTest.php
+++ b/test/unit/mongo/DiscoverImpactedSubjectsTest.php
@@ -24,7 +24,7 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
             'Exception',
             'Argument tripodConfig or tripodConfigGenerator was not present in supplied job args for job Tripod\Mongo\Jobs\DiscoverImpactedSubjects'
         );
-        $job->beforePerform();
+        $this->performJob($job);
     }
 
     public function testMandatoryArgStoreName()
@@ -35,7 +35,7 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
         $job->args = $this->args;
         $job->job->payload['id'] = uniqid();
         $this->setExpectedException('Exception', "Argument storeName was not present in supplied job args for job Tripod\Mongo\Jobs\DiscoverImpactedSubjects");
-        $job->beforePerform();
+        $this->performJob($job);
     }
 
     public function testMandatoryArgPodName()
@@ -46,7 +46,7 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
         $job->args = $this->args;
         $job->job->payload['id'] = uniqid();
         $this->setExpectedException('Exception', "Argument podName was not present in supplied job args for job Tripod\Mongo\Jobs\DiscoverImpactedSubjects");
-        $job->beforePerform();
+        $this->performJob($job);
     }
 
     public function testMandatoryArgChanges()
@@ -57,7 +57,7 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
         $job->args = $this->args;
         $job->job->payload['id'] = uniqid();
         $this->setExpectedException('Exception', "Argument changes was not present in supplied job args for job Tripod\Mongo\Jobs\DiscoverImpactedSubjects");
-        $job->beforePerform();
+        $this->performJob($job);
     }
 
     public function testMandatoryArgOperations()
@@ -68,7 +68,7 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
         $job->args = $this->args;
         $job->job->payload['id'] = uniqid();
         $this->setExpectedException('Exception', "Argument operations was not present in supplied job args for job Tripod\Mongo\Jobs\DiscoverImpactedSubjects");
-        $job->beforePerform();
+        $this->performJob($job);
     }
 
     public function testMandatoryArgContextAlias()
@@ -79,7 +79,7 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
         $job->args = $this->args;
         $job->job->payload['id'] = uniqid();
         $this->setExpectedException('Exception', "Argument contextAlias was not present in supplied job args for job Tripod\Mongo\Jobs\DiscoverImpactedSubjects");
-        $job->beforePerform();
+        $this->performJob($job);
     }
 
     public function testSubmitApplyOperationsJob()

--- a/test/unit/mongo/DiscoverImpactedSubjectsTest.php
+++ b/test/unit/mongo/DiscoverImpactedSubjectsTest.php
@@ -1,17 +1,14 @@
 <?php
 
-require_once 'MongoTripodTestBase.php';
-require_once 'PerformJob.php';
+require_once 'ResqueJobTestBase.php';
 
 use \Tripod\Mongo\Jobs\DiscoverImpactedSubjects;
 
 /**
  * Class DiscoverImpactedSubjectsTest
  */
-class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
+class DiscoverImpactedSubjectsTest extends ResqueJobTestBase
 {
-    use PerformJob;
-
     protected $args = array();
     public function testMandatoryArgTripodConfig()
     {
@@ -98,7 +95,7 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
             ->setConstructorArgs(
                 array(
                     'tripod_php_testing',
-                    \Tripod\Mongo\Config::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing'),
+                    \Tripod\Config::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing'),
                     'http://talisaspire.com/'
                 )
             )->getMock();
@@ -108,7 +105,7 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
             ->setConstructorArgs(
                 array(
                     'tripod_php_testing',
-                    \Tripod\Mongo\Config::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing'),
+                    \Tripod\Config::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing'),
                     'http://talisaspire.com/'
                 )
             )->getMock();
@@ -255,7 +252,7 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
         $jobData = array(
             'changes'=>$subjectsAndPredicatesOfChange,
             'operations'=>array(OP_SEARCH),
-            'tripodConfig'=>\Tripod\Mongo\Config::getConfig(),
+            'tripodConfig'=>\Tripod\Config::getConfig(),
             'storeName'=>'tripod_php_testing',
             'podName'=>'CBD_testing',
             'contextAlias'=>'http://talisaspire.com/'
@@ -290,7 +287,7 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
         $jobData = array(
             'changes'=>$subjectsAndPredicatesOfChange,
             'operations'=>array(OP_SEARCH),
-            'tripodConfig'=>\Tripod\Mongo\Config::getConfig(),
+            'tripodConfig'=>\Tripod\Config::getConfig(),
             'storeName'=>'tripod_php_testing',
             'podName'=>'CBD_testing',
             'contextAlias'=>'http://talisaspire.com/'
@@ -332,7 +329,7 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
             ->setConstructorArgs(
                 array(
                     'tripod_php_testing',
-                    \Tripod\Mongo\Config::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing'),
+                    \Tripod\Config::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing'),
                     'http://talisaspire.com/'
                 )
             )->getMock();
@@ -342,7 +339,7 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
             ->setConstructorArgs(
                 array(
                     'tripod_php_testing',
-                    \Tripod\Mongo\Config::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing'),
+                    \Tripod\Config::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing'),
                     'http://talisaspire.com/'
                 )
             )->getMock();
@@ -438,7 +435,7 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
 
     public function testDiscoverOperationWillSubmitApplyOperationForDistinctQueues()
     {
-        $config = \Tripod\Mongo\Config::getConfig();
+        $config = \Tripod\Config::getConfig();
 
         // Create a bunch of specs on various queues
         $tableSpecs = array(
@@ -518,7 +515,7 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
 
         $config['stores']['tripod_php_testing']['table_specifications'] = $tableSpecs;
 
-        \Tripod\Mongo\Config::setConfig($config);
+        \Tripod\Config::setConfig($config);
 
         /** @var DiscoverImpactedSubjects|PHPUnit_Framework_MockObject_MockObject $discoverImpactedSubjects */
         $discoverImpactedSubjects = $this->getMockBuilder('\Tripod\Mongo\Jobs\DiscoverImpactedSubjects')
@@ -541,7 +538,7 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
             ->setConstructorArgs(
                 array(
                     'tripod_php_testing',
-                    \Tripod\Mongo\Config::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing'),
+                    \Tripod\Config::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing'),
                     'http://talisaspire.com/'
                 )
             )->getMock();
@@ -672,7 +669,7 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
 
     public function testManuallySpecifiedQueueWillOverrideQueuesDefinedInConfig()
     {
-        $config = \Tripod\Mongo\Config::getConfig();
+        $config = \Tripod\Config::getConfig();
 
         // Create a bunch of specs on various queues
         $tableSpecs = array(
@@ -752,7 +749,7 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
 
         $config['stores']['tripod_php_testing']['table_specifications'] = $tableSpecs;
 
-        \Tripod\Mongo\Config::setConfig($config);
+        \Tripod\Config::setConfig($config);
 
         /** @var DiscoverImpactedSubjects|PHPUnit_Framework_MockObject_MockObject $discoverImpactedSubjects */
         $discoverImpactedSubjects = $this->getMockBuilder('\Tripod\Mongo\Jobs\DiscoverImpactedSubjects')
@@ -776,7 +773,7 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
             ->setConstructorArgs(
                 array(
                     'tripod_php_testing',
-                    \Tripod\Mongo\Config::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing'),
+                    \Tripod\Config::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing'),
                     'http://talisaspire.com/'
                 )
             )->getMock();
@@ -841,7 +838,7 @@ class DiscoverImpactedSubjectsTest extends MongoTripodTestBase
     protected function setArgs()
     {
         $this->args = array(
-            'tripodConfig'=>\Tripod\Mongo\Config::getConfig(),
+            'tripodConfig'=>\Tripod\Config::getConfig(),
             'storeName'=>'tripod_php_testing',
             'podName'=>'CBD_testing',
             'changes'=>array('http://example.com/resources/foo'=>array('rdf:type','dct:title')),

--- a/test/unit/mongo/EnsureIndexesTest.php
+++ b/test/unit/mongo/EnsureIndexesTest.php
@@ -1,12 +1,15 @@
 <?php
 
 require_once 'MongoTripodTestBase.php';
+require_once 'PerformJob.php';
 
 /**
  * Class EnsureIndexes Test
  */
 class EnsureIndexesTest extends MongoTripodTestBase
 {
+    use PerformJob;
+
     /**
      * @var array
      */
@@ -30,15 +33,21 @@ class EnsureIndexesTest extends MongoTripodTestBase
      * @group ensure-indexes
      * @throws Exception
      */
-    public function testMandatoryArgs($argumentName)
+    public function testMandatoryArgs($argument, $argumentName = null)
     {
+        if (!$argumentName) {
+            $argumentName = $argument;
+        }
         $job = new \Tripod\Mongo\Jobs\EnsureIndexes();
         $job->args = $this->args;
         $job->job->payload['id'] = uniqid();
-        unset($job->args[$argumentName]);
+        unset($job->args[$argument]);
 
-        $this->setExpectedException('Exception', "Argument $argumentName was not present in supplied job args for job Tripod\Mongo\Jobs\EnsureIndexes");
-        $job->perform();
+        $this->setExpectedException(
+            'Exception',
+            "Argument $argumentName was not present in supplied job args for job Tripod\Mongo\Jobs\EnsureIndexes"
+        );
+        $this->performJob($job);
     }
 
     /**
@@ -48,12 +57,12 @@ class EnsureIndexesTest extends MongoTripodTestBase
      */
     public function mandatoryArgDataProvider()
     {
-        return array(
-            array('tripodConfig'),
-            array('storeName'),
-            array('reindex'),
-            array('background')
-        );
+        return [
+            ['tripodConfig', 'tripodConfig or tripodConfigGenerator'],
+            ['storeName'],
+            ['reindex'],
+            ['background']
+        ];
     }
 
     /**
@@ -66,7 +75,7 @@ class EnsureIndexesTest extends MongoTripodTestBase
         $job->args = $this->createDefaultArguments();
         $this->jobSuccessfullyEnsuresIndexes($job);
 
-        $job->perform();
+        $this->performJob($job);
     }
 
     /**
@@ -80,7 +89,7 @@ class EnsureIndexesTest extends MongoTripodTestBase
         $this->jobThrowsExceptionWhenEnsuringIndexes($job);
         $this->setExpectedException('Exception', "Ensuring index failed");
 
-        $job->perform();
+        $this->performJob($job);
     }
 
     /**

--- a/test/unit/mongo/EnsureIndexesTest.php
+++ b/test/unit/mongo/EnsureIndexesTest.php
@@ -1,15 +1,12 @@
 <?php
 
-require_once 'MongoTripodTestBase.php';
-require_once 'PerformJob.php';
+require_once 'ResqueJobTestBase.php';
 
 /**
  * Class EnsureIndexes Test
  */
-class EnsureIndexesTest extends MongoTripodTestBase
+class EnsureIndexesTest extends ResqueJobTestBase
 {
-    use PerformJob;
-
     /**
      * @var array
      */
@@ -100,7 +97,7 @@ class EnsureIndexesTest extends MongoTripodTestBase
     {
         $jobData = array(
             'storeName' => 'tripod_php_testing',
-            'tripodConfig' => \Tripod\Mongo\Config::getConfig(),
+            'tripodConfig' => \Tripod\Config::getConfig(),
             'reindex' => false,
             'background' => true
         );
@@ -126,7 +123,7 @@ class EnsureIndexesTest extends MongoTripodTestBase
     {
         $jobData = array(
             'storeName' => 'tripod_php_testing',
-            'tripodConfig' => \Tripod\Mongo\Config::getConfig(),
+            'tripodConfig' => \Tripod\Config::getConfig(),
             'reindex' => false,
             'background' => true
         );
@@ -158,7 +155,7 @@ class EnsureIndexesTest extends MongoTripodTestBase
     {
         $jobData = array(
             'storeName' => 'tripod_php_testing',
-            'tripodConfig' => \Tripod\Mongo\Config::getConfig(),
+            'tripodConfig' => \Tripod\Config::getConfig(),
             'reindex' => false,
             'background' => true
         );
@@ -186,7 +183,7 @@ class EnsureIndexesTest extends MongoTripodTestBase
     {
         $jobData = array(
             'storeName' => 'tripod_php_testing',
-            'tripodConfig' => \Tripod\Mongo\Config::getConfig(),
+            'tripodConfig' => \Tripod\Config::getConfig(),
             'reindex' => false,
             'background' => true
         );
@@ -238,7 +235,7 @@ class EnsureIndexesTest extends MongoTripodTestBase
     protected function createDefaultArguments()
     {
         $arguments = array(
-            'tripodConfig' => \Tripod\Mongo\Config::getConfig(),
+            'tripodConfig' => \Tripod\Config::getConfig(),
             'storeName'    => 'tripod_php_testing',
             'reindex'      => false,
             'background'   => true

--- a/test/unit/mongo/MongoGraphTest.php
+++ b/test/unit/mongo/MongoGraphTest.php
@@ -46,7 +46,7 @@ class MongoGraphTest extends MongoTripodTestBase
 
         $expected = "<http://example.com/1> <http://purl.org/dc/terms/title> \"some literal title\" <http://talisaspire.com/> .
 <http://example.com/1> <http://purl.org/dc/terms/source> <http://www.google.com> <http://talisaspire.com/> .\n";
-        $this->assertEquals($expected, $g->to_nquads(\Tripod\Mongo\Config::getInstance()->getDefaultContextAlias()));
+        $this->assertEquals($expected, $g->to_nquads(\Tripod\Config::getInstance()->getDefaultContextAlias()));
     }
 
     public function testToNQuadsTwoGraphsWithDifferentContext()

--- a/test/unit/mongo/MongoSearchProviderTest.php
+++ b/test/unit/mongo/MongoSearchProviderTest.php
@@ -29,7 +29,7 @@ class MongoSearchProviderTest extends MongoTripodTestBase
 
         $this->loadBaseSearchDataViaTripod();
 
-        foreach(\Tripod\Mongo\Config::getInstance()->getCollectionsForSearch($this->tripod->getStoreName()) as $collection)
+        foreach(\Tripod\Config::getInstance()->getCollectionsForSearch($this->tripod->getStoreName()) as $collection)
         {
             $collection->drop();
         }
@@ -172,7 +172,7 @@ class MongoSearchProviderTest extends MongoTripodTestBase
         );
 
         // loop through every expected document and assert that it exists, and that each property matches the value we defined above.
-        $searchCollection = \Tripod\Mongo\Config::getInstance()->getCollectionForSearchDocument($this->tripod->getStoreName(), 'i_search_resource');
+        $searchCollection = \Tripod\Config::getInstance()->getCollectionForSearchDocument($this->tripod->getStoreName(), 'i_search_resource');
         foreach($expectedSearchDocs as $expectedSearchDoc){
             $this->assertDocumentExists($expectedSearchDoc["_id"], $searchCollection);
             $this->assertDocumentHasProperty($expectedSearchDoc["_id"], "result", $expectedSearchDoc["result"], $searchCollection);
@@ -196,7 +196,7 @@ class MongoSearchProviderTest extends MongoTripodTestBase
         $this->assertEquals(12, $actualSearchDocumentCount, "Should only be 12 search documents now that one of them has had its type changed with no corresponding search doc spec");
 
 
-        foreach(\Tripod\Mongo\Config::getInstance()->getCollectionsForSearch('tripod_php_testing') as $collection)
+        foreach(\Tripod\Config::getInstance()->getCollectionsForSearch('tripod_php_testing') as $collection)
         {
             $this->assertNull(
                 $collection->findOne(array("_id.r"=>"http://talisaspire.com/resources/doc1")),
@@ -227,7 +227,7 @@ class MongoSearchProviderTest extends MongoTripodTestBase
         $this->assertEquals(13, $actualSearchDocumentCount, "Should only be 13 search documents");
 
         $result = array();
-        foreach(\Tripod\Mongo\Config::getInstance()->getCollectionsForSearch('tripod_php_testing') as $collection)
+        foreach(\Tripod\Config::getInstance()->getCollectionsForSearch('tripod_php_testing') as $collection)
         {
             $result = $collection->findOne(array("_id.r"=>"http://talisaspire.com/resources/doc1"));
             if($result)
@@ -263,7 +263,7 @@ class MongoSearchProviderTest extends MongoTripodTestBase
 
         $results = array();
         // We don't know where exactly these might have stored
-        foreach(\Tripod\Mongo\Config::getInstance()->getCollectionsForSearch('tripod_php_testing') as $collection)
+        foreach(\Tripod\Config::getInstance()->getCollectionsForSearch('tripod_php_testing') as $collection)
         {
             foreach($collection->find(array("_id.r"=>"http://talisaspire.com/resources/doc1")) as $result)
             {
@@ -310,7 +310,7 @@ class MongoSearchProviderTest extends MongoTripodTestBase
 
         $results = array();
         // We don't know where exactly these might have stored
-        foreach(\Tripod\Mongo\Config::getInstance()->getCollectionsForSearch('tripod_php_testing') as $collection)
+        foreach(\Tripod\Config::getInstance()->getCollectionsForSearch('tripod_php_testing') as $collection)
         {
             foreach($collection->find(array("_id.r"=>"http://talisaspire.com/resources/doc1")) as $result)
             {
@@ -762,12 +762,12 @@ class MongoSearchProviderTest extends MongoTripodTestBase
         $count = 0;
         if(empty($specs))
         {
-            $specs = \Tripod\Mongo\Config::getInstance()->getSearchDocumentSpecifications($tripod->getStoreName(), null, true);
+            $specs = \Tripod\Config::getInstance()->getSearchDocumentSpecifications($tripod->getStoreName(), null, true);
         }
 
         foreach($specs as $spec)
         {
-            $count += \Tripod\Mongo\Config::getInstance()->getCollectionForSearchDocument($tripod->getStoreName(), $spec)->count(array('_id.type'=>$spec));
+            $count += \Tripod\Config::getInstance()->getCollectionForSearchDocument($tripod->getStoreName(), $spec)->count(array('_id.type'=>$spec));
         }
         return $count;
     }

--- a/test/unit/mongo/MongoTransactionLogTest.php
+++ b/test/unit/mongo/MongoTransactionLogTest.php
@@ -31,7 +31,7 @@ class MongoTransactionLogTest extends MongoTripodTestBase
         $this->getTripodCollection($this->tripod)->drop();
 
         // Lock collection no longer available from Driver, so drop it manually
-        \Tripod\Mongo\Config::getInstance()->getCollectionForLocks($this->tripod->getStoreName())->drop();
+        \Tripod\Config::getInstance()->getCollectionForLocks($this->tripod->getStoreName())->drop();
 
         $this->loadResourceDataViaTripod();
 

--- a/test/unit/mongo/MongoTripodComputedFieldsTest.php
+++ b/test/unit/mongo/MongoTripodComputedFieldsTest.php
@@ -12,13 +12,13 @@ class MongoTripodComputedFieldsTest extends MongoTripodTestBase
     public function setUp()
     {
         parent::setUp();
-        $this->originalConfig = \Tripod\Mongo\Config::getConfig();
+        $this->originalConfig = \Tripod\Config::getConfig();
         \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
     }
 
     public function tearDown()
     {
-        \Tripod\Mongo\Config::setConfig($this->originalConfig);
+        \Tripod\Config::setConfig($this->originalConfig);
         \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MIN);
         parent::tearDown();
     }
@@ -60,16 +60,16 @@ class MongoTripodComputedFieldsTest extends MongoTripodTestBase
             )
         );
 
-        $oldConfig = \Tripod\Mongo\Config::getConfig();
-        $newConfig = \Tripod\Mongo\Config::getConfig();
+        $oldConfig = \Tripod\Config::getConfig();
+        $newConfig = \Tripod\Config::getConfig();
         $newConfig['stores']['tripod_php_testing']['table_specifications'][] = $tableSpec;
-        \Tripod\Mongo\Config::setConfig($newConfig);
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::setConfig($newConfig);
+        \Tripod\Config::getInstance();
         $this->tripod = new \Tripod\Mongo\Driver('CBD_testing', 'tripod_php_testing');
         $this->loadDatesDataViaTripod();
         $this->tripod->generateTableRows('t_conditional_creators');
 
-        $collection = \Tripod\Mongo\Config::getInstance()->getCollectionForTable('tripod_php_testing', 't_conditional_creators');
+        $collection = \Tripod\Config::getInstance()->getCollectionForTable('tripod_php_testing', 't_conditional_creators');
 
         $tableDoc = $collection->findOne(array('_id.type'=>'t_conditional_creators', '_id.r' => 'baseData:foo1234'));
         $this->assertEquals('Updated', $tableDoc['value']['status']);
@@ -77,8 +77,8 @@ class MongoTripodComputedFieldsTest extends MongoTripodTestBase
         $tableDoc = $collection->findOne(array('_id.type'=>'t_conditional_creators', '_id.r' => 'baseData:foo12345'));
         $this->assertEquals('Published', $tableDoc['value']['status']);
 
-        \Tripod\Mongo\Config::setConfig($oldConfig);
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::setConfig($oldConfig);
+        \Tripod\Config::getInstance();
         $collection->drop();
     }
 
@@ -122,15 +122,15 @@ class MongoTripodComputedFieldsTest extends MongoTripodTestBase
             )
         );
 
-        $oldConfig = \Tripod\Mongo\Config::getConfig();
-        $newConfig = \Tripod\Mongo\Config::getConfig();
+        $oldConfig = \Tripod\Config::getConfig();
+        $newConfig = \Tripod\Config::getConfig();
         $newConfig['stores']['tripod_php_testing']['table_specifications'][] = $tableSpec;
-        \Tripod\Mongo\Config::setConfig($newConfig);
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::setConfig($newConfig);
+        \Tripod\Config::getInstance();
         $this->tripod = new \Tripod\Mongo\Driver('CBD_testing', 'tripod_php_testing');
         $this->loadResourceDataViaTripod();
         $this->tripod->generateTableRows('t_conditional_creators');
-        $collection = \Tripod\Mongo\Config::getInstance()->getCollectionForTable('tripod_php_testing', 't_conditional_creators');
+        $collection = \Tripod\Config::getInstance()->getCollectionForTable('tripod_php_testing', 't_conditional_creators');
 
         $tableDoc = $collection->findOne(array('_id.type'=>'t_conditional_creators', '_id.r'=>'baseData:foo1234'));
 
@@ -141,8 +141,8 @@ class MongoTripodComputedFieldsTest extends MongoTripodTestBase
         $this->assertEquals(1, $tableDoc['value']['creatorCount']);
         $this->assertEquals(2, $tableDoc['value']['contributorCount']);
 
-        \Tripod\Mongo\Config::setConfig($oldConfig);
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::setConfig($oldConfig);
+        \Tripod\Config::getInstance();
         $collection->drop();
     }
 
@@ -189,15 +189,15 @@ class MongoTripodComputedFieldsTest extends MongoTripodTestBase
             )
         );
 
-        $oldConfig = \Tripod\Mongo\Config::getConfig();
-        $newConfig = \Tripod\Mongo\Config::getConfig();
+        $oldConfig = \Tripod\Config::getConfig();
+        $newConfig = \Tripod\Config::getConfig();
         $newConfig['stores']['tripod_php_testing']['table_specifications'] = array($tableSpec);
-        \Tripod\Mongo\Config::setConfig($newConfig);
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::setConfig($newConfig);
+        \Tripod\Config::getInstance();
         $this->tripod = new \Tripod\Mongo\Driver('CBD_testing', 'tripod_php_testing');
         $this->loadResourceDataViaTripod();
         $this->tripod->generateTableRows('t_conditional_creators');
-        $collection = \Tripod\Mongo\Config::getInstance()->getCollectionForTable('tripod_php_testing', 't_conditional_creators');
+        $collection = \Tripod\Config::getInstance()->getCollectionForTable('tripod_php_testing', 't_conditional_creators');
 
         $tableDoc = $collection->findOne(array('_id.type'=>'t_conditional_creators', '_id.r'=>'baseData:foo1234'));
 
@@ -230,8 +230,8 @@ class MongoTripodComputedFieldsTest extends MongoTripodTestBase
         $this->assertArrayNotHasKey('contributorCount', $tableDoc['value']);
         $this->assertArrayNotHasKey('creatorCount', $tableDoc['value']);
 
-        \Tripod\Mongo\Config::setConfig($oldConfig);
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::setConfig($oldConfig);
+        \Tripod\Config::getInstance();
         $collection->drop();
     }
 
@@ -274,15 +274,15 @@ class MongoTripodComputedFieldsTest extends MongoTripodTestBase
             )
         );
 
-        $oldConfig = \Tripod\Mongo\Config::getConfig();
-        $newConfig = \Tripod\Mongo\Config::getConfig();
+        $oldConfig = \Tripod\Config::getConfig();
+        $newConfig = \Tripod\Config::getConfig();
         $newConfig['stores']['tripod_php_testing']['table_specifications'][] = $tableSpec;
-        \Tripod\Mongo\Config::setConfig($newConfig);
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::setConfig($newConfig);
+        \Tripod\Config::getInstance();
         $this->tripod = new \Tripod\Mongo\Driver('CBD_testing', 'tripod_php_testing');
         $this->loadResourceDataViaTripod();
         $this->tripod->generateTableRows('t_replace_type');
-        $collection = \Tripod\Mongo\Config::getInstance()->getCollectionForTable('tripod_php_testing', 't_replace_type');
+        $collection = \Tripod\Config::getInstance()->getCollectionForTable('tripod_php_testing', 't_replace_type');
 
         $tableDoc = $collection->findOne(array('_id.type'=>'t_replace_type', '_id.r'=>'baseData:foo1234'));
 
@@ -311,8 +311,8 @@ class MongoTripodComputedFieldsTest extends MongoTripodTestBase
         $this->assertEquals('Book Work', $tableDoc['value']['resourceType']);
         $this->assertArrayNotHasKey('rdfType', $tableDoc['value']);
 
-        \Tripod\Mongo\Config::setConfig($oldConfig);
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::setConfig($oldConfig);
+        \Tripod\Config::getInstance();
         $collection->drop();
     }
 
@@ -366,15 +366,15 @@ class MongoTripodComputedFieldsTest extends MongoTripodTestBase
             )
         );
 
-        $oldConfig = \Tripod\Mongo\Config::getConfig();
-        $newConfig = \Tripod\Mongo\Config::getConfig();
+        $oldConfig = \Tripod\Config::getConfig();
+        $newConfig = \Tripod\Config::getConfig();
         $newConfig['stores']['tripod_php_testing']['table_specifications'][] = $tableSpec;
-        \Tripod\Mongo\Config::setConfig($newConfig);
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::setConfig($newConfig);
+        \Tripod\Config::getInstance();
         $this->tripod = new \Tripod\Mongo\Driver('CBD_testing', 'tripod_php_testing');
         $this->loadResourceDataViaTripod();
         $this->tripod->generateTableRows('t_creator_count');
-        $collection = \Tripod\Mongo\Config::getInstance()->getCollectionForTable('tripod_php_testing', 't_creator_count');
+        $collection = \Tripod\Config::getInstance()->getCollectionForTable('tripod_php_testing', 't_creator_count');
 
         $tableDoc = $collection->findOne(array('_id.type'=>'t_creator_count', '_id.r'=>'baseData:foo1234'));
 
@@ -407,8 +407,8 @@ class MongoTripodComputedFieldsTest extends MongoTripodTestBase
         $this->assertArrayNotHasKey('contributorCount', $tableDoc['value']);
         $this->assertArrayNotHasKey('creatorCount', $tableDoc['value']);
 
-        \Tripod\Mongo\Config::setConfig($oldConfig);
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::setConfig($oldConfig);
+        \Tripod\Config::getInstance();
         $collection->drop();
     }
 
@@ -435,20 +435,20 @@ class MongoTripodComputedFieldsTest extends MongoTripodTestBase
                 )
             )
         );
-        $oldConfig = \Tripod\Mongo\Config::getConfig();
-        $newConfig = \Tripod\Mongo\Config::getConfig();
+        $oldConfig = \Tripod\Config::getConfig();
+        $newConfig = \Tripod\Config::getConfig();
         $newConfig['stores']['tripod_php_testing']['table_specifications'][] = $tableSpec;
-        \Tripod\Mongo\Config::setConfig($newConfig);
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::setConfig($newConfig);
+        \Tripod\Config::getInstance();
         $this->tripod = new \Tripod\Mongo\Driver('CBD_testing', 'tripod_php_testing');
         $this->loadResourceDataViaTripod();
         $this->tripod->generateTableRows('t_conditional_with_nested_arithmetic');
-        $collection = \Tripod\Mongo\Config::getInstance()->getCollectionForTable('tripod_php_testing', 't_conditional_with_nested_arithmetic');
+        $collection = \Tripod\Config::getInstance()->getCollectionForTable('tripod_php_testing', 't_conditional_with_nested_arithmetic');
         $tableDoc = $collection->findOne(array('_id.type'=>'t_conditional_with_nested_arithmetic'));
 
         $this->assertEquals('b', $tableDoc['value']['foobar']);
-        \Tripod\Mongo\Config::setConfig($oldConfig);
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::setConfig($oldConfig);
+        \Tripod\Config::getInstance();
         $collection->drop();
     }
 
@@ -483,20 +483,20 @@ class MongoTripodComputedFieldsTest extends MongoTripodTestBase
                 )
             )
         );
-        $oldConfig = \Tripod\Mongo\Config::getConfig();
-        $newConfig = \Tripod\Mongo\Config::getConfig();
+        $oldConfig = \Tripod\Config::getConfig();
+        $newConfig = \Tripod\Config::getConfig();
         $newConfig['stores']['tripod_php_testing']['table_specifications'][] = $tableSpec;
-        \Tripod\Mongo\Config::setConfig($newConfig);
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::setConfig($newConfig);
+        \Tripod\Config::getInstance();
         $this->tripod = new \Tripod\Mongo\Driver('CBD_testing', 'tripod_php_testing');
         $this->loadResourceDataViaTripod();
         $this->tripod->generateTableRows('t_arithmetic_with_nested_conditional');
-        $collection = \Tripod\Mongo\Config::getInstance()->getCollectionForTable('tripod_php_testing', 't_arithmetic_with_nested_conditional');
+        $collection = \Tripod\Config::getInstance()->getCollectionForTable('tripod_php_testing', 't_arithmetic_with_nested_conditional');
         $tableDoc = $collection->findOne(array('_id.type'=>'t_arithmetic_with_nested_conditional'));
 
         $this->assertEquals(300, $tableDoc['value']['foobar']);
-        \Tripod\Mongo\Config::setConfig($oldConfig);
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::setConfig($oldConfig);
+        \Tripod\Config::getInstance();
         $collection->drop();
     }
 }

--- a/test/unit/mongo/MongoTripodConfigTest.php
+++ b/test/unit/mongo/MongoTripodConfigTest.php
@@ -16,7 +16,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
     protected function setUp()
     {
         parent::setup();
-        $this->tripodConfig = \Tripod\Mongo\Config::getInstance();
+        $this->tripodConfig = \Tripod\Config::getInstance();
     }
 
     public function testGetInstanceThrowsExceptionIfSetInstanceNotCalledFirst()
@@ -27,8 +27,8 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $this->setExpectedException('\Tripod\Exceptions\ConfigException','Call Config::setConfig() first');
         unset($this->tripodConfig);
 
-        \Tripod\Mongo\Config::getInstance()->destroy();
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::destroy();
+        \Tripod\Config::getInstance();
     }
 
     public function testNamespaces()
@@ -59,8 +59,8 @@ class MongoTripodConfigTest extends MongoTripodTestBase
 
     public function testTConfig()
     {
-        $config = \Tripod\Mongo\Config::getInstance();
-        $cfg = \Tripod\Mongo\Config::getConfig();
+        $config = \Tripod\Config::getInstance();
+        $cfg = \Tripod\Config::getConfig();
         $tConfig = $config->getTransactionLogConfig();
         $this->assertEquals('tripod_php_testing',$tConfig['database']);
         $this->assertEquals('transaction_log',$tConfig['collection']);
@@ -95,8 +95,8 @@ class MongoTripodConfigTest extends MongoTripodTestBase
 
         );
 
-        \Tripod\Mongo\Config::setConfig($config);
-        $mtc = \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::setConfig($config);
+        $mtc = \Tripod\Config::getInstance();
         $this->assertEquals("mongodb://tloghost:27017,tloghost:27018/admin",$mtc->getTransactionLogConnStr());
     }
 
@@ -133,8 +133,8 @@ class MongoTripodConfigTest extends MongoTripodTestBase
             "data_source"=>"rs1"
         );
 
-        \Tripod\Mongo\Config::setConfig($config);
-        $mtc = \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::setConfig($config);
+        $mtc = \Tripod\Config::getInstance();
 
         $connStr = $mtc->getTransactionLogConnStr();
     }
@@ -150,7 +150,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
 
     public function testGetConnectionString()
     {
-        $this->assertEquals("mongodb://localhost:27017/",\Tripod\Mongo\Config::getInstance()->getConnStr("tripod_php_testing"));
+        $this->assertEquals("mongodb://localhost:27017/",\Tripod\Config::getInstance()->getConnStr("tripod_php_testing"));
     }
 
     public function testGetConnectionStringThrowsException()
@@ -158,7 +158,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $this->setExpectedException(
             '\Tripod\Exceptions\ConfigException',
             'Database notexists does not exist in configuration');
-        $this->assertEquals("mongodb://localhost:27017/",\Tripod\Mongo\Config::getInstance()->getConnStr("notexists"));
+        $this->assertEquals("mongodb://localhost:27017/",\Tripod\Config::getInstance()->getConnStr("notexists"));
     }
 
     public function testGetConnectionStringForReplicaSet(){
@@ -181,8 +181,8 @@ class MongoTripodConfigTest extends MongoTripodTestBase
             )
         );
 
-        \Tripod\Mongo\Config::setConfig($config);
-        $mtc = \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::setConfig($config);
+        $mtc = \Tripod\Config::getInstance();
 
         $this->assertEquals("mongodb://localhost:27017,localhost:27018/admin",$mtc->getConnStr("tripod_php_testing"));
     }
@@ -214,8 +214,8 @@ class MongoTripodConfigTest extends MongoTripodTestBase
             )
         );
 
-        \Tripod\Mongo\Config::setConfig($config);
-        $mtc = \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::setConfig($config);
+        $mtc = \Tripod\Config::getInstance();
 
         $mtc->getConnStr("tripod_php_testing");
     }
@@ -253,13 +253,13 @@ class MongoTripodConfigTest extends MongoTripodTestBase
             )
         );
 
-        \Tripod\Mongo\Config::setConfig($config);
-        $mtc = \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::setConfig($config);
+        $mtc = \Tripod\Config::getInstance();
     }
 
     public function testSearchConfig()
     {
-        $config = \Tripod\Mongo\Config::getInstance();
+        $config = \Tripod\Config::getInstance();
         $this->assertEquals('\Tripod\Mongo\MongoSearchProvider', $config->getSearchProviderClassName('tripod_php_testing'));
 
         $this->assertEquals(3, count($config->getSearchDocumentSpecifications('tripod_php_testing')));
@@ -290,8 +290,8 @@ class MongoTripodConfigTest extends MongoTripodTestBase
                 )
             )
         );
-        \Tripod\Mongo\Config::setConfig($config);
-        $mtc = \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::setConfig($config);
+        $mtc = \Tripod\Config::getInstance();
     }
 
     public function testGetSearchDocumentSpecificationsByType()
@@ -336,7 +336,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
                 )
             )
         );
-        $actualSpec = \Tripod\Mongo\Config::getInstance()->getSearchDocumentSpecifications("tripod_php_testing", "resourcelist:List");
+        $actualSpec = \Tripod\Config::getInstance()->getSearchDocumentSpecifications("tripod_php_testing", "resourcelist:List");
         $this->assertEquals($expectedSpec,$actualSpec);
     }
 
@@ -381,7 +381,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
                     )
                 )
             );
-        $actualSpec = \Tripod\Mongo\Config::getInstance()->getSearchDocumentSpecification('tripod_php_testing', "i_search_list");
+        $actualSpec = \Tripod\Config::getInstance()->getSearchDocumentSpecification('tripod_php_testing', "i_search_list");
         $this->assertEquals($expectedSpec,$actualSpec);
     }
 
@@ -389,7 +389,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
     public function testGetSearchDocumentSpecificationsWhereNoneExists()
     {
         $expectedSpec = array();
-        $actualSpec = \Tripod\Mongo\Config::getInstance()->getSearchDocumentSpecifications("something:doesntexist");
+        $actualSpec = \Tripod\Config::getInstance()->getSearchDocumentSpecifications("something:doesntexist");
         $this->assertEquals($expectedSpec,$actualSpec);
     }
 
@@ -430,8 +430,8 @@ class MongoTripodConfigTest extends MongoTripodTestBase
                 "joins"=>array("dct:hasVersion"=>array())
             )
         );
-        \Tripod\Mongo\Config::setConfig($config);
-        $mtc = \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::setConfig($config);
+        $mtc = \Tripod\Config::getInstance();
     }
 
     public function testViewSpecCountNestedInJoinWithoutTTLThrowsException()
@@ -474,8 +474,8 @@ class MongoTripodConfigTest extends MongoTripodTestBase
                 )
             )
         );
-        \Tripod\Mongo\Config::setConfig($config);
-        $mtc = \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::setConfig($config);
+        $mtc = \Tripod\Config::getInstance();
     }
 
     public function testTableSpecNestedCountWithoutPropertyThrowsException()
@@ -516,8 +516,8 @@ class MongoTripodConfigTest extends MongoTripodTestBase
                 )
             )
         );
-        \Tripod\Mongo\Config::setConfig($config);
-        $mtc = \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::setConfig($config);
+        $mtc = \Tripod\Config::getInstance();
     }
 
     public function testTableSpecNested2ndLevelCountWithoutFieldNameThrowsException()
@@ -561,8 +561,8 @@ class MongoTripodConfigTest extends MongoTripodTestBase
                 )
             )
         );
-        \Tripod\Mongo\Config::setConfig($config);
-        $mtc = \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::setConfig($config);
+        $mtc = \Tripod\Config::getInstance();
     }
 
     public function testTableSpecFieldWithoutFieldName()
@@ -600,8 +600,8 @@ class MongoTripodConfigTest extends MongoTripodTestBase
                 )
             )
         );
-        \Tripod\Mongo\Config::setConfig($config);
-        $mtc = \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::setConfig($config);
+        $mtc = \Tripod\Config::getInstance();
     }
 
     public function testTableSpecFieldWithoutPredicates()
@@ -639,8 +639,8 @@ class MongoTripodConfigTest extends MongoTripodTestBase
                 )
             )
         );
-        \Tripod\Mongo\Config::setConfig($config);
-        $mtc = \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::setConfig($config);
+        $mtc = \Tripod\Config::getInstance();
     }
 
     public function testTableSpecCountWithoutProperty()
@@ -678,8 +678,8 @@ class MongoTripodConfigTest extends MongoTripodTestBase
                 )
             )
         );
-        \Tripod\Mongo\Config::setConfig($config);
-        $mtc = \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::setConfig($config);
+        $mtc = \Tripod\Config::getInstance();
     }
 
     public function testTableSpecCountWithoutFieldName()
@@ -717,8 +717,8 @@ class MongoTripodConfigTest extends MongoTripodTestBase
                 )
             )
         );
-        \Tripod\Mongo\Config::setConfig($config);
-        $mtc = \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::setConfig($config);
+        $mtc = \Tripod\Config::getInstance();
     }
 
     public function testTableSpecCountWithoutPropertyAsAString()
@@ -757,8 +757,8 @@ class MongoTripodConfigTest extends MongoTripodTestBase
                 )
             )
         );
-        \Tripod\Mongo\Config::setConfig($config);
-        $mtc = \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::setConfig($config);
+        $mtc = \Tripod\Config::getInstance();
     }
 
     public function testConfigWithoutDefaultNamespaceThrowsException()
@@ -799,8 +799,8 @@ class MongoTripodConfigTest extends MongoTripodTestBase
                 )
             )
         );
-        \Tripod\Mongo\Config::setConfig($config);
-        $mtc = \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::setConfig($config);
+        $mtc = \Tripod\Config::getInstance();
     }
 
     /**
@@ -809,7 +809,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
      */
     public function testGetIndexesGroupedByCollection()
     {
-        $indexSpecs = \Tripod\Mongo\Config::getInstance()->getIndexesGroupedByCollection("tripod_php_testing");
+        $indexSpecs = \Tripod\Config::getInstance()->getIndexesGroupedByCollection("tripod_php_testing");
 
         $this->assertArrayHasKey("CBD_testing", $indexSpecs);
         $this->assertArrayHasKey("index1", $indexSpecs["CBD_testing"]);
@@ -869,8 +869,8 @@ class MongoTripodConfigTest extends MongoTripodTestBase
                 )
             )
         );
-        \Tripod\Mongo\Config::setConfig($config);
-        $mtc = \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::setConfig($config);
+        $mtc = \Tripod\Config::getInstance();
         $this->assertEquals("myreplicaset", $mtc->getReplicaSetName($mtc->getDefaultDataSourceForStore("tripod_php_testing")));
 
         $this->assertNull($mtc->getReplicaSetName("testing_2"));
@@ -900,10 +900,10 @@ class MongoTripodConfigTest extends MongoTripodTestBase
             )
         );
 
-        $vspec = \Tripod\Mongo\Config::getInstance()->getViewSpecification('tripod_php_testing', "v_resource_full");
+        $vspec = \Tripod\Config::getInstance()->getViewSpecification('tripod_php_testing', "v_resource_full");
         $this->assertEquals($expectedVspec, $vspec);
 
-        $vspec = \Tripod\Mongo\Config::getInstance()->getViewSpecification('tripod_php_testing', "doesnt_exist");
+        $vspec = \Tripod\Config::getInstance()->getViewSpecification('tripod_php_testing', "doesnt_exist");
         $this->assertNull($vspec);
     }
 
@@ -937,10 +937,10 @@ class MongoTripodConfigTest extends MongoTripodTestBase
             )
         );
 
-        $tspec = \Tripod\Mongo\Config::getInstance()->getTableSpecification("tripod_php_testing", "t_resource");
+        $tspec = \Tripod\Config::getInstance()->getTableSpecification("tripod_php_testing", "t_resource");
         $this->assertEquals($expectedTspec, $tspec);
 
-        $tspec = \Tripod\Mongo\Config::getInstance()->getTableSpecification("tripod_php_testing", "doesnt_exist");
+        $tspec = \Tripod\Config::getInstance()->getTableSpecification("tripod_php_testing", "doesnt_exist");
         $this->assertNull($tspec);
     }
 
@@ -965,8 +965,8 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         );
         $config["transaction_log"] = array("database"=>"transactions","collection"=>"transaction_log","data_source"=>"mongo1");
 
-        \Tripod\Mongo\Config::setConfig($config);
-        $mtc = \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::setConfig($config);
+        $mtc = \Tripod\Config::getInstance();
         $this->assertNull($mtc->getSearchProviderClassName("tripod_php_testing"));
         $this->assertEquals(array(), $mtc->getSearchDocumentSpecifications("tripod_php_testing"));
     }
@@ -1085,7 +1085,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
         $storeName = 'tripod_php_testing';
 
         $dataSourcesForStore = array();
-        $config = \Tripod\Mongo\Config::getInstance();
+        $config = \Tripod\Config::getInstance();
         $pods = $config->getPods($storeName);
 
         foreach($pods as $pod)
@@ -1127,7 +1127,7 @@ class MongoTripodConfigTest extends MongoTripodTestBase
 
         $diff = false;
 
-        $cfg = \Tripod\Mongo\Config::getConfig();
+        $cfg = \Tripod\Config::getConfig();
         $defaultDataSource = $cfg["data_sources"][$config->getDefaultDataSourceForStore($storeName)];
 
         foreach($dataSourcesForStore as $source)
@@ -1184,9 +1184,9 @@ class MongoTripodConfigTest extends MongoTripodTestBase
 
         $collectionsForDataSource['rs2'] = array(VIEWS_COLLECTION, SEARCH_INDEX_COLLECTION, TABLE_ROWS_COLLECTION, 'CBD_testing_2', 'transaction_log');
         $specs = array();
-        $specs['views'] = \Tripod\Mongo\Config::getInstance()->getViewSpecifications($storeName);
-        $specs['search'] = \Tripod\Mongo\Config::getInstance()->getSearchDocumentSpecifications($storeName);
-        $specs['table_rows'] = \Tripod\Mongo\Config::getInstance()->getTableSpecifications($storeName);
+        $specs['views'] = \Tripod\Config::getInstance()->getViewSpecifications($storeName);
+        $specs['search'] = \Tripod\Config::getInstance()->getSearchDocumentSpecifications($storeName);
+        $specs['table_rows'] = \Tripod\Config::getInstance()->getTableSpecifications($storeName);
         $specsForDataSource = array();
 
         foreach(array('views', 'search', 'table_rows') as $type)
@@ -1279,13 +1279,13 @@ class MongoTripodConfigTest extends MongoTripodTestBase
     public function testTransactionLogIsWrittenToCorrectDBAndCollection()
     {
         $storeName = 'tripod_php_testing';
-        $newConfig = \Tripod\Mongo\Config::getConfig();
+        $newConfig = \Tripod\Config::getConfig();
         $newConfig['transaction_log']['database'] = 'tripod_php_testing_transaction_log';
         $newConfig['transaction_log']['collection'] = 'transaction_log';
 
-        \Tripod\Mongo\Config::setConfig($newConfig);
+        \Tripod\Config::setConfig($newConfig);
 
-        $config = \Tripod\Mongo\Config::getInstance();
+        $config = \Tripod\Config::getInstance();
 
         // Clear out any old data
         $tlogDB = $config->getTransactionLogDatabase();
@@ -1345,355 +1345,355 @@ class MongoTripodConfigTest extends MongoTripodTestBase
 
     public function testComputedFieldSpecValidationInvalidFunction()
     {
-        $newConfig = \Tripod\Mongo\Config::getConfig();
+        $newConfig = \Tripod\Config::getConfig();
         \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $computedFieldFunction = array('fieldName'=>'fooBar', 'value'=>array('shazzbot'=>array()));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($computedFieldFunction);
-        \Tripod\Mongo\Config::setConfig($newConfig);
+        \Tripod\Config::setConfig($newConfig);
         $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed field spec does not contain valid function");
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::getInstance();
     }
 
     public function testComputedFieldSpecValidationMultipleFunctions()
     {
-        $newConfig = \Tripod\Mongo\Config::getConfig();
+        $newConfig = \Tripod\Config::getConfig();
         \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $computedFieldFunction = array('fieldName'=>'fooBar', 'value'=>array('conditional'=>array(),'replace'=>array()));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($computedFieldFunction);
-        \Tripod\Mongo\Config::setConfig($newConfig);
+        \Tripod\Config::setConfig($newConfig);
         $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed field spec contains more than one function");
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::getInstance();
     }
 
     public function testComputedFieldSpecValidationMustBeAtBaseLevel()
     {
-        $newConfig = \Tripod\Mongo\Config::getConfig();
+        $newConfig = \Tripod\Config::getConfig();
         \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $computedFieldFunction = array('fieldName'=>'fooBar', 'value'=>array('conditional'=>array()));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['joins']['dct:isVersionOf']['computed_fields'] = array($computedFieldFunction);
-        \Tripod\Mongo\Config::setConfig($newConfig);
+        \Tripod\Config::setConfig($newConfig);
         $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Table spec can only contain 'computed_fields' at the base level");
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::getInstance();
     }
 
     public function testConditionalSpecValidationEmptyConditional()
     {
-        $newConfig = \Tripod\Mongo\Config::getConfig();
+        $newConfig = \Tripod\Config::getConfig();
         \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $conditionalFunction = array('fieldName'=>'fooBar', 'value'=>array('conditional'=>array()));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($conditionalFunction);
-        \Tripod\Mongo\Config::setConfig($newConfig);
+        \Tripod\Config::setConfig($newConfig);
         $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed conditional spec does not contain an 'if' value");
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::getInstance();
     }
 
     public function testConditionalSpecValidationMissingThenElse()
     {
-        $newConfig = \Tripod\Mongo\Config::getConfig();
+        $newConfig = \Tripod\Config::getConfig();
         \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $conditionalFunction = array('fieldName'=>'fooBar', 'value'=>array('conditional'=>array('if'=>array())));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($conditionalFunction);
-        \Tripod\Mongo\Config::setConfig($newConfig);
+        \Tripod\Config::setConfig($newConfig);
         $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed conditional spec must contain a then or else value");
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::getInstance();
     }
 
     public function testConditionalSpecValidationEmptyIf()
     {
-        $newConfig = \Tripod\Mongo\Config::getConfig();
+        $newConfig = \Tripod\Config::getConfig();
         \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $conditionalFunction = array('fieldName'=>'fooBar', 'value'=>array('conditional'=>array('if'=>array(),'then'=>'wibble')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($conditionalFunction);
-        \Tripod\Mongo\Config::setConfig($newConfig);
+        \Tripod\Config::setConfig($newConfig);
         $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed conditional field spec 'if' value array must have 1 or 3 values");
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::getInstance();
     }
 
     public function testConditionalSpecValidationIfNotArray()
     {
-        $newConfig = \Tripod\Mongo\Config::getConfig();
+        $newConfig = \Tripod\Config::getConfig();
         \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $conditionalFunction = array('fieldName'=>'fooBar', 'value'=>array('conditional'=>array('if'=>'foo','then'=>'wibble')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($conditionalFunction);
-        \Tripod\Mongo\Config::setConfig($newConfig);
+        \Tripod\Config::setConfig($newConfig);
         $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed conditional field spec 'if' value must be an array");
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::getInstance();
     }
 
     public function testConditionalSpecValidationIfHasTwoValues()
     {
-        $newConfig = \Tripod\Mongo\Config::getConfig();
+        $newConfig = \Tripod\Config::getConfig();
         \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $conditionalFunction = array('fieldName'=>'fooBar', 'value'=>array('conditional'=>array('if'=>array('foo','*'),'then'=>'wibble')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($conditionalFunction);
-        \Tripod\Mongo\Config::setConfig($newConfig);
+        \Tripod\Config::setConfig($newConfig);
         $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed conditional field spec 'if' value array must have 1 or 3 values");
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::getInstance();
     }
 
     public function testConditionalSpecValidationIfHasMoreThanThreeValues()
     {
-        $newConfig = \Tripod\Mongo\Config::getConfig();
+        $newConfig = \Tripod\Config::getConfig();
         \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $conditionalFunction = array('fieldName'=>'fooBar', 'value'=>array('conditional'=>array('if'=>array('a','b','c','d'),'then'=>'wibble')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($conditionalFunction);
-        \Tripod\Mongo\Config::setConfig($newConfig);
+        \Tripod\Config::setConfig($newConfig);
         $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed conditional field spec 'if' value array must have 1 or 3 values");
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::getInstance();
     }
 
     public function testConditionalSpecValidationIfHasInvalidConditionalOperator()
     {
-        $newConfig = \Tripod\Mongo\Config::getConfig();
+        $newConfig = \Tripod\Config::getConfig();
         \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $conditionalFunction = array('fieldName'=>'fooBar', 'value'=>array('conditional'=>array('if'=>array('a','*','c'),'then'=>'wibble')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($conditionalFunction);
-        \Tripod\Mongo\Config::setConfig($newConfig);
+        \Tripod\Config::setConfig($newConfig);
         $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Invalid conditional operator '*' in conditional spec");
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::getInstance();
     }
 
     public function testConditionalSpecValidationIfHasInvalidVariableAsLeftOperand()
     {
-        $newConfig = \Tripod\Mongo\Config::getConfig();
+        $newConfig = \Tripod\Config::getConfig();
         \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $conditionalFunction = array('fieldName'=>'fooBar', 'value'=>array('conditional'=>array('if'=>array('$wibble','>=','c'),'then'=>'wibble')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($conditionalFunction);
-        \Tripod\Mongo\Config::setConfig($newConfig);
+        \Tripod\Config::setConfig($newConfig);
         $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed spec variable '\$wibble' is not defined in table spec");
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::getInstance();
     }
 
     public function testConditionalSpecValidationIfHasInvalidVariableAsRightOperand()
     {
-        $newConfig = \Tripod\Mongo\Config::getConfig();
+        $newConfig = \Tripod\Config::getConfig();
         \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $conditionalFunction = array('fieldName'=>'fooBar', 'value'=>array('conditional'=>array('if'=>array('a','contains','$wibble'),'then'=>'wibble')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($conditionalFunction);
-        \Tripod\Mongo\Config::setConfig($newConfig);
+        \Tripod\Config::setConfig($newConfig);
         $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed spec variable '\$wibble' is not defined in table spec");
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::getInstance();
     }
 
     public function testConditionalSpecValidationThenHasInvalidVariable()
     {
-        $newConfig = \Tripod\Mongo\Config::getConfig();
+        $newConfig = \Tripod\Config::getConfig();
         \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $conditionalFunction = array('fieldName'=>'fooBar', 'value'=>array('conditional'=>array('if'=>array('a','<','b'),'then'=>'$wibble')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($conditionalFunction);
-        \Tripod\Mongo\Config::setConfig($newConfig);
+        \Tripod\Config::setConfig($newConfig);
         $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed spec variable '\$wibble' is not defined in table spec");
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::getInstance();
     }
 
 
     public function testConditionalSpecValidationElseHasInvalidVariable()
     {
-        $newConfig = \Tripod\Mongo\Config::getConfig();
+        $newConfig = \Tripod\Config::getConfig();
         \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $conditionalFunction = array('fieldName'=>'fooBar', 'value'=>array('conditional'=>array('if'=>array('a','<','b'),'then'=>true,'else'=>'$wibble')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($conditionalFunction);
-        \Tripod\Mongo\Config::setConfig($newConfig);
+        \Tripod\Config::setConfig($newConfig);
         $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed spec variable '\$wibble' is not defined in table spec");
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::getInstance();
     }
 
     public function testReplaceSpecValidationEmptyFunction()
     {
-        $newConfig = \Tripod\Mongo\Config::getConfig();
+        $newConfig = \Tripod\Config::getConfig();
         \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $replaceFunction = array('fieldName'=>'fooBar', 'value'=>array('replace'=>array()));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($replaceFunction);
-        \Tripod\Mongo\Config::setConfig($newConfig);
+        \Tripod\Config::setConfig($newConfig);
         $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed replace spec does not contain 'search' value");
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::getInstance();
     }
 
     public function testReplaceSpecValidationMissingReplace()
     {
-        $newConfig = \Tripod\Mongo\Config::getConfig();
+        $newConfig = \Tripod\Config::getConfig();
         \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $replaceFunction = array('fieldName'=>'fooBar', 'value'=>array('replace'=>array('search'=>'x')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($replaceFunction);
-        \Tripod\Mongo\Config::setConfig($newConfig);
+        \Tripod\Config::setConfig($newConfig);
         $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed replace spec does not contain 'replace' value");
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::getInstance();
     }
 
     public function testReplaceSpecValidationMissingSubject()
     {
-        $newConfig = \Tripod\Mongo\Config::getConfig();
+        $newConfig = \Tripod\Config::getConfig();
         \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $replaceFunction = array('fieldName'=>'fooBar', 'value'=>array('replace'=>array('search'=>'x', 'replace'=>'y')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($replaceFunction);
-        \Tripod\Mongo\Config::setConfig($newConfig);
+        \Tripod\Config::setConfig($newConfig);
         $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed replace spec does not contain 'subject' value");
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::getInstance();
     }
 
     public function testReplaceSpecValidationInvalidVariableInSearch()
     {
-        $newConfig = \Tripod\Mongo\Config::getConfig();
+        $newConfig = \Tripod\Config::getConfig();
         \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $replaceFunction = array('fieldName'=>'fooBar', 'value'=>array('replace'=>array('search'=>'$x','replace'=>'y','subject'=>'z')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($replaceFunction);
-        \Tripod\Mongo\Config::setConfig($newConfig);
+        \Tripod\Config::setConfig($newConfig);
         $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed spec variable '\$x' is not defined in table spec");
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::getInstance();
     }
 
     public function testReplaceSpecValidationInvalidVariableInSearchArray()
     {
-        $newConfig = \Tripod\Mongo\Config::getConfig();
+        $newConfig = \Tripod\Config::getConfig();
         \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $replaceFunction = array('fieldName'=>'fooBar', 'value'=>array('replace'=>array('search'=>array('a','b','$x'),'replace'=>'y','subject'=>'z')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($replaceFunction);
-        \Tripod\Mongo\Config::setConfig($newConfig);
+        \Tripod\Config::setConfig($newConfig);
         $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed spec variable '\$x' is not defined in table spec");
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::getInstance();
     }
 
     public function testReplaceSpecValidationInvalidVariableInReplace()
     {
-        $newConfig = \Tripod\Mongo\Config::getConfig();
+        $newConfig = \Tripod\Config::getConfig();
         \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $replaceFunction = array('fieldName'=>'fooBar', 'value'=>array('replace'=>array('search'=>'x','replace'=>'$y','subject'=>'z')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($replaceFunction);
-        \Tripod\Mongo\Config::setConfig($newConfig);
+        \Tripod\Config::setConfig($newConfig);
         $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed spec variable '\$y' is not defined in table spec");
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::getInstance();
     }
 
     public function testReplaceSpecValidationInvalidVariableInReplaceArray()
     {
-        $newConfig = \Tripod\Mongo\Config::getConfig();
+        $newConfig = \Tripod\Config::getConfig();
         \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $replaceFunction = array('fieldName'=>'fooBar', 'value'=>array('replace'=>array('search'=>'x','replace'=>array('a','$y', 'c'),'subject'=>'z')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($replaceFunction);
-        \Tripod\Mongo\Config::setConfig($newConfig);
+        \Tripod\Config::setConfig($newConfig);
         $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed spec variable '\$y' is not defined in table spec");
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::getInstance();
     }
 
     public function testReplaceSpecValidationInvalidVariableInSubject()
     {
-        $newConfig = \Tripod\Mongo\Config::getConfig();
+        $newConfig = \Tripod\Config::getConfig();
         \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $replaceFunction = array('fieldName'=>'fooBar', 'value'=>array('replace'=>array('search'=>'x','replace'=>'y','subject'=>'$z')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($replaceFunction);
-        \Tripod\Mongo\Config::setConfig($newConfig);
+        \Tripod\Config::setConfig($newConfig);
         $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed spec variable '\$z' is not defined in table spec");
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::getInstance();
     }
 
     public function testReplaceSpecValidationInvalidVariableInSubjectArray()
     {
-        $newConfig = \Tripod\Mongo\Config::getConfig();
+        $newConfig = \Tripod\Config::getConfig();
         \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $replaceFunction = array('fieldName'=>'fooBar', 'value'=>array('replace'=>array('search'=>'x','replace'=>'y','subject'=>array('$z','b','c'))));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($replaceFunction);
-        \Tripod\Mongo\Config::setConfig($newConfig);
+        \Tripod\Config::setConfig($newConfig);
         $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed spec variable '\$z' is not defined in table spec");
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::getInstance();
     }
 
     public function testArithmeticSpecValidationEmptyFunction()
     {
-        $newConfig = \Tripod\Mongo\Config::getConfig();
+        $newConfig = \Tripod\Config::getConfig();
         \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $arithmeticFunction = array('fieldName'=>'fooBar', 'value'=>array('arithmetic'=>array()));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($arithmeticFunction);
-        \Tripod\Mongo\Config::setConfig($newConfig);
+        \Tripod\Config::setConfig($newConfig);
         $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed arithmetic spec must contain 3 values");
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::getInstance();
     }
 
     public function testArithmeticSpecValidationOneValue()
     {
-        $newConfig = \Tripod\Mongo\Config::getConfig();
+        $newConfig = \Tripod\Config::getConfig();
         \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $arithmeticFunction = array('fieldName'=>'fooBar', 'value'=>array('arithmetic'=>array(1)));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($arithmeticFunction);
-        \Tripod\Mongo\Config::setConfig($newConfig);
+        \Tripod\Config::setConfig($newConfig);
         $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed arithmetic spec must contain 3 values");
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::getInstance();
     }
 
     public function testArithmeticSpecValidationTwoValues()
     {
-        $newConfig = \Tripod\Mongo\Config::getConfig();
+        $newConfig = \Tripod\Config::getConfig();
         \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $arithmeticFunction = array('fieldName'=>'fooBar', 'value'=>array('arithmetic'=>array(1,'+')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($arithmeticFunction);
-        \Tripod\Mongo\Config::setConfig($newConfig);
+        \Tripod\Config::setConfig($newConfig);
         $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed arithmetic spec must contain 3 values");
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::getInstance();
     }
 
     public function testArithmeticSpecValidationFourValues()
     {
-        $newConfig = \Tripod\Mongo\Config::getConfig();
+        $newConfig = \Tripod\Config::getConfig();
         \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $arithmeticFunction = array('fieldName'=>'fooBar', 'value'=>array('arithmetic'=>array(1,'+',3,4)));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($arithmeticFunction);
-        \Tripod\Mongo\Config::setConfig($newConfig);
+        \Tripod\Config::setConfig($newConfig);
         $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed arithmetic spec must contain 3 values");
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::getInstance();
     }
 
     public function testArithmeticSpecValidationInvalidArithmeticOperator()
     {
-        $newConfig = \Tripod\Mongo\Config::getConfig();
+        $newConfig = \Tripod\Config::getConfig();
         \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $arithmeticFunction = array('fieldName'=>'fooBar', 'value'=>array('arithmetic'=>array(1,'x',3)));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($arithmeticFunction);
-        \Tripod\Mongo\Config::setConfig($newConfig);
+        \Tripod\Config::setConfig($newConfig);
         $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Invalid arithmetic operator 'x' in computed arithmetic spec");
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::getInstance();
     }
 
     public function testArithmeticSpecValidationInvalidVariableLeftOperand()
     {
-        $newConfig = \Tripod\Mongo\Config::getConfig();
+        $newConfig = \Tripod\Config::getConfig();
         \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $arithmeticFunction = array('fieldName'=>'fooBar', 'value'=>array('arithmetic'=>array('$x','*',3)));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($arithmeticFunction);
-        \Tripod\Mongo\Config::setConfig($newConfig);
+        \Tripod\Config::setConfig($newConfig);
         $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed spec variable '\$x' is not defined in table spec");
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::getInstance();
     }
 
     public function testArithmeticSpecValidationInvalidVariableRightOperand()
     {
-        $newConfig = \Tripod\Mongo\Config::getConfig();
+        $newConfig = \Tripod\Config::getConfig();
         \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $arithmeticFunction = array('fieldName'=>'fooBar', 'value'=>array('arithmetic'=>array(1,'*','$x')));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($arithmeticFunction);
-        \Tripod\Mongo\Config::setConfig($newConfig);
+        \Tripod\Config::setConfig($newConfig);
         $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed spec variable '\$x' is not defined in table spec");
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::getInstance();
     }
 
     public function testArithmeticSpecValidationInvalidNestedVariable()
     {
-        $newConfig = \Tripod\Mongo\Config::getConfig();
+        $newConfig = \Tripod\Config::getConfig();
         \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $arithmeticFunction = array('fieldName'=>'fooBar', 'value'=>array('arithmetic'=>array(array('$x','-',100),'*',3)));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($arithmeticFunction);
-        \Tripod\Mongo\Config::setConfig($newConfig);
+        \Tripod\Config::setConfig($newConfig);
         $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Computed spec variable '\$x' is not defined in table spec");
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::getInstance();
     }
 
     public function testArithmeticSpecValidationInvalidNestedOperator()
     {
-        $newConfig = \Tripod\Mongo\Config::getConfig();
+        $newConfig = \Tripod\Config::getConfig();
         \Tripod\Mongo\Config::setValidationLevel(\Tripod\Mongo\Config::VALIDATE_MAX);
         $arithmeticFunction = array('fieldName'=>'fooBar', 'value'=>array('arithmetic'=>array(array(101,'#',100),'*',3)));
         $newConfig['stores']['tripod_php_testing']['table_specifications'][0]['computed_fields'] = array($arithmeticFunction);
-        \Tripod\Mongo\Config::setConfig($newConfig);
+        \Tripod\Config::setConfig($newConfig);
         $this->setExpectedException('\Tripod\Exceptions\ConfigException', "Invalid arithmetic operator '#' in computed arithmetic spec");
-        \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::getInstance();
     }
 
     public function testGetResqueServer()

--- a/test/unit/mongo/MongoTripodDriverTest.php
+++ b/test/unit/mongo/MongoTripodDriverTest.php
@@ -44,7 +44,7 @@ class MongoTripodDriverTest extends MongoTripodTestBase
         $this->getTripodCollection($this->tripod)->drop();
 
         // Lock collection no longer available from Tripod, so drop it manually
-        \Tripod\Mongo\Config::getInstance()->getCollectionForLocks($this->tripod->getStoreName())->drop();
+        \Tripod\Config::getInstance()->getCollectionForLocks($this->tripod->getStoreName())->drop();
 
         $this->tripod->setTransactionLog($this->tripodTransactionLog);
 
@@ -584,21 +584,21 @@ class MongoTripodDriverTest extends MongoTripodTestBase
         $subjectOne = "http://talisaspire.com/works/checkReadPreferencesWrite";
         /** @var $tripodMock \Tripod\Mongo\Driver **/
         $tripodMock = $this->getMock(
-            '\Tripod\Mongo\Driver', 
-            array('getDataUpdater'), 
+            '\Tripod\Mongo\Driver',
+            array('getDataUpdater'),
             array(
                 'CBD_testing',
                 'tripod_php_testing',
                 array('defaultContext'=>'http://talisaspire.com/')
             )
         );
-        
+
         $tripodUpdate = $this->getMock(
             '\Tripod\Mongo\Updates',
-            array('addToSearchIndexQueue','setReadPreferenceToPrimary','resetOriginalReadPreference'), 
+            array('addToSearchIndexQueue','setReadPreferenceToPrimary','resetOriginalReadPreference'),
             array($tripodMock)
         );
-        
+
         $tripodUpdate
             ->expects($this->once(0))
             ->method('setReadPreferenceToPrimary');
@@ -606,7 +606,7 @@ class MongoTripodDriverTest extends MongoTripodTestBase
         $tripodUpdate
             ->expects($this->once())
             ->method('resetOriginalReadPreference');
-        
+
         $tripodMock
             ->expects($this->once())
             ->method('getDataUpdater')
@@ -624,8 +624,8 @@ class MongoTripodDriverTest extends MongoTripodTestBase
         $subjectOne = "http://talisaspire.com/works/checkReadPreferencesAreRestoredOnError";
         /** @var $tripodMock \Tripod\Mongo\Driver|PHPUnit_Framework_MockObject_MockObject **/
         $tripodMock = $this->getMock(
-            '\Tripod\Mongo\Driver', 
-            array('getDataUpdater'), 
+            '\Tripod\Mongo\Driver',
+            array('getDataUpdater'),
             array(
                 'CBD_testing',
                 'tripod_php_testing',
@@ -636,7 +636,7 @@ class MongoTripodDriverTest extends MongoTripodTestBase
         /** @var $tripodUpdate \Tripod\Mongo\Updates|PHPUnit_Framework_MockObject_MockObject **/
         $tripodUpdate = $this->getMock(
             '\Tripod\Mongo\Updates',
-            array('addToSearchIndexQueue','resetOriginalReadPreference','getContextAlias'), 
+            array('addToSearchIndexQueue','resetOriginalReadPreference','getContextAlias'),
             array($tripodMock)
         );
 
@@ -862,7 +862,7 @@ class MongoTripodDriverTest extends MongoTripodTestBase
         $config['queue'] = array("database"=>"queue","collection"=>"q_queue","data_source"=>"db");
 
         // Override the config defined in base test class as we need specific config here.
-        \Tripod\Mongo\Config::setConfig($config);
+        \Tripod\Config::setConfig($config);
 
         $tripod = new \Tripod\Mongo\Driver('CBD_testing','tripod_php_testing',array('defaultContext'=>'http://talisaspire.com/'));
 
@@ -943,7 +943,6 @@ class MongoTripodDriverTest extends MongoTripodTestBase
         $jobData = array(
             'changes'=>$subjectsAndPredicatesOfChange,
             'operations'=>array(OP_TABLES, OP_VIEWS, OP_SEARCH),
-            'tripodConfig'=>\Tripod\Mongo\Config::getConfig(),
             'storeName'=>'tripod_php_testing',
             'podName'=>'CBD_testing',
             'contextAlias'=>'http://talisaspire.com/',
@@ -1019,7 +1018,7 @@ class MongoTripodDriverTest extends MongoTripodTestBase
             array('getImpactedSubjects', 'update'),
             array(
                 'tripod_php_testing',
-                \Tripod\Mongo\Config::getInstance()->getCollectionForCBD('tripod_php_testing','CBD_testing'),
+                \Tripod\Config::getInstance()->getCollectionForCBD('tripod_php_testing','CBD_testing'),
                 'http://talisaspire.com/'
             )
         );
@@ -1029,7 +1028,7 @@ class MongoTripodDriverTest extends MongoTripodTestBase
             array('getImpactedSubjects', 'update'),
             array(
                 'tripod_php_testing',
-                \Tripod\Mongo\Config::getInstance()->getCollectionForCBD('tripod_php_testing','CBD_testing'),
+                \Tripod\Config::getInstance()->getCollectionForCBD('tripod_php_testing','CBD_testing'),
                 'http://talisaspire.com/'
             )
         );
@@ -1049,7 +1048,6 @@ class MongoTripodDriverTest extends MongoTripodTestBase
         $jobData = array(
             'changes'=>$subjectsAndPredicatesOfChange,
             'operations'=>array(OP_SEARCH),
-            'tripodConfig'=>\Tripod\Mongo\Config::getConfig(),
             'storeName'=>'tripod_php_testing',
             'podName'=>'CBD_testing',
             'contextAlias'=>'http://talisaspire.com/',
@@ -1234,7 +1232,7 @@ class MongoTripodDriverTest extends MongoTripodTestBase
             array('getImpactedSubjects', 'update'),
             array(
                 'tripod_php_testing',
-                \Tripod\Mongo\Config::getInstance()->getCollectionForCBD('tripod_php_testing','CBD_testing'),
+                \Tripod\Config::getInstance()->getCollectionForCBD('tripod_php_testing','CBD_testing'),
                 'http://talisaspire.com/'
             )
         );
@@ -1284,7 +1282,6 @@ class MongoTripodDriverTest extends MongoTripodTestBase
         $jobData = array(
             'changes'=>$subjectsAndPredicatesOfChange,
             'operations'=>array(OP_TABLES, OP_SEARCH),
-            'tripodConfig'=>\Tripod\Mongo\Config::getConfig(),
             'storeName'=>'tripod_php_testing',
             'podName'=>'CBD_testing',
             'contextAlias'=>'http://talisaspire.com/',
@@ -1384,7 +1381,7 @@ class MongoTripodDriverTest extends MongoTripodTestBase
             array('getImpactedSubjects', 'update'),
             array(
                 'tripod_php_testing',
-                \Tripod\Mongo\Config::getInstance()->getCollectionForCBD('tripod_php_testing','CBD_testing'),
+                \Tripod\Config::getInstance()->getCollectionForCBD('tripod_php_testing','CBD_testing'),
                 'http://talisaspire.com/'
             )
         );
@@ -1434,7 +1431,6 @@ class MongoTripodDriverTest extends MongoTripodTestBase
         $jobData = array(
             'changes'=>$subjectsAndPredicatesOfChange,
             'operations'=>array(OP_TABLES, OP_SEARCH),
-            'tripodConfig'=>\Tripod\Mongo\Config::getConfig(),
             'storeName'=>'tripod_php_testing',
             'podName'=>'CBD_testing',
             'contextAlias'=>'http://talisaspire.com/',
@@ -1926,7 +1922,7 @@ class MongoTripodDriverTest extends MongoTripodTestBase
         $tripodUpdate = $this->getMock('\Tripod\Mongo\Updates',
             array('unlockAllDocuments', 'generateIdForNewMongoDocument', 'getMongoDate', 'getAuditManualRollbacksCollection'),
             array($tripod));
-        
+
         $tripodUpdate->expects($this->once())
             ->method("generateIdForNewMongoDocument")
             ->will($this->returnValue($mongoDocumentId));
@@ -2004,7 +2000,7 @@ class MongoTripodDriverTest extends MongoTripodTestBase
         $tripodUpdate = $this->getMock('\Tripod\Mongo\Updates',
             array('unlockAllDocuments', 'generateIdForNewMongoDocument', 'getMongoDate', 'getAuditManualRollbacksCollection'),
             array($tripod));
-        
+
         $tripodUpdate->expects($this->once())
             ->method("generateIdForNewMongoDocument")
             ->will($this->returnValue($mongoDocumentId));
@@ -2181,7 +2177,7 @@ class MongoTripodDriverTest extends MongoTripodTestBase
 
     public function testEtagIsMicrotimeFormat() {
 
-        $config = \Tripod\Mongo\Config::getInstance();
+        $config = \Tripod\Config::getInstance();
         $updatedAt = \Tripod\Mongo\DateUtil::getMongoDate();
 
         $_id = array(

--- a/test/unit/mongo/MongoTripodNQuadSerializerTest.php
+++ b/test/unit/mongo/MongoTripodNQuadSerializerTest.php
@@ -23,7 +23,7 @@ class MongoTripodNQuadSerializerTest extends MongoTripodTestBase
 <http://example.com/1> <http://purl.org/dc/terms/source> <http://www.google.com> <http://talisaspire.com/> .\n";
 
         $serializer = new NQuadSerializer();
-        $actual = $serializer->getSerializedIndex($g->_index, \Tripod\Mongo\Config::getInstance()->getDefaultContextAlias());
+        $actual = $serializer->getSerializedIndex($g->_index, \Tripod\Config::getInstance()->getDefaultContextAlias());
 
         $this->assertEquals($expected, $actual);
     }
@@ -166,7 +166,7 @@ class MongoTripodNQuadSerializerTest extends MongoTripodTestBase
 <http://basedata.com/b/docWithEmptySeq123> <http://purl.org/dc/terms/title> \"Doc with sequence\" <http://talisaspire.com/> .";
         
         $serializer = new NQuadSerializer();
-        $actual = $serializer->getSerializedIndex($g->_index, \Tripod\Mongo\Config::getInstance()->getDefaultContextAlias());
+        $actual = $serializer->getSerializedIndex($g->_index, \Tripod\Config::getInstance()->getDefaultContextAlias());
 
         // This test initially asserted that $expected was equal to $actual
         //   $this->assertEquals($expected, $actual);

--- a/test/unit/mongo/MongoTripodQueueOperationsTest.php
+++ b/test/unit/mongo/MongoTripodQueueOperationsTest.php
@@ -11,7 +11,7 @@ require_once 'src/mongo/Driver.class.php';
  * the results are as we would expect. For that reason this suite is more than just a series of unit tests, feels more like a set of integration tests since we
  * are testing a chained flow of events.
  */
-class MongoTripodQueueOperations extends MongoTripodTestBase
+class MongoTripodQueueOperationsTest extends MongoTripodTestBase
 {
     /**
      * @var \Tripod\Mongo\Driver
@@ -76,7 +76,6 @@ class MongoTripodQueueOperations extends MongoTripodTestBase
         $data = array(
             "changes" => $subjectsAndPredicatesOfChange,
             "operations" => array(OP_VIEWS, OP_TABLES, OP_SEARCH),
-            "tripodConfig" => \Tripod\Mongo\Config::getConfig(),
             "storeName" => 'tripod_php_testing',
             "podName" => 'CBD_testing',
             "contextAlias" => 'http://talisaspire.com/',
@@ -155,7 +154,6 @@ class MongoTripodQueueOperations extends MongoTripodTestBase
         $data = array(
             "changes" => $subjectsAndPredicatesOfChange,
             "operations" => array(OP_VIEWS),
-            "tripodConfig" => \Tripod\Mongo\Config::getConfig(),
             "storeName" => 'tripod_php_testing',
             "podName" => 'CBD_testing',
             "contextAlias" => 'http://talisaspire.com/',
@@ -289,7 +287,6 @@ class MongoTripodQueueOperations extends MongoTripodTestBase
         $data = array(
             "changes" => $subjectsAndPredicatesOfChange,
             "operations" => array(OP_VIEWS, OP_TABLES, OP_SEARCH),
-            "tripodConfig" => \Tripod\Mongo\Config::getConfig(),
             "storeName" => 'tripod_php_testing',
             "podName" => 'CBD_testing',
             "contextAlias" => 'http://talisaspire.com/',

--- a/test/unit/mongo/MongoTripodSearchDocumentsTest.php
+++ b/test/unit/mongo/MongoTripodSearchDocumentsTest.php
@@ -18,7 +18,7 @@ class MongoTripodSearchDocumentsTest extends MongoTripodTestBase
         $this->tripod = new \Tripod\Mongo\Driver('CBD_testing', 'tripod_php_testing');
         $this->getTripodCollection($this->tripod)->drop();
         $this->loadBaseSearchDataViaTripod();
-        foreach (\Tripod\Mongo\Config::getInstance()->getCollectionsForSearch($this->tripod->getStoreName()) as $collection)
+        foreach (\Tripod\Config::getInstance()->getCollectionsForSearch($this->tripod->getStoreName()) as $collection)
         {
             $collection->drop();
         }
@@ -132,7 +132,7 @@ class MongoTripodSearchDocumentsTest extends MongoTripodTestBase
             ->setConstructorArgs(
                 array(
                     $this->defaultStoreName,
-                    \Tripod\Mongo\Config::getInstance()->getCollectionForCBD($this->defaultStoreName, $this->defaultPodName),
+                    \Tripod\Config::getInstance()->getCollectionForCBD($this->defaultStoreName, $this->defaultPodName),
                     $this->defaultContext
                 )
             )->getMock();
@@ -218,7 +218,7 @@ class MongoTripodSearchDocumentsTest extends MongoTripodTestBase
             ->setConstructorArgs(
                 array(
                     $this->defaultStoreName,
-                    \Tripod\Mongo\Config::getInstance()->getCollectionForCBD($this->defaultStoreName, $this->defaultPodName),
+                    \Tripod\Config::getInstance()->getCollectionForCBD($this->defaultStoreName, $this->defaultPodName),
                     $this->defaultContext
                 )
             )->getMock();
@@ -340,7 +340,7 @@ class MongoTripodSearchDocumentsTest extends MongoTripodTestBase
             ->setConstructorArgs(
                 array(
                     $this->defaultStoreName,
-                    \Tripod\Mongo\Config::getInstance()->getCollectionForCBD($this->defaultStoreName, $this->defaultPodName),
+                    \Tripod\Config::getInstance()->getCollectionForCBD($this->defaultStoreName, $this->defaultPodName),
                     $this->defaultContext
                 )
             )->getMock();
@@ -552,7 +552,7 @@ class MongoTripodSearchDocumentsTest extends MongoTripodTestBase
 
         $tripod->saveChanges(new \Tripod\ExtendedGraph(), $graph);
 
-        $collection = \Tripod\Mongo\Config::getInstance()->getCollectionForSearchDocument($this->defaultStoreName, 'i_search_resource');
+        $collection = \Tripod\Config::getInstance()->getCollectionForSearchDocument($this->defaultStoreName, 'i_search_resource');
 
         $query = array(
             _ID_KEY => array(

--- a/test/unit/mongo/MongoTripodSearchIndexerTest.php
+++ b/test/unit/mongo/MongoTripodSearchIndexerTest.php
@@ -13,7 +13,7 @@ class MongoTripodSearchIndexerTest extends MongoTripodTestBase {
         parent::setUp();
 
         $this->tripod = new \Tripod\Mongo\Driver("CBD_testing", "tripod_php_testing", array("async"=>array(OP_VIEWS=>true, OP_TABLES=>true, OP_SEARCH=>false)));
-        foreach(\Tripod\Mongo\Config::getInstance()->getCollectionsForSearch($this->tripod->getStoreName()) as $collection)
+        foreach(\Tripod\Config::getInstance()->getCollectionsForSearch($this->tripod->getStoreName()) as $collection)
         {
             $collection->drop();
         }

--- a/test/unit/mongo/MongoTripodTablesTest.php
+++ b/test/unit/mongo/MongoTripodTablesTest.php
@@ -44,9 +44,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
 
         $this->getTripodCollection($this->tripod)->drop();
         $this->tripod->setTransactionLog($this->tripodTransactionLog);
-        error_log('start');
         $this->loadResourceDataViaTripod();
-        error_log('eng');
         $this->tablesConstParams = array($this->tripod->getStoreName(),$this->getTripodCollection($this->tripod),'http://talisaspire.com/');
 
         $this->tripodTables = new \Tripod\Mongo\Composites\Tables($this->tripod->getStoreName(),$this->getTripodCollection($this->tripod),null); // pass null context, should default to http://talisaspire.com

--- a/test/unit/mongo/MongoTripodTablesTest.php
+++ b/test/unit/mongo/MongoTripodTablesTest.php
@@ -1,4 +1,6 @@
 <?php
+
+use Monolog\Logger;
 require_once 'MongoTripodTestBase.php';
 require_once 'src/mongo/delegates/Tables.class.php';
 require_once 'src/mongo/Driver.class.php';
@@ -42,16 +44,15 @@ class MongoTripodTablesTest extends MongoTripodTestBase
 
         $this->getTripodCollection($this->tripod)->drop();
         $this->tripod->setTransactionLog($this->tripodTransactionLog);
-
+        error_log('start');
         $this->loadResourceDataViaTripod();
-
+        error_log('eng');
         $this->tablesConstParams = array($this->tripod->getStoreName(),$this->getTripodCollection($this->tripod),'http://talisaspire.com/');
 
         $this->tripodTables = new \Tripod\Mongo\Composites\Tables($this->tripod->getStoreName(),$this->getTripodCollection($this->tripod),null); // pass null context, should default to http://talisaspire.com
 
         // purge tables
-        foreach(\Tripod\Mongo\Config::getInstance()->getCollectionsForTables($this->tripod->getStoreName()) as $collection)
-        {
+        foreach (\Tripod\Config::getInstance()->getCollectionsForTables($this->tripod->getStoreName()) as $collection) {
             $collection->drop();
         }
     }
@@ -456,8 +457,8 @@ class MongoTripodTablesTest extends MongoTripodTestBase
 
         // Note that you need some config in order to create the Config object successfully.
         // Once that object has been created, we use our own table specifications to test against.
-        \Tripod\Mongo\Config::setConfig($this->generateMongoTripodTestConfig());
-        $tripodConfig = \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::setConfig($this->generateMongoTripodTestConfig());
+        $tripodConfig = \Tripod\Config::getInstance();
 
         foreach($tableSpecifications['fields'] as $field)
         {
@@ -493,8 +494,8 @@ class MongoTripodTablesTest extends MongoTripodTestBase
 
         // Note that you need some config in order to create the Config object successfully.
         // Once that object has been created, we use our own table specifications to test against.
-        \Tripod\Mongo\Config::setConfig($this->generateMongoTripodTestConfig());
-        $tripodConfig = \Tripod\Mongo\Config::getInstance();
+        \Tripod\Config::setConfig($this->generateMongoTripodTestConfig());
+        $tripodConfig = \Tripod\Config::getInstance();
 
         $tripodConfig->checkModifierFunctions($tableSpecifications['predicates'], \Tripod\Mongo\Composites\Tables::$predicateModifiers);
     }
@@ -838,7 +839,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
 
     public function testTableRowsGenerateWhenDefinedPredicateChanges()
     {
-        foreach(\Tripod\Mongo\Config::getInstance()->getTableSpecifications($this->tripod->getStoreName()) as $specId=>$spec)
+        foreach(\Tripod\Config::getInstance()->getTableSpecifications($this->tripod->getStoreName()) as $specId=>$spec)
         {
             $this->generateTableRows($specId);
         }
@@ -939,7 +940,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
 
         // This should be 0, because we mocked the actual adding of the regenerated table.  If it's zero, however,
         // it means we successfully deleted the views with $uri1 in the impactIndex
-        $collections = \Tripod\Mongo\Config::getInstance()->getCollectionsForTables($this->defaultStoreName);
+        $collections = \Tripod\Config::getInstance()->getCollectionsForTables($this->defaultStoreName);
         foreach($collections as $collection)
         {
             $query = array(
@@ -952,7 +953,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
 
     public function testTableRowsNotGeneratedWhenUndefinedPredicateChanges()
     {
-        foreach(\Tripod\Mongo\Config::getInstance()->getTableSpecifications($this->tripod->getStoreName()) as $specId=>$spec)
+        foreach(\Tripod\Config::getInstance()->getTableSpecifications($this->tripod->getStoreName()) as $specId=>$spec)
         {
             $this->generateTableRows($specId);
         }
@@ -968,7 +969,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
 
         $table = new \Tripod\Mongo\Composites\Tables(
             $this->defaultStoreName,
-            \Tripod\Mongo\Config::getInstance()->getCollectionForCBD($this->defaultStoreName, $this->defaultPodName),
+            \Tripod\Config::getInstance()->getCollectionForCBD($this->defaultStoreName, $this->defaultPodName),
             $this->defaultContext
         );
 
@@ -1126,7 +1127,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
             array('generateTableRowsForType'),
             array(
                 $this->defaultStoreName,
-                \Tripod\Mongo\Config::getInstance()->getCollectionForCBD($this->defaultStoreName, $this->defaultPodName),
+                \Tripod\Config::getInstance()->getCollectionForCBD($this->defaultStoreName, $this->defaultPodName),
                 $this->defaultContext
             )
         );
@@ -1172,7 +1173,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
 
         $tables = new \Tripod\Mongo\Composites\Tables(
             $this->defaultStoreName,
-            \Tripod\Mongo\Config::getInstance()->getCollectionForCBD($this->defaultStoreName, $this->defaultPodName),
+            \Tripod\Config::getInstance()->getCollectionForCBD($this->defaultStoreName, $this->defaultPodName),
             $this->defaultContext
         );
 
@@ -1569,7 +1570,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
 
     public function testRemoveTableSpecDoesNotAffectInvalidation()
     {
-        foreach(\Tripod\Mongo\Config::getInstance()->getTableSpecifications($this->tripod->getStoreName()) as $specId=>$spec)
+        foreach(\Tripod\Config::getInstance()->getTableSpecifications($this->tripod->getStoreName()) as $specId=>$spec)
         {
             $this->generateTableRows($specId);
         }
@@ -1577,11 +1578,11 @@ class MongoTripodTablesTest extends MongoTripodTestBase
         $context = 'http://talisaspire.com/';
         $uri = "http://talisaspire.com/works/4d101f63c10a6";
 
-        $collection = \Tripod\Mongo\Config::getInstance()->getCollectionForTable('tripod_php_testing', 't_resource');
+        $collection = \Tripod\Config::getInstance()->getCollectionForTable('tripod_php_testing', 't_resource');
         $this->assertGreaterThan(0, $collection->count(array('_id.type'=>'t_resource', 'value._impactIndex'=>array(_ID_RESOURCE=>$uri, _ID_CONTEXT=>$context))));
-        $config = \Tripod\Mongo\Config::getConfig();
+        $config = \Tripod\Config::getConfig();
         unset($config['stores']['tripod_php_testing']['table_specifications'][0]);
-        \Tripod\Mongo\Config::setConfig($config);
+        \Tripod\Config::setConfig($config);
 
         /** @var PHPUnit_Framework_MockObject_MockObject|\Tripod\Mongo\Driver $mockTripod */
         $mockTripod = $this->getMockBuilder('\Tripod\Mongo\Driver')
@@ -1607,7 +1608,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
             ->setConstructorArgs(
                 array(
                     'tripod_php_testing',
-                    \Tripod\Mongo\Config::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing'),
+                    \Tripod\Config::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing'),
                     $context
                 )
             )

--- a/test/unit/mongo/MongoTripodTestBase.php
+++ b/test/unit/mongo/MongoTripodTestBase.php
@@ -10,8 +10,6 @@ set_include_path(
   . PATH_SEPARATOR . dirname(dirname(dirname(dirname(__FILE__)))).'/src');
 
 require_once('tripod.inc.php');
-require_once TRIPOD_DIR . 'mongo/Config.class.php';
-require_once TRIPOD_DIR . 'mongo/base/DriverBase.class.php';
 
 /**
  * Mongo Config For Main DB
@@ -67,13 +65,12 @@ abstract class MongoTripodTestBase extends PHPUnit_Framework_TestCase
     /**
      * @param string $filename
      */
-    private function loadDataViaTripod($filename){
+    private function loadDataViaTripod($filename) {
         $docs = json_decode(file_get_contents(dirname(__FILE__).$filename), true);
-        foreach ($docs as $d)
-        {
+        foreach ($docs as $d) {
             $g = new \Tripod\Mongo\MongoGraph();
             $g->add_tripod_array($d);
-            $this->tripod->saveChanges(new \Tripod\ExtendedGraph(), $g,$d['_id'][_ID_CONTEXT]);
+            $this->tripod->saveChanges(new \Tripod\ExtendedGraph(), $g ,$d['_id'][_ID_CONTEXT]);
         }
     }
 
@@ -95,7 +92,7 @@ abstract class MongoTripodTestBase extends PHPUnit_Framework_TestCase
         {
             $config['data_sources']['rs2'] = json_decode(getenv('TRIPOD_DATASOURCE_RS2_CONFIG'), true);
         }
-        \Tripod\Mongo\Config::setConfig($config);
+        \Tripod\Config::setConfig($config);
 
         $className = get_class($this);
         $testName = $this->getName();
@@ -112,7 +109,7 @@ abstract class MongoTripodTestBase extends PHPUnit_Framework_TestCase
 
     protected function addDocument($doc, $toTransactionLog=false)
     {
-        $config = \Tripod\Mongo\Config::getInstance();
+        $config = \Tripod\Config::getInstance();
         if($toTransactionLog == true)
         {
             return $this->getTlogCollection()->insertOne($doc, array("w"=>1));
@@ -129,7 +126,7 @@ abstract class MongoTripodTestBase extends PHPUnit_Framework_TestCase
      */
     protected function getTlogCollection()
     {
-        $config = \Tripod\Mongo\Config::getInstance();
+        $config = \Tripod\Config::getInstance();
         $tLogConfig = $config->getTransactionLogConfig();
         return $config->getTransactionLogDatabase()->selectCollection($tLogConfig['collection']);
     }
@@ -140,7 +137,7 @@ abstract class MongoTripodTestBase extends PHPUnit_Framework_TestCase
      */
     protected function getTripodCollection(\Tripod\Mongo\Driver $tripod)
     {
-        $config = \Tripod\Mongo\Config::getInstance();
+        $config = \Tripod\Config::getInstance();
         $podName = $tripod->getPodName();
         $dataSource = $config->getDataSourceForPod($tripod->getStoreName(), $podName);
         return $config->getDatabase(
@@ -404,10 +401,10 @@ abstract class MongoTripodTestBase extends PHPUnit_Framework_TestCase
      */
     protected function lockDocument($subject, $transaction_id)
     {
-        $collection = \Tripod\Mongo\Config::getInstance()->getCollectionForLocks('tripod_php_testing');
+        $collection = \Tripod\Config::getInstance()->getCollectionForLocks('tripod_php_testing');
         $labeller = new \Tripod\Mongo\Labeller();
         $doc = array(
-            '_id' => array(_ID_RESOURCE => $labeller->uri_to_alias($subject), _ID_CONTEXT => \Tripod\Mongo\Config::getInstance()->getDefaultContextAlias()),
+            '_id' => array(_ID_RESOURCE => $labeller->uri_to_alias($subject), _ID_CONTEXT => \Tripod\Config::getInstance()->getDefaultContextAlias()),
             _LOCKED_FOR_TRANS => $transaction_id,
             _LOCKED_FOR_TRANS_TS => \Tripod\Mongo\DateUtil::getMongoDate()
         );

--- a/test/unit/mongo/MongoTripodTestBase.php
+++ b/test/unit/mongo/MongoTripodTestBase.php
@@ -70,7 +70,7 @@ abstract class MongoTripodTestBase extends PHPUnit_Framework_TestCase
         foreach ($docs as $d) {
             $g = new \Tripod\Mongo\MongoGraph();
             $g->add_tripod_array($d);
-            $this->tripod->saveChanges(new \Tripod\ExtendedGraph(), $g ,$d['_id'][_ID_CONTEXT]);
+            $this->tripod->saveChanges(new \Tripod\ExtendedGraph(), $g, $d['_id'][_ID_CONTEXT]);
         }
     }
 

--- a/test/unit/mongo/MongoTripodTransactionRollbackTest.php
+++ b/test/unit/mongo/MongoTripodTransactionRollbackTest.php
@@ -40,10 +40,10 @@ class MongoTripodTransactionRollbackTest extends MongoTripodTestBase
         $tripod->expects($this->any())->method('addToSearchIndexQueue');
 
         /** @var $tripod \Tripod\Mongo\Driver */
-        \Tripod\Mongo\Config::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing')->drop();
+        \Tripod\Config::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing')->drop();
 
         // Lock collection no longer available from Driver, so drop it manually
-        \Tripod\Mongo\Config::getInstance()->getCollectionForLocks('tripod_php_testing')->drop();
+        \Tripod\Config::getInstance()->getCollectionForLocks('tripod_php_testing')->drop();
 
         $tripod->setTransactionLog($this->tripodTransactionLog);
 
@@ -429,7 +429,7 @@ class MongoTripodTransactionRollbackTest extends MongoTripodTestBase
      */
     public function lockSingleDocumentCallback($s, $transaction_id, $contextAlias)
     {
-        $lCollection = \Tripod\Mongo\Config::getInstance()->getCollectionForLocks($this->tripod->getStoreName());
+        $lCollection = \Tripod\Config::getInstance()->getCollectionForLocks($this->tripod->getStoreName());
         $countEntriesInLocksCollection = $lCollection->count(array('_id' => array(_ID_RESOURCE => $this->labeller->uri_to_alias($s), _ID_CONTEXT => $contextAlias)));
 
         if($countEntriesInLocksCollection > 0) //Subject is already locked

--- a/test/unit/mongo/MongoTripodViewsTest.php
+++ b/test/unit/mongo/MongoTripodViewsTest.php
@@ -45,7 +45,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         );
 
 
-        foreach(\Tripod\Mongo\Config::getInstance()->getCollectionsForViews($this->tripod->getStoreName()) as $collection)
+        foreach(\Tripod\Config::getInstance()->getCollectionsForViews($this->tripod->getStoreName()) as $collection)
         {
             $collection->drop();
         }
@@ -103,7 +103,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         // get the view direct from mongo
 //        $result = $this->tripod->getViewForResource("http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA","v_resource_full");
         $mongo = new Client(
-            \Tripod\Mongo\Config::getInstance()->getConnStr('tripod_php_testing'),
+            \Tripod\Config::getInstance()->getConnStr('tripod_php_testing'),
             [],
             ['typeMap' => ['root' => 'array', 'document' => 'array', 'array' => 'array']]
         );
@@ -176,7 +176,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         );
         // get the view direct from mongo
         $mongo = new Client(
-            \Tripod\Mongo\Config::getInstance()->getConnStr('tripod_php_testing'),
+            \Tripod\Config::getInstance()->getConnStr('tripod_php_testing'),
             [],
             ['typeMap' => ['root' => 'array', 'document' => 'array', 'array' => 'array']]
         );
@@ -241,7 +241,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         );
         // get the view direct from mongo
         $mongo = new Client(
-            \Tripod\Mongo\Config::getInstance()->getConnStr('tripod_php_testing'),
+            \Tripod\Config::getInstance()->getConnStr('tripod_php_testing'),
             [],
             ['typeMap' => ['root' => 'array', 'document' => 'array', 'array' => 'array']]
         );
@@ -316,7 +316,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         );
         // get the view direct from mongo
         $mongo = new Client(
-            \Tripod\Mongo\Config::getInstance()->getConnStr('tripod_php_testing'),
+            \Tripod\Config::getInstance()->getConnStr('tripod_php_testing'),
             [],
             ['typeMap' => ['root' => 'array', 'document' => 'array', 'array' => 'array']]
         );
@@ -462,7 +462,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         );
         // get the view direct from mongo
         $mongo = new Client(
-            \Tripod\Mongo\Config::getInstance()->getConnStr('tripod_php_testing'),
+            \Tripod\Config::getInstance()->getConnStr('tripod_php_testing'),
             [],
             ['typeMap' => ['root' => 'array', 'document' => 'array', 'array' => 'array']]
         );
@@ -515,7 +515,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             )
         );
         // get the view direct from mongo
-        $actualView = \Tripod\Mongo\Config::getInstance()->getCollectionForView('tripod_php_testing', 'v_resource_full_ttl')->findOne(array('_id'=>array("r"=>'http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA',"c"=>'http://talisaspire.com/',"type"=>'v_resource_full_ttl')));
+        $actualView = \Tripod\Config::getInstance()->getCollectionForView('tripod_php_testing', 'v_resource_full_ttl')->findOne(array('_id'=>array("r"=>'http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA',"c"=>'http://talisaspire.com/',"type"=>'v_resource_full_ttl')));
         $this->assertEquals($expectedView['_id'], $actualView['_id']);
         $this->assertEquals($expectedView['value'], $actualView['value']);
         $this->assertInstanceOf('\MongoDB\BSON\UTCDateTime', $actualView['_cts']);
@@ -565,7 +565,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             ]
         ];
         // get the view direct from mongo
-        $actualView = \Tripod\Mongo\Config::getInstance()
+        $actualView = \Tripod\Config::getInstance()
             ->getCollectionForView('tripod_php_testing', 'v_event_no_expiration')
             ->findOne(
                 [
@@ -617,7 +617,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         );
 
         // get the view direct from mongo, it should the same as earlier
-        $actualView2 = \Tripod\Mongo\Config::getInstance()
+        $actualView2 = \Tripod\Config::getInstance()
             ->getCollectionForView('tripod_php_testing', 'v_event_no_expiration')
             ->findOne(
                 [
@@ -732,7 +732,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             )
         );
 
-        $actualView = \Tripod\Mongo\Config::getInstance()->getCollectionForView('tripod_php_testing', 'v_counts')->findOne(array('_id'=>array("r"=>'http://talisaspire.com/works/4d101f63c10a6',"c"=>"http://talisaspire.com/","type"=>'v_counts')));
+        $actualView = \Tripod\Config::getInstance()->getCollectionForView('tripod_php_testing', 'v_counts')->findOne(array('_id'=>array("r"=>'http://talisaspire.com/works/4d101f63c10a6',"c"=>"http://talisaspire.com/","type"=>'v_counts')));
         $this->assertEquals($expectedView['_id'], $actualView['_id']);
         $this->assertEquals($expectedView['value'], $actualView['value']);
         $this->assertInstanceOf('\MongoDB\BSON\UTCDateTime', $actualView['_cts']);
@@ -834,7 +834,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             ->with('tripod_php_testing', $this->anything(), $this->anything())
             ->will($this->returnValue($mockViewColl));
 
-        $mockConfig->loadConfig(\Tripod\Mongo\Config::getConfig());
+        $mockConfig->loadConfig(\Tripod\Config::getConfig());
 
         /* @var $mockTripodViews|PHPUnit_Framework_MockObject_MockObject Views */
         $mockTripodViews = $this->getMock(
@@ -901,7 +901,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             ->with('tripod_php_testing', $this->anything(), $this->anything())
             ->will($this->returnValue($mockViewColl));
 
-        $mockConfig->loadConfig(\Tripod\Mongo\Config::getConfig());
+        $mockConfig->loadConfig(\Tripod\Config::getConfig());
 
 
         /* @var $mockTripodViews \Tripod\Mongo\Composites\Views */
@@ -957,7 +957,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         $tripod = new \Tripod\Mongo\Driver('CBD_testing', 'tripod_php_testing', ['defaultContext' => $context]);
         $tripod->saveChanges(new \Tripod\ExtendedGraph(), $originalGraph);
 
-        $collections = \Tripod\Mongo\Config::getInstance()->getCollectionsForViews(
+        $collections = \Tripod\Config::getInstance()->getCollectionsForViews(
             'tripod_php_testing',
             ['v_resource_full', 'v_resource_full_ttl', 'v_resource_to_single_source']
         );
@@ -1013,7 +1013,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             ['generateViewsForResourcesOfType'],
             [
                 'tripod_php_testing',
-                \Tripod\Mongo\Config::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing'),
+                \Tripod\Config::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing'),
                 $context
             ]
         );
@@ -1117,7 +1117,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         $tripod = new \Tripod\Mongo\Driver('CBD_testing', 'tripod_php_testing', array('defaultContext'=>$context));
         $tripod->saveChanges(new \Tripod\ExtendedGraph(), $originalGraph);
 
-        $collections = \Tripod\Mongo\Config::getInstance()->getCollectionsForViews('tripod_php_testing', array('v_resource_full', 'v_resource_full_ttl', 'v_resource_to_single_source'));
+        $collections = \Tripod\Config::getInstance()->getCollectionsForViews('tripod_php_testing', array('v_resource_full', 'v_resource_full_ttl', 'v_resource_to_single_source'));
 
         foreach($collections as $collection)
         {
@@ -1172,7 +1172,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             array('generateView'),
             array(
                 'tripod_php_testing',
-                \Tripod\Mongo\Config::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing'),
+                \Tripod\Config::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing'),
                 $context
             )
         );
@@ -1300,7 +1300,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         $tripod = new \Tripod\Mongo\Driver('CBD_testing', 'tripod_php_testing', array('defaultContext'=>$context));
         $tripod->saveChanges(new \Tripod\ExtendedGraph(), $originalGraph);
 
-        $collections = \Tripod\Mongo\Config::getInstance()->getCollectionsForViews('tripod_php_testing', array('v_resource_full', 'v_resource_full_ttl', 'v_resource_to_single_source'));
+        $collections = \Tripod\Config::getInstance()->getCollectionsForViews('tripod_php_testing', array('v_resource_full', 'v_resource_full_ttl', 'v_resource_to_single_source'));
 
         foreach($collections as $collection)
         {
@@ -1353,7 +1353,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             array('generateView'),
             array(
                 'tripod_php_testing',
-                \Tripod\Mongo\Config::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing'),
+                \Tripod\Config::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing'),
                 $context
             )
         );
@@ -1482,7 +1482,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         $tripod = new \Tripod\Mongo\Driver('CBD_testing', 'tripod_php_testing', array('defaultContext'=>$context));
         $tripod->saveChanges(new \Tripod\ExtendedGraph(), $originalGraph);
 
-        $collections = \Tripod\Mongo\Config::getInstance()->getCollectionsForViews('tripod_php_testing', array('v_resource_full', 'v_resource_full_ttl', 'v_resource_to_single_source'));
+        $collections = \Tripod\Config::getInstance()->getCollectionsForViews('tripod_php_testing', array('v_resource_full', 'v_resource_full_ttl', 'v_resource_to_single_source'));
 
         foreach($collections as $collection)
         {
@@ -1535,7 +1535,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             array('generateView'),
             array(
                 'tripod_php_testing',
-                \Tripod\Mongo\Config::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing'),
+                \Tripod\Config::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing'),
                 $context
             )
         );
@@ -1707,7 +1707,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             array('generateViewsForResourcesOfType'),
             array(
                 'tripod_php_testing',
-                \Tripod\Mongo\Config::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing'),
+                \Tripod\Config::getInstance()->getCollectionForCBD('tripod_php_testing', 'CBD_testing'),
                 $context
             )
         );
@@ -1997,7 +1997,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             ->with('tripod_php_testing', $this->anything(), $this->anything())
             ->will($this->returnValue($mockViewColl));
 
-        $mockConfig->loadConfig(\Tripod\Mongo\Config::getConfig());
+        $mockConfig->loadConfig(\Tripod\Config::getConfig());
 
         /* @var $mockTripodViews|PHPUnit_Framework_MockObject_MockObject Views */
         $mockTripodViews = $this->getMock(
@@ -2058,7 +2058,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             ->with('tripod_php_testing', $this->anything(), $this->anything())
             ->will($this->returnValue($mockViewColl));
 
-        $mockConfig->loadConfig(\Tripod\Mongo\Config::getConfig());
+        $mockConfig->loadConfig(\Tripod\Config::getConfig());
 
         /* @var $mockTripodViews|PHPUnit_Framework_MockObject_MockObject Views */
         $mockTripodViews = $this->getMock(
@@ -2132,7 +2132,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
             ->with('tripod_php_testing', $this->anything(), $this->anything())
             ->will($this->returnValue($mockViewColl));
 
-        $mockConfig->loadConfig(\Tripod\Mongo\Config::getConfig());
+        $mockConfig->loadConfig(\Tripod\Config::getConfig());
 
         /* @var $mockTripodViews|PHPUnit_Framework_MockObject_MockObject Views */
         $mockTripodViews = $this->getMock(

--- a/test/unit/mongo/PerformJob.php
+++ b/test/unit/mongo/PerformJob.php
@@ -1,0 +1,13 @@
+<?php
+
+use Tripod\Mongo\Jobs\JobBase;
+
+trait PerformJob
+{
+    protected function performJob(JobBase $job)
+    {
+        $job->beforePerform();
+        $job->perform();
+        $job->afterPerform();
+    }
+}

--- a/test/unit/mongo/PerformJob.php
+++ b/test/unit/mongo/PerformJob.php
@@ -6,8 +6,17 @@ trait PerformJob
 {
     protected function performJob(JobBase $job)
     {
-        $job->beforePerform();
-        $job->perform();
-        $job->afterPerform();
+        $mockJob = $this->getMockBuilder('\Resque_Job')
+            ->setMethods(['getInstance', 'getArguments'])
+            ->setConstructorArgs(['test', get_class($job), $job->args])
+            ->getMock();
+        $mockJob->expects($this->atLeastOnce())
+            ->method('getInstance')
+            ->will($this->returnValue($job));
+        $mockJob->expects($this->any())
+            ->method('getArguments')
+            ->will($this->returnValue($job->args));
+        $mockJob->perform();
+
     }
 }

--- a/test/unit/mongo/ResqueJobTestBase.php
+++ b/test/unit/mongo/ResqueJobTestBase.php
@@ -2,7 +2,9 @@
 
 use Tripod\Mongo\Jobs\JobBase;
 
-trait PerformJob
+require_once 'MongoTripodTestBase.php';
+
+class ResqueJobTestBase extends MongoTripodTestBase
 {
     protected function performJob(JobBase $job)
     {

--- a/test/unit/mongo/TestConfigGenerator.php
+++ b/test/unit/mongo/TestConfigGenerator.php
@@ -1,0 +1,24 @@
+<?php
+
+class TestConfigGenerator extends \Tripod\Mongo\Config
+{
+    protected $fileName;
+
+    private function __construct()
+    {
+    }
+
+    public function serialize()
+    {
+        return ['class' => get_class($this), 'filename' => $this->fileName];
+    }
+
+    public static function deserialize(array $config)
+    {
+        $instance = new self();
+        $instance->fileName = $config['filename'];
+        $cfg = json_decode(file_get_contents($config['filename']), true);
+        $instance->loadConfig($cfg);
+        return $instance;
+    }
+}


### PR DESCRIPTION
This replaces the very verbose config array that is sent with *every* queued job with option to specify a Config generator, which can be deserialized in the job to create the config at job run time.