### PR TITLE
Fix build by pinning to trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+dist: trusty
+addons:
+  apt:
+    packages:
+      ant
 language: php
 sudo: required
 php:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 ==========
 
 [![Build status](https://travis-ci.org/talis/tripod-php.svg)](https://travis-ci.org/talis/tripod-php)
-[![Dependency Status](https://dependencyci.com/github/talis/tripod-php/badge)](https://dependencyci.com/github/talis/tripod-php)
 
 Object Graph Mapper for managing [RDF](http://www.w3.org/TR/rdf-primer/) data stored in [MongoDB](http://www.mongodb.org/). See also [tripod-node](https://github.com/talis/tripod-node).
 


### PR DESCRIPTION
The travis builds of talis-php started failing with this error recently. 

See https://github.com/talis/talis-php/pull/16

> This PR installs ant to fix the 5.6 to 7.2 inclusive builds.
> The build image is pinned to trusty which is needed to be able to install PHP 5.5. (This may mean that ant is installed by default without specifying it explicitly, but we are using it, and when we do move to Xenial or later it might not be there. We're using it - lets be explicit. )

Resolves https://github.com/talis/platform/issues/4133