### PR TITLE
Batch generate composites

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ php:
 - 7.0
 - 5.6
 - 5.5
-- 5.4
 services:
 - redis
 - docker

--- a/composer.json
+++ b/composer.json
@@ -18,17 +18,17 @@
         }
     ],
     "require": {
-        "php" : ">=5.4",
+        "php" : ">=5.5",
         "semsol/arc2": "v2.2.4",
         "chrisboulton/php-resque": "dev-master#98fde571db008a8b48e73022599d1d1c07d4a7b5",
         "monolog/monolog" : "~1.13",
         "mongodb/mongodb": "1.0.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.1.*",
+        "phpunit/phpunit": "4.8.",
         "squizlabs/php_codesniffer": "3.2.*"
-    },    
+    },
     "autoload": {
         "classmap": ["src/"]
-    }    
+    }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
 mongo:
-  image: mongo/2.6.12:latest
+  image: rossfsinger/mongo-2.6.12:latest
   ports:
       - "27017:27017"

--- a/src/mongo/Config.class.php
+++ b/src/mongo/Config.class.php
@@ -276,8 +276,8 @@ class Config implements IConfigInstance
             }
             if (isset($storeConfig['batch_sizes'])) {
                 foreach ([OP_TABLES, OP_SEARCH, OP_VIEWS] as $op) {
-                    if (isset($searchConfig['batch_sizes'][$op]) && is_numeric($searchConfig['batch_sizes'][$op])) {
-                        $this->batchSize[$op] = intval($searchConfig['batch_sizes'][$op]);
+                    if (isset($storeConfig['batch_sizes'][$op]) && is_numeric($storeConfig['batch_sizes'][$op])) {
+                        $this->batchSize[$op] = intval($storeConfig['batch_sizes'][$op]);
                     }
                 }
             }

--- a/src/mongo/Driver.class.php
+++ b/src/mongo/Driver.class.php
@@ -61,7 +61,7 @@ class Driver extends DriverBase implements \Tripod\IDriver
      * <li>readPreference: The Read preference to set for Mongo: Default is ReadPreference::RP_PRIMARY_PREFERRED</li>
      * <li>retriesToGetLock: Retries to do when unable to get lock on a document, default is 20</li></ul>
      */
-    public function __construct($podName, $storeName, $opts=array())
+    public function __construct($podName, $storeName, $opts = [])
     {
 
         $opts = array_merge(array(

--- a/src/mongo/IConfigInstance.php
+++ b/src/mongo/IConfigInstance.php
@@ -282,6 +282,14 @@ interface IConfigInstance extends \Tripod\ITripodConfigSerializer
     public function getTransactionLogDatabase($readPreference = ReadPreference::RP_PRIMARY_PREFERRED);
 
     /**
+     * Return the maximum batch size for async operations
+     *
+     * @param string $operation Async operation, e.g. OP_TABLES, OP_VIEWS
+     * @return integer
+     */
+    public function getBatchSize($operation);
+
+    /**
      * @return string
      */
     public static function getDiscoverQueueName();

--- a/src/mongo/base/CompositeBase.class.php
+++ b/src/mongo/base/CompositeBase.class.php
@@ -12,70 +12,67 @@ abstract class CompositeBase extends \Tripod\Mongo\DriverBase implements \Tripod
      * @var \Tripod\Mongo\Jobs\ApplyOperation
      */
     protected $applyOperation;
+
+    protected $batchSize = 1;
+
     /**
      * Returns an array of ImpactedSubjects based on the subjects and predicates of change
      * @param array $subjectsAndPredicatesOfChange
      * @param string $contextAlias
      * @return \Tripod\Mongo\ImpactedSubject[]
      */
-    public function getImpactedSubjects(Array $subjectsAndPredicatesOfChange,$contextAlias)
+    public function getImpactedSubjects(array $subjectsAndPredicatesOfChange, $contextAlias)
     {
-        $candidates = array();
-        $filter = array();
-        $subjectsToAlias = array();
-        foreach(array_keys($subjectsAndPredicatesOfChange) as $s){
+        $candidates = [];
+        $filter = [];
+        $subjectsToAlias = [];
+        foreach (array_keys($subjectsAndPredicatesOfChange) as $s) {
             $resourceAlias = $this->labeller->uri_to_alias($s);
             $subjectsToAlias[$s] = $resourceAlias;
             // build $filter for queries to impact index
-            $filter[] = array(_ID_RESOURCE=>$resourceAlias,_ID_CONTEXT=>$contextAlias);
+            $filter[] = [_ID_RESOURCE=>$resourceAlias,_ID_CONTEXT=>$contextAlias];
         }
-        $query = array(_ID_KEY=>array('$in'=>$filter));
-        $docs = $this->getCollection()->find($query, array(
-            'projection' => array(_ID_KEY=>true, 'rdf:type'=>true)
-        ));
+        $query = [_ID_KEY=> ['$in' => $filter]];
+        $docs = $this->getCollection()->find(
+            $query,
+            ['projection' => [_ID_KEY => true, 'rdf:type' => true]]
+        );
 
         $types = $this->getTypesInSpecifications();
 
-        if($this->getCollection()->count($query) !== 0 ) {
-            foreach($docs as $doc)
-            {
+        if ($this->getCollection()->count($query) !== 0) {
+            foreach ($docs as $doc) {
                 $docResource = $doc[_ID_KEY][_ID_RESOURCE];
                 $docContext  = $doc[_ID_KEY][_ID_CONTEXT];
                 $docHash     = md5($docResource.$docContext);
 
-                $docTypes = array();
-                if(isset($doc["rdf:type"])) {
-                    if(isset($doc["rdf:type"][VALUE_URI])){
-                        $docTypes[] = $doc["rdf:type"][VALUE_URI];
+                $docTypes = [];
+                if (isset($doc['rdf:type'])) {
+                    if (isset($doc['rdf:type'][VALUE_URI])) {
+                        $docTypes[] = $doc['rdf:type'][VALUE_URI];
                     } else {
-                        foreach($doc["rdf:type"] as $t){
-                            if(isset($t[VALUE_URI]))
-                            {
+                        foreach ($doc['rdf:type'] as $t) {
+                            if (isset($t[VALUE_URI])) {
                                 $docTypes[] = $t[VALUE_URI];
                             }
                         }
                     }
                 }
 
-                $currentSubjectProperties = array();
-                if(isset($subjectsAndPredicatesOfChange[$docResource]))
-                {
+                $currentSubjectProperties = [];
+                if (isset($subjectsAndPredicatesOfChange[$docResource])) {
                     $currentSubjectProperties = $subjectsAndPredicatesOfChange[$docResource];
-                }
-                elseif(isset($subjectsToAlias[$docResource]) &&
-                    isset($subjectsAndPredicatesOfChange[$subjectsToAlias[$docResource]]))
-                {
+                } elseif (isset($subjectsToAlias[$docResource]) &&
+                    isset($subjectsAndPredicatesOfChange[$subjectsToAlias[$docResource]])) {
                     $currentSubjectProperties = $subjectsAndPredicatesOfChange[$subjectsToAlias[$docResource]];
                 }
-                foreach($docTypes as $type)
-                {
-                    if($this->checkIfTypeShouldTriggerOperation($type, $types, $currentSubjectProperties)) {
-                        if(!array_key_exists($this->getPodName(), $candidates))
-                        {
-                            $candidates[$this->getPodName()] = array();
+                foreach ($docTypes as $type) {
+                    if ($this->checkIfTypeShouldTriggerOperation($type, $types, $currentSubjectProperties)) {
+                        if (!array_key_exists($this->getPodName(), $candidates)) {
+                            $candidates[$this->getPodName()] = [];
                         }
-                        if(!array_key_exists($docHash, $candidates[$this->getPodName()])){
-                            $candidates[$this->getPodName()][$docHash] = array('id'=>$doc[_ID_KEY]);
+                        if (!array_key_exists($docHash, $candidates[$this->getPodName()])) {
+                            $candidates[$this->getPodName()][$docHash] = ['id'=>$doc[_ID_KEY]];
                         }
                     }
                 }
@@ -83,40 +80,37 @@ abstract class CompositeBase extends \Tripod\Mongo\DriverBase implements \Tripod
         }
 
         // add to this any composites
-        foreach($this->findImpactedComposites($subjectsAndPredicatesOfChange, $contextAlias) as $doc) {
+        foreach ($this->findImpactedComposites($subjectsAndPredicatesOfChange, $contextAlias) as $doc) {
             $spec = $this->getSpecification($this->storeName, $doc[_ID_KEY]['type']);
-            if(is_array($spec) && array_key_exists('from', $spec)){
-                if(!array_key_exists($spec['from'], $candidates))
-                {
-                    $candidates[$spec['from']] = array();
+            if (is_array($spec) && array_key_exists('from', $spec)) {
+                if (!array_key_exists($spec['from'], $candidates)) {
+                    $candidates[$spec['from']] = [];
                 }
                 $docHash = md5($doc[_ID_KEY][_ID_RESOURCE] . $doc[_ID_KEY][_ID_CONTEXT]);
 
-                if(!array_key_exists($docHash, $candidates[$spec['from']])){
-                    $candidates[$spec['from']][$docHash] = array(
-                        'id'=>array(
+                if (!array_key_exists($docHash, $candidates[$spec['from']])) {
+                    $candidates[$spec['from']][$docHash] = [
+                        'id' => [
                             _ID_RESOURCE=>$doc[_ID_KEY][_ID_RESOURCE],
                             _ID_CONTEXT=>$doc[_ID_KEY][_ID_CONTEXT],
-                        )
-                    );
+                        ]
+                    ];
                 }
-                if(!array_key_exists('specTypes', $candidates[$spec['from']][$docHash])) {
-                    $candidates[$spec['from']][$docHash]['specTypes'] = array();
+                if (!array_key_exists('specTypes', $candidates[$spec['from']][$docHash])) {
+                    $candidates[$spec['from']][$docHash]['specTypes'] = [];
                 }
                 // Save the specification type so we only have to regen resources in that table type
-                if(!in_array($doc[_ID_KEY][_ID_TYPE], $candidates[$spec['from']][$docHash]['specTypes']))
-                {
+                if (!in_array($doc[_ID_KEY][_ID_TYPE], $candidates[$spec['from']][$docHash]['specTypes'])) {
                     $candidates[$spec['from']][$docHash]['specTypes'][] = $doc[_ID_KEY][_ID_TYPE];
                 }
             }
         }
 
         // convert operations to subjects
-        $impactedSubjects = array();
-        foreach(array_keys($candidates) as $podName){
-            foreach($candidates[$podName] as $candidate)
-            {
-                $specTypes = (isset($candidate['specTypes']) ? $candidate['specTypes'] : array());
+        $impactedSubjects = [];
+        foreach (array_keys($candidates) as $podName) {
+            foreach ($candidates[$podName] as $candidate) {
+                $specTypes = (isset($candidate['specTypes']) ? $candidate['specTypes'] : []);
                 $impactedSubjects[] = new \Tripod\Mongo\ImpactedSubject($candidate['id'], $this->getOperationType(), $this->getStoreName(), $podName, $specTypes);
             }
         }
@@ -128,14 +122,14 @@ abstract class CompositeBase extends \Tripod\Mongo\DriverBase implements \Tripod
      * Returns an array of the rdf types that will trigger the specification
      * @return array
      */
-    public abstract function getTypesInSpecifications();
+    abstract public function getTypesInSpecifications();
 
     /**
      * @param array $resourcesAndPredicates
      * @param string $contextAlias
      * @return mixed // @todo: This may eventually return a either a Cursor or array
      */
-    public abstract function findImpactedComposites(Array $resourcesAndPredicates,$contextAlias);
+    abstract public function findImpactedComposites(array $resourcesAndPredicates, $contextAlias);
 
     /**
      * Returns the specification config
@@ -143,7 +137,7 @@ abstract class CompositeBase extends \Tripod\Mongo\DriverBase implements \Tripod
      * @param string $specId The specification id
      * @return array|null
      */
-    public abstract function getSpecification($storeName, $specId);
+    abstract public function getSpecification($storeName, $specId);
 
     /**
      * Test if the a particular type appears in the array of types associated with a particular spec and that the changeset
@@ -153,20 +147,20 @@ abstract class CompositeBase extends \Tripod\Mongo\DriverBase implements \Tripod
      * @param array $subjectPredicates
      * @return bool
      */
-    protected function checkIfTypeShouldTriggerOperation($rdfType, array $validTypes, Array $subjectPredicates)
+    protected function checkIfTypeShouldTriggerOperation($rdfType, array $validTypes, array $subjectPredicates)
     {
         // We don't know if this is an alias or a fqURI, nor what is in the valid types, necessarily
-        $types = array($rdfType);
-        try
-        {
+        $types = [$rdfType];
+        try {
             $types[] = $this->labeller->qname_to_uri($rdfType);
+        } catch (\Tripod\Exceptions\LabellerException $e) {
+            // Not a qname, apparently
         }
-        catch(\Tripod\Exceptions\LabellerException $e) {}
-        try
-        {
+        try {
             $types[] = $this->labeller->uri_to_alias($rdfType);
+        } catch (\Tripod\Exceptions\LabellerException $e) {
+            // Not a declared uri, apparently
         }
-        catch(\Tripod\Exceptions\LabellerException $e) {}
 
         $intersectingTypes = array_unique(array_intersect($types, $validTypes));
         // If views have a matching type *at all*, the operation is triggered
@@ -175,15 +169,27 @@ abstract class CompositeBase extends \Tripod\Mongo\DriverBase implements \Tripod
 
     /**
      * For mocking
-     * 
+     *
      * @return \Tripod\Mongo\Jobs\ApplyOperation
      */
     protected function getApplyOperation()
     {
-        if(!isset($this->applyOperation))
-        {
+        if (!isset($this->applyOperation)) {
             $this->applyOperation = new \Tripod\Mongo\Jobs\ApplyOperation();
         }
         return $this->applyOperation;
+    }
+
+    /**
+     * Queues a batch of ImpactedSubjects in a single ApplyOperation job
+     *
+     * @param \Tripod\Mongo\ImpactedSubject[] $subjects   Array of ImpactedSubjects
+     * @param string                          $queueName  Queue name
+     * @param array                           $jobOptions Job options
+     * @return void
+     */
+    protected function queueApplyJob(array $subjects, $queueName, array $jobOptions)
+    {
+        $this->getApplyOperation()->createJob($subjects, $queueName, $jobOptions);
     }
 }

--- a/src/mongo/base/CompositeBase.class.php
+++ b/src/mongo/base/CompositeBase.class.php
@@ -32,9 +32,9 @@ abstract class CompositeBase extends \Tripod\Mongo\DriverBase implements \Tripod
             $resourceAlias = $this->labeller->uri_to_alias($s);
             $subjectsToAlias[$s] = $resourceAlias;
             // build $filter for queries to impact index
-            $filter[] = [_ID_RESOURCE=>$resourceAlias,_ID_CONTEXT=>$contextAlias];
+            $filter[] = [_ID_RESOURCE=>$resourceAlias, _ID_CONTEXT=>$contextAlias];
         }
-        $query = [_ID_KEY=> ['$in' => $filter]];
+        $query = [_ID_KEY => ['$in' => $filter]];
         $docs = $this->getCollection()->find(
             $query,
             ['projection' => [_ID_KEY => true, 'rdf:type' => true]]

--- a/src/mongo/base/CompositeBase.class.php
+++ b/src/mongo/base/CompositeBase.class.php
@@ -2,6 +2,8 @@
 
 namespace Tripod\Mongo\Composites;
 
+use \Tripod\Mongo\JobGroup;
+
 /**
  * Class CompositeBase
  * @package Tripod\Mongo\Composites
@@ -191,5 +193,16 @@ abstract class CompositeBase extends \Tripod\Mongo\DriverBase implements \Tripod
     protected function queueApplyJob(array $subjects, $queueName, array $jobOptions)
     {
         $this->getApplyOperation()->createJob($subjects, $queueName, $jobOptions);
+    }
+
+    /**
+     * For mocking
+     *
+     * @param string $storeName
+     * @return JobGroup
+     */
+    protected function getJobGroup($storeName)
+    {
+        return new JobGroup($storeName);
     }
 }

--- a/src/mongo/base/CompositeBase.class.php
+++ b/src/mongo/base/CompositeBase.class.php
@@ -15,8 +15,6 @@ abstract class CompositeBase extends \Tripod\Mongo\DriverBase implements \Tripod
      */
     protected $applyOperation;
 
-    protected $batchSize = 1;
-
     /**
      * Returns an array of ImpactedSubjects based on the subjects and predicates of change
      * @param array $subjectsAndPredicatesOfChange

--- a/src/mongo/delegates/SearchIndexer.class.php
+++ b/src/mongo/delegates/SearchIndexer.class.php
@@ -10,7 +10,6 @@ require_once TRIPOD_DIR . 'exceptions/SearchException.class.php';
 use Tripod\Mongo\ImpactedSubject;
 use Tripod\Mongo\Labeller;
 use Tripod\Mongo\Jobs\ApplyOperation;
-use Tripod\Mongo\JobGroup;
 use \MongoDB\Driver\ReadPreference;
 use \MongoDB\Collection;
 use Tripod\Mongo\Config;
@@ -225,6 +224,7 @@ class SearchIndexer extends CompositeBase
                 );
 
                 $subjects[] = $subject;
+                // Queue ApplyOperations jobs in batches rather than individually
                 if (count($subjects) >= $this->getConfigInstance()->getBatchSize(OP_SEARCH)) {
                     $this->queueApplyJob($subjects, $queueName, $jobOptions);
                     $subjects = [];
@@ -314,11 +314,12 @@ class SearchIndexer extends CompositeBase
     /**
      * For mocking
      *
-     * @param Driver $tripod Mongo Tripod Driver
-     * @param Config $config Mongo Tripod ConfigInstance
+     * @param Driver                        $tripod Mongo Tripod Driver
+     * @param \Tripod\Mongo\IConfigInstance $config Mongo Tripod ConfigInstance
      * @return void
+     * @throws \Tripod\Exceptions\SearchException If provider class cannot be found
      */
-    protected function setSearchProvider(Driver $tripod, Config $config = null)
+    protected function setSearchProvider(Driver $tripod, \Tripod\Mongo\IConfigInstance $config = null)
     {
         if (is_null($config)) {
             $config = $this->getConfigInstance();

--- a/src/mongo/delegates/Tables.class.php
+++ b/src/mongo/delegates/Tables.class.php
@@ -64,7 +64,7 @@ class Tables extends CompositeBase
     /**
      * @var array
      */
-    protected $temporaryFields = array();
+    protected $temporaryFields = [];
 
     /**
      * Construct accepts actual objects rather than strings as this class is a delegate of
@@ -104,7 +104,7 @@ class Tables extends CompositeBase
         $resourceUri    = $resource[_ID_RESOURCE];
         $context        = $resource[_ID_CONTEXT];
 
-        $this->generateTableRowsForResource($resourceUri,$context,$subject->getSpecTypes());
+        $this->generateTableRowsForResource($resourceUri, $context, $subject->getSpecTypes());
     }
 
     /**
@@ -126,7 +126,7 @@ class Tables extends CompositeBase
     {
         $contextAlias = $this->getContextAlias($contextAlias); // belt and braces
 
-        $tablePredicates = array();
+        $tablePredicates = [];
 
         foreach ($this->getConfigInstance()->getTableSpecifications($this->storeName) as $tableSpec) {
             if (isset($tableSpec[_ID_KEY])) {
@@ -136,8 +136,8 @@ class Tables extends CompositeBase
         }
 
         // build a filter - will be used for impactIndex detection and finding direct tables to re-gen
-        $tableFilters = array();
-        $resourceFilters = array();
+        $tableFilters = [];
+        $resourceFilters = [];
         foreach ($resourcesAndPredicates as $resource => $resourcePredicates) {
             $resourceAlias = $this->labeller->uri_to_alias($resource);
             $id = array(_ID_RESOURCE=>$resourceAlias,_ID_CONTEXT=>$contextAlias);
@@ -149,11 +149,9 @@ class Tables extends CompositeBase
             } else {
                 foreach ($tablePredicates as $tableType => $predicates) {
                     // Only look for table rows if the changed predicates are actually defined in the tablespec
-                    if(array_intersect($resourcePredicates, $predicates))
-                    {
-                        if(!isset($tableFilters[$tableType]))
-                        {
-                            $tableFilters[$tableType] = array();
+                    if (array_intersect($resourcePredicates, $predicates)) {
+                        if (!isset($tableFilters[$tableType])) {
+                            $tableFilters[$tableType] = [];
                         }
                         // build $filter for queries to impact index
                         $tableFilters[$tableType][] = $id;
@@ -163,15 +161,11 @@ class Tables extends CompositeBase
 
         }
 
-        if(empty($tableFilters) && !empty($resourceFilters))
-        {
+        if (empty($tableFilters) && !empty($resourceFilters)) {
             $query = array("value."._IMPACT_INDEX=>array('$in'=>$resourceFilters));
-        }
-        else
-        {
-            $query = array();
-            foreach($tableFilters as $tableType=>$filters)
-            {
+        } else {
+            $query = [];
+            foreach ($tableFilters as $tableType => $filters) {
                 // first re-gen table rows where resources appear in the impact index
                 $query[] = array("value."._IMPACT_INDEX=>array('$in'=>$filters), '_id.'._ID_TYPE=>$tableType);
             }
@@ -193,10 +187,10 @@ class Tables extends CompositeBase
 
         if(empty($query))
         {
-            return array();
+            return [];
         }
 
-        $affectedTableRows = array();
+        $affectedTableRows = [];
 
         foreach($this->config->getCollectionsForTables($this->storeName) as $collection)
         {
@@ -242,7 +236,7 @@ class Tables extends CompositeBase
      * @param int $limit
      * @return array
      */
-    public function getTableRows($tableSpecId,$filter=array(),$sortBy=array(),$offset=0,$limit=10)
+    public function getTableRows($tableSpecId,$filter=[],$sortBy=[],$offset=0,$limit=10)
     {
         $t = new \Tripod\Timer();
         $t->start();
@@ -251,7 +245,7 @@ class Tables extends CompositeBase
 
         $collection = $this->config->getCollectionForTable($this->storeName, $tableSpecId, $this->readPreference);
 
-        $findOptions = array();
+        $findOptions = [];
         if (!empty($limit)) {
            $findOptions['skip'] = (int) $offset;
            $findOptions['limit'] = (int) $limit;
@@ -261,7 +255,7 @@ class Tables extends CompositeBase
         }
         $results = $collection->find($filter, $findOptions);
 
-        $rows = array();
+        $rows = [];
         foreach ($results as $doc)
         {
             if (array_key_exists(_IMPACT_INDEX,$doc['value'])) unset($doc['value'][_IMPACT_INDEX]); // remove impact index from client
@@ -289,7 +283,7 @@ class Tables extends CompositeBase
      * @param array $filter
      * @return array
      */
-    public function distinct($tableSpecId, $fieldName, array $filter=array())
+    public function distinct($tableSpecId, $fieldName, array $filter=[])
     {
         $t = new \Tripod\Timer();
         $t->start();
@@ -324,7 +318,7 @@ class Tables extends CompositeBase
         $resourceAlias = $this->labeller->uri_to_alias($resource);
         $contextAlias = $this->getContextAlias($context);
         $query = array(_ID_KEY . '.' . _ID_RESOURCE => $resourceAlias,  _ID_KEY . '.' . _ID_CONTEXT => $contextAlias);
-        $specNames = array();
+        $specNames = [];
         $specTypes = $this->config->getTableSpecifications($this->storeName);
         if (empty($specType)) {
             $specNames = array_keys($specTypes);
@@ -395,14 +389,14 @@ class Tables extends CompositeBase
      * @param string|null $context
      * @param array $specTypes
      */
-    protected function generateTableRowsForResource($resource, $context=null, $specTypes=array())
+    protected function generateTableRowsForResource($resource, $context=null, $specTypes=[])
     {
         $resourceAlias = $this->labeller->uri_to_alias($resource);
         $contextAlias = $this->getContextAlias($context);
 
         $this->deleteTableRowsForResource($resource, $context, $specTypes);
 
-        $filter = array();
+        $filter = [];
         $filter[] = array("r"=>$resourceAlias,"c"=>$contextAlias);
 
         // now go through the types
@@ -444,7 +438,7 @@ class Tables extends CompositeBase
      * @param array $specTypes
      * @return mixed
      */
-    public function generateTableRowsForType($rdfType,$subject=null,$context=null, $specTypes = array())
+    public function generateTableRowsForType($rdfType,$subject=null,$context=null, $specTypes = [])
     {
         $rdfType = $this->labeller->qname_to_alias($rdfType);
         $rdfTypeAlias = $this->labeller->uri_to_alias($rdfType);
@@ -456,7 +450,7 @@ class Tables extends CompositeBase
         }
         else
         {
-            $tableSpecs = array();
+            $tableSpecs = [];
             foreach($specTypes as $specType)
             {
                 $spec = $this->getConfigInstance()->getTableSpecification($this->storeName, $specType);
@@ -502,7 +496,7 @@ class Tables extends CompositeBase
     {
         $t = new \Tripod\Timer();
         $t->start();
-        $this->temporaryFields = array();
+        $this->temporaryFields = [];
         $tableSpec = $this->getConfigInstance()->getTableSpecification($this->storeName, $tableType);
         $collection = $this->config->getCollectionForTable($this->storeName, $tableType);
 
@@ -517,7 +511,7 @@ class Tables extends CompositeBase
         // default collection
         $from = (isset($tableSpec["from"])) ? $tableSpec["from"] : $this->podName;
 
-        $types = array();
+        $types = [];
         if (is_array($tableSpec["type"])) {
             foreach ($tableSpec["type"] as $type) {
                 $types[] = array("rdf:type.u"=>$this->labeller->qname_to_alias($type));
@@ -538,6 +532,7 @@ class Tables extends CompositeBase
         ));
 
         $jobOptions = [];
+        $subjects = [];
         if ($queueName && !$resource && ($this->stat || !empty($this->statsConfig))) {
             $jobOptions['statsConfig'] = $this->getStatsConfig();
             $jobGroup = new JobGroup($this->storeName);
@@ -554,8 +549,11 @@ class Tables extends CompositeBase
                     $from,
                     array($tableType)
                 );
-
-                $this->getApplyOperation()->createJob(array($subject), $queueName, $jobOptions);
+                $subjects[] = $subject;
+                if (count($subjects) >= $this->getConfigInstance()->getBatchSize(OP_TABLES)) {
+                    $this->queueApplyJob($subjects, $queueName, $jobOptions);
+                    $subjects = [];
+                }
             } else {
                 // set up ID
                 $generatedRow = [
@@ -569,12 +567,12 @@ class Tables extends CompositeBase
                 // everything must go in the value object todo: this is a hang over from map reduce days, engineer out once we have stability on new PHP method for M/R
                 $value = ['_id' => $doc['_id']];
                 $this->addIdToImpactIndex($doc['_id'], $value); // need to add the doc to the impact index to be consistent with views/search etc. this is needed for discovering impacted operations
-                $this->addFields($doc,$tableSpec,$value);
+                $this->addFields($doc, $tableSpec, $value);
                 if (isset($tableSpec['joins'])) {
-                    $this->doJoins($doc,$tableSpec['joins'],$value,$from,$contextAlias);
+                    $this->doJoins($doc, $tableSpec['joins'], $value, $from, $contextAlias);
                 }
                 if (isset($tableSpec['counts'])) {
-                    $this->doCounts($doc,$tableSpec['counts'],$value);
+                    $this->doCounts($doc, $tableSpec['counts'], $value);
                 }
 
                 if (isset($tableSpec['computed_fields'])) {
@@ -588,13 +586,17 @@ class Tables extends CompositeBase
             }
         }
 
+        if (!empty($subjects)) {
+            $this->queueApplyJob($subjects, $queueName, $jobOptions);
+        }
+
         $t->stop();
         $this->timingLog(MONGO_CREATE_TABLE, array(
             'type'=>$tableSpec['type'],
             'duration'=>$t->result(),
             'filter'=>$filter,
             'from'=>$from));
-        $this->getStat()->timer(MONGO_CREATE_TABLE.".$tableType",$t->result());
+        $this->getStat()->timer(MONGO_CREATE_TABLE.".$tableType", $t->result());
 
         $stat = ['count' => $count];
         if (isset($jobOptions[ApplyOperation::TRACKING_KEY])) {
@@ -641,7 +643,7 @@ class Tables extends CompositeBase
     protected function truncateFields(Collection $collection, array &$generatedRow)
     {
         // Find the name of any indexed fields
-        $indexedFields = array();
+        $indexedFields = [];
         $indexesGroupedByCollection = $this->config->getIndexesGroupedByCollection($this->storeName);
         if (isset($indexesGroupedByCollection) && isset($indexesGroupedByCollection[$collection->getCollectionName()]))
         {
@@ -911,7 +913,7 @@ class Tables extends CompositeBase
                 $function = array_keys($value);
                 return $this->getComputedValue($function[0], $value, $dest);
             }
-            $aryValue = array();
+            $aryValue = [];
             foreach($value as $v)
             {
                 $aryValue[] = $this->rewriteVariableValue($v, $dest);
@@ -1129,7 +1131,7 @@ class Tables extends CompositeBase
      */
     protected function generateValues($source, $f, $predicate, &$dest)
     {
-        $values = array();
+        $values = [];
         if (isset($source[$predicate][VALUE_URI]) && !empty($source[$predicate][VALUE_URI]))
         {
             $values[] = $source[$predicate][VALUE_URI];
@@ -1175,7 +1177,7 @@ class Tables extends CompositeBase
             {
                 // convert from single value to array of values
                 $existingVal = $dest[$f['fieldName']];
-                $dest[$f['fieldName']] = array();
+                $dest[$f['fieldName']] = [];
                 $dest[$f['fieldName']][] = $existingVal;
                 $dest[$f['fieldName']][] = $v;
             }
@@ -1190,7 +1192,7 @@ class Tables extends CompositeBase
      */
     protected function getPredicateFunctions($array)
     {
-        $predicateFunctions = array();
+        $predicateFunctions = [];
         if(is_array($array))
         {
             if(isset($array['predicates']))
@@ -1217,7 +1219,7 @@ class Tables extends CompositeBase
      * @throws \Exception
      * @return mixed
      */
-    private function applyModifier($modifier, $value, $options = array())
+    private function applyModifier($modifier, $value, $options = [])
     {
         try
         {
@@ -1271,7 +1273,7 @@ class Tables extends CompositeBase
                 // to join on it. However, we need to think about different combinations of
                 // nested joins in different points of the view spec and see if this would
                 // complicate things. Needs a unit test or two.
-                $joinUris = array();
+                $joinUris = [];
                 if (isset($source[$predicate][VALUE_URI]))
                 {
                     // single value for join
@@ -1291,7 +1293,7 @@ class Tables extends CompositeBase
                     }
                 }
 
-                $recursiveJoins = array();
+                $recursiveJoins = [];
                 $collection = (isset($ruleset['from'])
                     ? $this->config->getCollectionForCBD($this->storeName, $ruleset['from'])
                     : $this->config->getCollectionForCBD($this->storeName, $from)

--- a/src/mongo/delegates/Tables.class.php
+++ b/src/mongo/delegates/Tables.class.php
@@ -7,7 +7,6 @@ require_once TRIPOD_DIR . 'mongo/MongoTripodConstants.php';
 use \Tripod\Mongo\Jobs\ApplyOperation;
 use \Tripod\Mongo\ImpactedSubject;
 use \Tripod\Mongo\Labeller;
-use \Tripod\Mongo\JobGroup;
 use \MongoDB\Driver\ReadPreference;
 use \MongoDB\Collection;
 

--- a/src/mongo/delegates/Views.class.php
+++ b/src/mongo/delegates/Views.class.php
@@ -7,7 +7,6 @@ use \Tripod\Mongo\ImpactedSubject;
 use \Tripod\Mongo\Labeller;
 use \MongoDB\Driver\ReadPreference;
 use \MongoDB\Collection;
-use Tripod\Mongo\JobGroup;
 
 /**
  * Class Views

--- a/src/mongo/delegates/Views.class.php
+++ b/src/mongo/delegates/Views.class.php
@@ -431,7 +431,7 @@ class Views extends CompositeBase
         $t->start();
 
         $from = $this->getFromCollectionForViewSpec($viewSpec);
-        $collection = $this->config->getCollectionForView($this->storeName, $viewId);
+        $collection = $this->getConfigInstance()->getCollectionForView($this->storeName, $viewId);
 
         if (!isset($viewSpec['joins'])) {
             throw new \Tripod\Exceptions\ViewException('Could not find any joins in view specification - usecase better served with select()');
@@ -454,8 +454,8 @@ class Views extends CompositeBase
         }
 
         // @todo Change this to a command when we upgrade MongoDB to 1.1+
-        $count = $this->config->getCollectionForCBD($this->storeName, $from)->count($filter);
-        $docs = $this->config->getCollectionForCBD($this->storeName, $from)->find($filter, array(
+        $count = $this->getConfigInstance()->getCollectionForCBD($this->storeName, $from)->count($filter);
+        $docs = $this->getConfigInstance()->getCollectionForCBD($this->storeName, $from)->find($filter, array(
             'maxTimeMS' => $this->getConfigInstance()->getMongoCursorTimeout()
         ));
 
@@ -465,7 +465,7 @@ class Views extends CompositeBase
         $subjects = [];
         if ($queueName && !$resource) {
             $jobOptions['statsConfig'] = $this->getStatsConfig();
-            $jobGroup = new JobGroup($this->storeName);
+            $jobGroup = $this->getJobGroup($this->storeName);
             $jobOptions[ApplyOperation::TRACKING_KEY] = $jobGroup->getId()->__toString();
             $jobGroup->setJobCount($count);
         }

--- a/test/unit/mongo/MongoTripodSearchIndexerTest.php
+++ b/test/unit/mongo/MongoTripodSearchIndexerTest.php
@@ -13,8 +13,7 @@ class MongoTripodSearchIndexerTest extends MongoTripodTestBase {
         parent::setUp();
 
         $this->tripod = new \Tripod\Mongo\Driver("CBD_testing", "tripod_php_testing", array("async"=>array(OP_VIEWS=>true, OP_TABLES=>true, OP_SEARCH=>false)));
-        foreach(\Tripod\Config::getInstance()->getCollectionsForSearch($this->tripod->getStoreName()) as $collection)
-        {
+        foreach (\Tripod\Config::getInstance()->getCollectionsForSearch($this->tripod->getStoreName()) as $collection) {
             $collection->drop();
         }
         $this->loadResourceDataViaTripod();
@@ -511,7 +510,7 @@ class MongoTripodSearchIndexerTest extends MongoTripodTestBase {
         }
 
         $fakeCursor = new ArrayIterator($docs);
-        /** @var \PHPUnit_Framework_MockObject_MockObject|TripodTestConfig $config */
+        /** @var \PHPUnit_Framework_MockObject_MockObject|TripodTestConfig $configInstance */
         $configInstance = $this->getMockBuilder('TripodTestConfig')
             ->setMethods(['getCollectionForCBD'])
             ->disableOriginalConstructor()

--- a/test/unit/mongo/MongoTripodSearchIndexerTest.php
+++ b/test/unit/mongo/MongoTripodSearchIndexerTest.php
@@ -499,4 +499,85 @@ class MongoTripodSearchIndexerTest extends MongoTripodTestBase {
         $this->assertEquals($expectedImpactedSubjects, $impactedSubjects);
     }
 
+    public function testBatchSearchDocumentsGeneration()
+    {
+        $count = 234;
+        $docs = [];
+
+        $configOptions = json_decode(file_get_contents(__DIR__ . '/data/config.json'), true);
+
+        for ($i = 0; $i < $count; $i++) {
+            $docs[] = ['_id' => ['r' => 'tenantLists:batch' . $i, 'c' => 'tenantContexts:DefaultGraph']];
+        }
+
+        $fakeCursor = new ArrayIterator($docs);
+        /** @var \PHPUnit_Framework_MockObject_MockObject|TripodTestConfig $config */
+        $configInstance = $this->getMockBuilder('TripodTestConfig')
+            ->setMethods(['getCollectionForCBD'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $configInstance->loadConfig($configOptions);
+
+        /** @var \PHPUnit_Framework_MockObject_MockObject|\MongoDB\Collection $collection */
+        $collection = $this->getMockBuilder('\MongoDB\Collection')
+            ->setMethods(['count', 'find'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $collection->expects($this->atLeastOnce())->method('count')->willReturn($count);
+        $collection->expects($this->atLeastOnce())->method('find')->willReturn($fakeCursor);
+
+        /** @var \PHPUnit_Framework_MockObject_MockObject|\Tripod\Mongo\JobGroup $jobGroup */
+        $jobGroup = $this->getMockBuilder('\Tripod\Mongo\JobGroup')
+            ->setMethods(['setJobCount'])
+            ->setConstructorArgs(['tripod_php_testing'])
+            ->getMock();
+        $jobGroup->expects($this->once())->method('setJobCount')->with($count);
+
+        $configInstance->expects($this->atLeastOnce())->method('getCollectionForCBD')->willReturn($collection);
+        /** @var \PHPUnit_Framework_MockObject_MockObject|\Tripod\Mongo\Driver $tripod */
+        $tripod = $this->getMockBuilder('\Tripod\Mongo\Driver')
+            ->setMethods(['getConfigInstance',])
+            ->setConstructorArgs(['tripod_php_testing', 'CBD_testing'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        /** @var \PHPUnit_Framework_MockObject_MockObject|\Tripod\Mongo\Composites\SearchIndexer $search */
+        $search = $this->getMockBuilder('\Tripod\Mongo\Composites\SearchIndexer')
+            ->setMethods(['setSearchProvider', 'getConfigInstance', 'queueApplyJob', 'getJobGroup'])
+            ->setConstructorArgs([$tripod])
+            ->getMock();
+        $search->expects($this->atLeastOnce())->method('getConfigInstance')->willReturn($configInstance);
+        $search->expects($this->once())->method('getJobGroup')->willReturn($jobGroup);
+        $search->expects($this->exactly(3))->method('queueApplyJob')
+            ->withConsecutive(
+                [
+                    $this->logicalAnd(
+                        $this->isType('array'),
+                        $this->containsOnlyInstancesOf('\Tripod\Mongo\ImpactedSubject'),
+                        $this->countOf(100)
+                    ),
+                    'TESTQUEUE',
+                    $this->isType('array')
+                ],
+                [
+                    $this->logicalAnd(
+                        $this->isType('array'),
+                        $this->containsOnlyInstancesOf('\Tripod\Mongo\ImpactedSubject'),
+                        $this->countOf(100)
+                    ),
+                    'TESTQUEUE',
+                    $this->isType('array')
+                ],
+                [
+                    $this->logicalAnd(
+                        $this->isType('array'),
+                        $this->containsOnlyInstancesOf('\Tripod\Mongo\ImpactedSubject'),
+                        $this->countOf(34)
+                    ),
+                    'TESTQUEUE',
+                    $this->isType('array')
+                ]
+            );
+        $search->generateSearchDocuments('i_search_list', null, null, 'TESTQUEUE');
+    }
 }

--- a/test/unit/mongo/MongoTripodTablesTest.php
+++ b/test/unit/mongo/MongoTripodTablesTest.php
@@ -328,7 +328,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
         }
 
         $fakeCursor = new ArrayIterator($docs);
-        /** @var \PHPUnit_Framework_MockObject_MockObject|TripodTestConfig $config */
+        /** @var \PHPUnit_Framework_MockObject_MockObject|TripodTestConfig $configInstance */
         $configInstance = $this->getMockBuilder('TripodTestConfig')
             ->setMethods(['getCollectionForTable', 'getCollectionForCBD'])
             ->disableOriginalConstructor()

--- a/test/unit/mongo/MongoTripodViewsTest.php
+++ b/test/unit/mongo/MongoTripodViewsTest.php
@@ -2289,7 +2289,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
         }
 
         $fakeCursor = new ArrayIterator($docs);
-        /** @var \PHPUnit_Framework_MockObject_MockObject|TripodTestConfig $config */
+        /** @var \PHPUnit_Framework_MockObject_MockObject|TripodTestConfig $configInstance */
         $configInstance = $this->getMockBuilder('TripodTestConfig')
             ->setMethods(['getCollectionForView', 'getCollectionForCBD'])
             ->disableOriginalConstructor()

--- a/test/unit/mongo/MongoTripodViewsTest.php
+++ b/test/unit/mongo/MongoTripodViewsTest.php
@@ -2276,4 +2276,135 @@ class MongoTripodViewsTest extends MongoTripodTestBase {
 
         $this->assertEquals(30, $views->deleteViewsByViewId('v_resource_full', $timestamp));
     }
+
+    public function testBatchViewGeneration()
+    {
+        $count = 234;
+        $docs = [];
+
+        $configOptions = json_decode(file_get_contents(__DIR__ . '/data/config.json'), true);
+
+        for ($i = 0; $i < $count; $i++) {
+            $docs[] = ['_id' => ['r' => 'tenantLists:batch' . $i, 'c' => 'tenantContexts:DefaultGraph']];
+        }
+
+        $fakeCursor = new ArrayIterator($docs);
+        /** @var \PHPUnit_Framework_MockObject_MockObject|TripodTestConfig $config */
+        $configInstance = $this->getMockBuilder('TripodTestConfig')
+            ->setMethods(['getCollectionForView', 'getCollectionForCBD'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $configInstance->loadConfig($configOptions);
+
+        /** @var \PHPUnit_Framework_MockObject_MockObject|\MongoDB\Collection $collection */
+        $collection = $this->getMockBuilder('\MongoDB\Collection')
+            ->setMethods(['count', 'find'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $collection->expects($this->atLeastOnce())->method('count')->willReturn($count);
+        $collection->expects($this->atLeastOnce())->method('find')->willReturn($fakeCursor);
+
+        $configInstance->expects($this->atLeastOnce())->method('getCollectionForCBD')->willReturn($collection);
+
+        /** @var \PHPUnit_Framework_MockObject_MockObject|\Tripod\Mongo\Composites\Views $views */
+        $views = $this->getMockBuilder('\Tripod\Mongo\Composites\Views')
+            ->setMethods(['getConfigInstance', 'queueApplyJob'])
+            ->setConstructorArgs(['tripod_php_testing', $collection, 'tenantContexts:DefaultGraph'])
+            ->getMock();
+        $views->expects($this->atLeastOnce())->method('getConfigInstance')->willReturn($configInstance);
+        $views->expects($this->exactly(10))->method('queueApplyJob')
+            ->withConsecutive(
+                [
+                    $this->logicalAnd(
+                        $this->isType('array'),
+                        $this->containsOnlyInstancesOf('\Tripod\Mongo\ImpactedSubject'),
+                        $this->countOf(25)
+                    ),
+                    'TESTQUEUE',
+                    $this->isType('array')
+                ],
+                [
+                    $this->logicalAnd(
+                        $this->isType('array'),
+                        $this->containsOnlyInstancesOf('\Tripod\Mongo\ImpactedSubject'),
+                        $this->countOf(25)
+                    ),
+                    'TESTQUEUE',
+                    $this->isType('array')
+                ],
+                [
+                    $this->logicalAnd(
+                        $this->isType('array'),
+                        $this->containsOnlyInstancesOf('\Tripod\Mongo\ImpactedSubject'),
+                        $this->countOf(25)
+                    ),
+                    'TESTQUEUE',
+                    $this->isType('array')
+                ],
+                [
+                    $this->logicalAnd(
+                        $this->isType('array'),
+                        $this->containsOnlyInstancesOf('\Tripod\Mongo\ImpactedSubject'),
+                        $this->countOf(25)
+                    ),
+                    'TESTQUEUE',
+                    $this->isType('array')
+                ],
+                [
+                    $this->logicalAnd(
+                        $this->isType('array'),
+                        $this->containsOnlyInstancesOf('\Tripod\Mongo\ImpactedSubject'),
+                        $this->countOf(25)
+                    ),
+                    'TESTQUEUE',
+                    $this->isType('array')
+                ],
+                [
+                    $this->logicalAnd(
+                        $this->isType('array'),
+                        $this->containsOnlyInstancesOf('\Tripod\Mongo\ImpactedSubject'),
+                        $this->countOf(25)
+                    ),
+                    'TESTQUEUE',
+                    $this->isType('array')
+                ],
+                [
+                    $this->logicalAnd(
+                        $this->isType('array'),
+                        $this->containsOnlyInstancesOf('\Tripod\Mongo\ImpactedSubject'),
+                        $this->countOf(25)
+                    ),
+                    'TESTQUEUE',
+                    $this->isType('array')
+                ],
+                [
+                    $this->logicalAnd(
+                        $this->isType('array'),
+                        $this->containsOnlyInstancesOf('\Tripod\Mongo\ImpactedSubject'),
+                        $this->countOf(25)
+                    ),
+                    'TESTQUEUE',
+                    $this->isType('array')
+                ],
+                [
+                    $this->logicalAnd(
+                        $this->isType('array'),
+                        $this->containsOnlyInstancesOf('\Tripod\Mongo\ImpactedSubject'),
+                        $this->countOf(25)
+                    ),
+                    'TESTQUEUE',
+                    $this->isType('array')
+                ],
+                [
+                    $this->logicalAnd(
+                        $this->isType('array'),
+                        $this->containsOnlyInstancesOf('\Tripod\Mongo\ImpactedSubject'),
+                        $this->countOf(9)
+                    ),
+                    'TESTQUEUE',
+                    $this->isType('array')
+                ]
+            );
+        $views->generateView('v_resource_full', null, null, 'TESTQUEUE');
+    }
 }


### PR DESCRIPTION
Presently, an individual job is queued for each document that needs composite generation.  This causes an unnecessary bottleneck by queuing up (potentially) many ApplyOperation Resque jobs to update one resource: Resque needs to contact Redis, then make a Mongo connection, do validation, etc. perform a very small update, then close the mongo connection, etc.

A much more efficient way to do this is to *batch* the ApplyOperation jobs with, e.g., 100 table row operations.  It's already designed to work this way, we just aren't utilizing it.