### PR TITLE
fsockopen UDP connections should be non-blocking

### DIFF
--- a/src/classes/StatsD.class.php
+++ b/src/classes/StatsD.class.php
@@ -104,6 +104,8 @@ class StatsD implements ITripodStat
             {
                 $fp = fsockopen("udp://{$this->host}", $this->port);
                 if (! $fp) { return; }
+                // make this a non blocking stream
+                stream_set_blocking($fp, false);
                 foreach ($sampledData as $stat => $value)
                 {
                     if (is_array($value))


### PR DESCRIPTION
We are using `fsockopen` to create a stream so we can, connect and write to our StatsD server via UDP:

```php
      if (!empty($this->host)) // if host is configured, send..
            {
                $fp = fsockopen("udp://{$this->host}", $this->port);
                if (! $fp) { return; }
                foreach ($sampledData as $stat => $value)
                {
                    if (is_array($value))
                    {
                        foreach ($value as $v)
                        {
                            fwrite($fp, "$stat:$v");
                        }
                    }
                    else
                    {
                        fwrite($fp, "$stat:$value");
                    }
                }
                fclose($fp);
            }
        }
``` 

From the PHP manual for fsockopen
```
The socket will by default be opened in blocking mode. You can switch it to non-blocking mode by using stream_set_blocking().
```

However, we are not telling PHP to make the stream non-blocking. As a consequence when this attempts to write to the StatsD server if the UDP buffer on the server is full, this call will block on the client and wait.

This P/R sets the stream to non blocking. This means that when it attempts to write, if the server is busy or the UDP buffer on the server is full this will no longer block and instead will return an error which we already ignore. 