### PR TITLE
PLAT-6747 Bump Mongo to 3.2 in development and build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,12 @@
 version: 2.1
 parameters: &version
   version:
-    type: string    
+    type: string
     default: "php55"
 
 commands:
   install_composer_dependencies:
-    parameters: *version   
+    parameters: *version
     description: Install composer dependencies for << parameters.version >>
     steps:
       - run: docker-compose run << parameters.version >> composer install
@@ -14,7 +14,7 @@ commands:
     parameters: *version
     description: Run unit tests for << parameters.version >>
     steps:
-      - run: docker-compose run << parameters.version >> ./vendor/bin/phpunit test/unit  
+      - run: docker-compose run << parameters.version >> ./vendor/bin/phpunit test/unit
   performance_tests:
     parameters: *version
     description: Run performance tests for << parameters.version >>
@@ -27,7 +27,7 @@ jobs:
     machine:
       image: ubuntu-2004:202010-01
     steps:
-      - checkout      
+      - checkout
       - install_composer_dependencies:
           version: << parameters.version >>
       - unit_tests:
@@ -41,8 +41,8 @@ workflows:
       - test:
           matrix:
             parameters:
-              version: 
-                - php55 
+              version:
+                - php55
                 - php56
                 - php70
                 - php72

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,10 @@ x-base-config: &base-config
     - ./:/var/tripod-php
     - ./vendor:/var/tripod-php/vendor:delegated
   links:
-    - "mongo26:mongodb"
+    - "mongo32:mongodb"
     - redis    
   depends_on:
-    - mongo26
+    - mongo32
     - redis    
   working_dir: /var/tripod-php    
   env_file: .env
@@ -42,8 +42,8 @@ services:
     image: talis/tripod-php:php72-latest
     <<: *base-config    
 
-  mongo26:
-    image: rossfsinger/mongo-2.6.12:latest
+  mongo32:
+    image: mongo:3.2.21
 
   redis:
     image: redis:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,4 +46,4 @@ services:
     image: mongo:3.2.21
 
   redis:
-    image: redis:latest
+    image: redis:6.2.6


### PR DESCRIPTION
* Related to https://github.com/talis/platform/issues/6747
* Bump Mongo to 3.2.
* Pin version of redis - ran into an issue with it on CircleCI, 
  see https://discuss.circleci.com/t/redis-fatal-cant-initialize-background-jobs/48376