### PR TITLE
Change timingLog level from INFO to DEBUG

### DIFF
--- a/src/mongo/base/DriverBase.class.php
+++ b/src/mongo/base/DriverBase.class.php
@@ -281,7 +281,7 @@ abstract class DriverBase
     public function timingLog($type, $params=null)
     {
         $type = "[PID " . getmypid() ."] " . $type;
-        $this->log(\Psr\Log\LogLevel::INFO,$type,$params); // todo: timing log is a bit weird. Should it infact go in a different channel? Is it just debug?
+        $this->log(\Psr\Log\LogLevel::DEBUG,$type,$params);
     }
 
     /**


### PR DESCRIPTION
Upon trying to make TARL logging a bit more sane with a default log level of INFO, it was spotted that `tripod-php` was sending timing logs to INFO level, but also had a comment against the line querying whether this should be DEBUG.

Change the `timingLog` log level to DEBUG as these are absolutely not INFO level logs.