### PR TITLE
Remove ref to getStoreStatPath

### DIFF
--- a/src/classes/StatsD.class.php
+++ b/src/classes/StatsD.class.php
@@ -251,7 +251,7 @@ class StatsD implements ITripodStat
      */
     protected function getStatsPaths()
     {
-        return(array_values(array_filter(array($this->getAggregateStatPath()))));
+        return array_values(array_filter([$this->getAggregateStatPath()]));
     }
 
     /**

--- a/src/classes/StatsD.class.php
+++ b/src/classes/StatsD.class.php
@@ -251,24 +251,7 @@ class StatsD implements ITripodStat
      */
     protected function getStatsPaths()
     {
-        return(array_values(array_filter(array($this->getStoreStatPath(), $this->getAggregateStatPath()))));
-    }
-
-    /**
-     * @return null|string
-     */
-    protected function getStoreStatPath()
-    {
-        $path = null;
-        if(isset($this->pivotValue))
-        {
-            if(!empty($this->prefix))
-            {
-                $path = $this->prefix . '.';
-            }
-            $path .= STAT_CLASS . '.' . STAT_PIVOT_FIELD . '.' . $this->pivotValue;
-        }
-        return $path;
+        return(array_values(array_filter(array($this->getAggregateStatPath()))));
     }
 
     /**

--- a/test/unit/mongo/MongoTripodDriverTest.php
+++ b/test/unit/mongo/MongoTripodDriverTest.php
@@ -2048,8 +2048,7 @@ class MongoTripodDriverTest extends MongoTripodTestBase
             ->method("send")
             ->with(
                 array(
-                    "myapp.tripod.MONGO_GET_ETAG"=>"1|c",
-                    "myapp.tripod.group_by_db.tripod_php_testing.MONGO_GET_ETAG"=>"1|c"
+                    "myapp.tripod.MONGO_GET_ETAG"=>"1|c"
                 )
             );
 

--- a/test/unit/mongo/MongoTripodStatTest.php
+++ b/test/unit/mongo/MongoTripodStatTest.php
@@ -76,7 +76,6 @@ class MongoTripodStatTest extends MongoTripodTestBase
             ->method('send')
             ->with(
                 array(
-                    STAT_CLASS.'.'.STAT_PIVOT_FIELD.'.wibble.FOO.BAR'=>'1|c',
                     STAT_CLASS.'.FOO.BAR'=>"1|c"
                 ),
                 1
@@ -112,7 +111,6 @@ class MongoTripodStatTest extends MongoTripodTestBase
             ->method('send')
             ->with(
                 array(
-                    'somePrefix.' . STAT_CLASS . '.' . STAT_PIVOT_FIELD . '.wibble.FOO.BAR'=>"5|c",
                     'somePrefix.' . STAT_CLASS.'.FOO.BAR'=>"5|c"
                 ),
                 1
@@ -147,7 +145,6 @@ class MongoTripodStatTest extends MongoTripodTestBase
             ->method('send')
             ->with(
                 array(
-                    STAT_CLASS . '.' . STAT_PIVOT_FIELD . '.wibble.FOO.BAR'=>array("1|c","1234|ms"),
                     STAT_CLASS . '.FOO.BAR'=>array("1|c","1234|ms")
                 ),
                 1
@@ -181,7 +178,6 @@ class MongoTripodStatTest extends MongoTripodTestBase
             ->method('send')
             ->with(
                 array(
-                    'somePrefix.' . STAT_CLASS . '.' . STAT_PIVOT_FIELD . '.wibble.FOO.BAR'=>array("1|c","4567|ms"),
                     'somePrefix.' . STAT_CLASS . '.FOO.BAR'=>array("1|c","4567|ms")
                 ),
                 1
@@ -216,7 +212,6 @@ class MongoTripodStatTest extends MongoTripodTestBase
             ->method('send')
             ->with(
                 array(
-                    STAT_CLASS. '.' . STAT_PIVOT_FIELD .'.wibble.FOO.BAR'=>"xyz|g",
                     STAT_CLASS.'.FOO.BAR'=>"xyz|g"
                 ),
                 1
@@ -251,7 +246,6 @@ class MongoTripodStatTest extends MongoTripodTestBase
             ->method('send')
             ->with(
                 array(
-                    'somePrefix.' . STAT_CLASS . '.' . STAT_PIVOT_FIELD . '.wibble.FOO.BAR'=>"abc|g",
                     'somePrefix.' . STAT_CLASS . '.FOO.BAR'=>"abc|g"
                 ),
                 1


### PR DESCRIPTION
If you have a statsd host configured, whenever there is a request to send stats, we work out which stats paths to send data to.

As well as stats about the current operation, in a pretty straight forward `myapp.tripod.MONGO_SOMETHING` we also send `myapp.tripod.group_by_db.db_name.MONGO_SOMETHING`.

There are known issues with statsd sending this data in a blocking fashion, rather than non-blocking, so having more data, that is verbose and as it turns out, really not that useful (we have been blacklisting these stats for years), makes the app run slower.

By reducing the amount of data, we reduce the [number of loops](https://github.com/talis/tripod-php/blob/master/src/classes/StatsD.class.php#L109) we do, which means that we block the operation for less. This means a more performant app.