### PR TITLE
TA-1913 - Support Mongo index options in Tripod config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "talis/tripod-php",
+    "version": "dev-local",
     "type": "library",
     "description": "A library for managing RDF data in Mongo",
     "keywords": ["rdf","sparql"],

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
     "name": "talis/tripod-php",
-    "version": "dev-local",
     "type": "library",
     "description": "A library for managing RDF data in Mongo",
     "keywords": ["rdf","sparql"],

--- a/src/mongo/Config.class.php
+++ b/src/mongo/Config.class.php
@@ -254,29 +254,31 @@ class Config implements IConfigInstance
                             $todoKeys = array_keys($indexFields);
                             if (is_numeric($todoKeys[0])) {
                                 error_log('new format config - two arrays' . json_encode($todoKeys[0]));
+                                $todoIndexFields = $indexFields[0];
                             } else {
                                 error_log('old format config' . json_encode($todoKeys[0]));
+                                $todoIndexFields = $indexFields;
                             }
 
                             // If we have the new config, it doesn't like this cardinality check
                             // so bypass it for now and come back to it later once discussed
 
                             // check no more than 1 indexField is an array to ensure Mongo will be able to create compound indexes
-                            // if (count($indexFields) > 1) {
-                            //     $fieldsThatAreArrays = 0;
-                            //     foreach ($indexFields as $field => $fieldVal) {
-                            //         $cardinalityField = str_replace('.value', '', $field);
-                            //         if (!array_key_exists($cardinalityField, $this->cardinality[$storeName][$podName]) ||
-                            //             $this->cardinality[$storeName][$podName][$cardinalityField] != 1) {
-                            //             $fieldsThatAreArrays++;
-                            //         }
-                            //         if ($fieldsThatAreArrays > 1) {
-                            //             throw new \Tripod\Exceptions\ConfigException("Compound index $indexName has more than one field with cardinality > 1 - mongo will not be able to build this index");
-                            //         }
-                            //     }
-                            // }
+                            if (count($todoIndexFields) > 1) {
+                                $fieldsThatAreArrays = 0;
+                                foreach ($todoIndexFields as $field => $fieldVal) {
+                                    $cardinalityField = str_replace('.value', '', $field);
+                                    if (!array_key_exists($cardinalityField, $this->cardinality[$storeName][$podName]) ||
+                                        $this->cardinality[$storeName][$podName][$cardinalityField] != 1) {
+                                        $fieldsThatAreArrays++;
+                                    }
+                                    if ($fieldsThatAreArrays > 1) {
+                                        throw new \Tripod\Exceptions\ConfigException("Compound index $indexName has more than one field with cardinality > 1 - mongo will not be able to build this index");
+                                    }
+                                }
+                            }
 
-                            $this->indexes[$storeName][$podName][$indexName] = $indexFields;
+                            $this->indexes[$storeName][$podName][$indexName] = $todoIndexFields;
                         }
                     }
                 }

--- a/src/mongo/Config.class.php
+++ b/src/mongo/Config.class.php
@@ -248,37 +248,33 @@ class Config implements IConfigInstance
                     if (array_key_exists("indexes", $podConfig)) {
                         $this->indexes[$storeName][$podName] = [];
 
-                        error_log('Config indexes: '.json_encode($podConfig["indexes"]));
                         foreach ($podConfig["indexes"] as $indexName => $indexFields) {
 
                             $this->indexes[$storeName][$podName][$indexName] = $indexFields;
-                            error_log('Index for store: '.$storeName.' - '.json_encode($indexFields));
 
                             $indexKeys = array_keys($indexFields);
                             if (is_numeric($indexKeys[0])) {
-                                error_log('new format config - two arrays' . json_encode($indexKeys[0]));
+                                // New format config - two arrays, where second is index options (e.g. unique=>true, sparse=>true)
                                 $cardinalityIndexFields = $indexFields[0];
                             } else {
-                                error_log('old format config' . json_encode($indexKeys[0]));
+                                // Standard format config - single array
                                 $cardinalityIndexFields = $indexFields;
                             }
 
-                            // AJB
-
                             // check no more than 1 indexField is an array to ensure Mongo will be able to create compound indexes
-                            // if (count($cardinalityIndexFields) > 1) {
-                            //     $fieldsThatAreArrays = 0;
-                            //     foreach ($cardinalityIndexFields as $field => $fieldVal) {
-                            //         $cardinalityField = str_replace('.value', '', $field);
-                            //         if (!array_key_exists($cardinalityField, $this->cardinality[$storeName][$podName]) ||
-                            //             $this->cardinality[$storeName][$podName][$cardinalityField] != 1) {
-                            //             $fieldsThatAreArrays++;
-                            //         }
-                            //         if ($fieldsThatAreArrays > 1) {
-                            //             throw new \Tripod\Exceptions\ConfigException("Compound index $indexName has more than one field with cardinality > 1 - mongo will not be able to build this index");
-                            //         }
-                            //     }
-                            // }
+                            if (count($cardinalityIndexFields) > 1) {
+                                $fieldsThatAreArrays = 0;
+                                foreach ($cardinalityIndexFields as $field => $fieldVal) {
+                                    $cardinalityField = str_replace('.value', '', $field);
+                                    if (!array_key_exists($cardinalityField, $this->cardinality[$storeName][$podName]) ||
+                                        $this->cardinality[$storeName][$podName][$cardinalityField] != 1) {
+                                        $fieldsThatAreArrays++;
+                                    }
+                                    if ($fieldsThatAreArrays > 1) {
+                                        throw new \Tripod\Exceptions\ConfigException("Compound index $indexName has more than one field with cardinality > 1 - mongo will not be able to build this index");
+                                    }
+                                }
+                            }
                         }
                     }
                 }
@@ -1132,7 +1128,6 @@ class Config implements IConfigInstance
     public function getIndexesGroupedByCollection($storeName)
     {
         $indexes = $this->indexes[$storeName];
-        error_log('Config->getIndexesGroupedByCollection: ' . json_encode($indexes));
         //TODO: if we have much more default indexes we should find a better way of doing this
         foreach($indexes as $collection=>$indices) {
             $indexes[$collection][_LOCKED_FOR_TRANS_INDEX] = array(_ID_KEY=>1, _LOCKED_FOR_TRANS=>1);

--- a/src/mongo/Config.class.php
+++ b/src/mongo/Config.class.php
@@ -263,20 +263,22 @@ class Config implements IConfigInstance
                                 $cardinalityIndexFields = $indexFields;
                             }
 
+                            // AJB
+
                             // check no more than 1 indexField is an array to ensure Mongo will be able to create compound indexes
-                            if (count($cardinalityIndexFields) > 1) {
-                                $fieldsThatAreArrays = 0;
-                                foreach ($cardinalityIndexFields as $field => $fieldVal) {
-                                    $cardinalityField = str_replace('.value', '', $field);
-                                    if (!array_key_exists($cardinalityField, $this->cardinality[$storeName][$podName]) ||
-                                        $this->cardinality[$storeName][$podName][$cardinalityField] != 1) {
-                                        $fieldsThatAreArrays++;
-                                    }
-                                    if ($fieldsThatAreArrays > 1) {
-                                        throw new \Tripod\Exceptions\ConfigException("Compound index $indexName has more than one field with cardinality > 1 - mongo will not be able to build this index");
-                                    }
-                                }
-                            }
+                            // if (count($cardinalityIndexFields) > 1) {
+                            //     $fieldsThatAreArrays = 0;
+                            //     foreach ($cardinalityIndexFields as $field => $fieldVal) {
+                            //         $cardinalityField = str_replace('.value', '', $field);
+                            //         if (!array_key_exists($cardinalityField, $this->cardinality[$storeName][$podName]) ||
+                            //             $this->cardinality[$storeName][$podName][$cardinalityField] != 1) {
+                            //             $fieldsThatAreArrays++;
+                            //         }
+                            //         if ($fieldsThatAreArrays > 1) {
+                            //             throw new \Tripod\Exceptions\ConfigException("Compound index $indexName has more than one field with cardinality > 1 - mongo will not be able to build this index");
+                            //         }
+                            //     }
+                            // }
                         }
                     }
                 }

--- a/src/mongo/Config.class.php
+++ b/src/mongo/Config.class.php
@@ -247,22 +247,34 @@ class Config implements IConfigInstance
                     // Ensure indexes are legal
                     if (array_key_exists("indexes", $podConfig)) {
                         $this->indexes[$storeName][$podName] = [];
+                        error_log('Config indexes: '.json_encode($podConfig["indexes"]));
                         foreach ($podConfig["indexes"] as $indexName => $indexFields) {
+
+                            // Ugh.... Discuss.
+                            $todoKeys = array_keys($indexFields);
+                            if (is_numeric($todoKeys[0])) {
+                                error_log('new format config - two arrays' . json_encode($todoKeys[0]));
+                            } else {
+                                error_log('old format config' . json_encode($todoKeys[0]));
+                            }
+
+                            // If we have the new config, it doesn't like this cardinality check
+                            // so bypass it for now and come back to it later once discussed
+
                             // check no more than 1 indexField is an array to ensure Mongo will be able to create compound indexes
-                            if (count($indexFields) > 1) {
-                                $fieldsThatAreArrays = 0;
-                                foreach ($indexFields as $field => $fieldVal) {
-                                    $cardinalityField = str_replace('.value', '', $field);
-                                    if (!array_key_exists($cardinalityField, $this->cardinality[$storeName][$podName]) ||
-                                        $this->cardinality[$storeName][$podName][$cardinalityField] != 1) {
-                                        $fieldsThatAreArrays++;
-                                    }
-                                    if ($fieldsThatAreArrays > 1) {
-                                        throw new \Tripod\Exceptions\ConfigException("Compound index $indexName has more than one field with cardinality > 1 - mongo will not be able to build this index");
-                                    }
-                                }
-                            } // @codeCoverageIgnoreStart
-                            // @codeCoverageIgnoreEnd
+                            // if (count($indexFields) > 1) {
+                            //     $fieldsThatAreArrays = 0;
+                            //     foreach ($indexFields as $field => $fieldVal) {
+                            //         $cardinalityField = str_replace('.value', '', $field);
+                            //         if (!array_key_exists($cardinalityField, $this->cardinality[$storeName][$podName]) ||
+                            //             $this->cardinality[$storeName][$podName][$cardinalityField] != 1) {
+                            //             $fieldsThatAreArrays++;
+                            //         }
+                            //         if ($fieldsThatAreArrays > 1) {
+                            //             throw new \Tripod\Exceptions\ConfigException("Compound index $indexName has more than one field with cardinality > 1 - mongo will not be able to build this index");
+                            //         }
+                            //     }
+                            // }
 
                             $this->indexes[$storeName][$podName][$indexName] = $indexFields;
                         }

--- a/src/mongo/Config.class.php
+++ b/src/mongo/Config.class.php
@@ -247,26 +247,26 @@ class Config implements IConfigInstance
                     // Ensure indexes are legal
                     if (array_key_exists("indexes", $podConfig)) {
                         $this->indexes[$storeName][$podName] = [];
+
                         error_log('Config indexes: '.json_encode($podConfig["indexes"]));
                         foreach ($podConfig["indexes"] as $indexName => $indexFields) {
 
-                            // Ugh.... Discuss.
-                            $todoKeys = array_keys($indexFields);
-                            if (is_numeric($todoKeys[0])) {
-                                error_log('new format config - two arrays' . json_encode($todoKeys[0]));
-                                $todoIndexFields = $indexFields[0];
+                            $this->indexes[$storeName][$podName][$indexName] = $indexFields;
+                            error_log('Index for store: '.$storeName.' - '.json_encode($indexFields));
+
+                            $indexKeys = array_keys($indexFields);
+                            if (is_numeric($indexKeys[0])) {
+                                error_log('new format config - two arrays' . json_encode($indexKeys[0]));
+                                $cardinalityIndexFields = $indexFields[0];
                             } else {
-                                error_log('old format config' . json_encode($todoKeys[0]));
-                                $todoIndexFields = $indexFields;
+                                error_log('old format config' . json_encode($indexKeys[0]));
+                                $cardinalityIndexFields = $indexFields;
                             }
 
-                            // If we have the new config, it doesn't like this cardinality check
-                            // so bypass it for now and come back to it later once discussed
-
                             // check no more than 1 indexField is an array to ensure Mongo will be able to create compound indexes
-                            if (count($todoIndexFields) > 1) {
+                            if (count($cardinalityIndexFields) > 1) {
                                 $fieldsThatAreArrays = 0;
-                                foreach ($todoIndexFields as $field => $fieldVal) {
+                                foreach ($cardinalityIndexFields as $field => $fieldVal) {
                                     $cardinalityField = str_replace('.value', '', $field);
                                     if (!array_key_exists($cardinalityField, $this->cardinality[$storeName][$podName]) ||
                                         $this->cardinality[$storeName][$podName][$cardinalityField] != 1) {
@@ -277,8 +277,6 @@ class Config implements IConfigInstance
                                     }
                                 }
                             }
-
-                            $this->indexes[$storeName][$podName][$indexName] = $todoIndexFields;
                         }
                     }
                 }
@@ -1132,6 +1130,7 @@ class Config implements IConfigInstance
     public function getIndexesGroupedByCollection($storeName)
     {
         $indexes = $this->indexes[$storeName];
+        error_log('Config->getIndexesGroupedByCollection: ' . json_encode($indexes));
         //TODO: if we have much more default indexes we should find a better way of doing this
         foreach($indexes as $collection=>$indices) {
             $indexes[$collection][_LOCKED_FOR_TRANS_INDEX] = array(_ID_KEY=>1, _LOCKED_FOR_TRANS=>1);

--- a/src/mongo/util/IndexUtils.class.php
+++ b/src/mongo/util/IndexUtils.class.php
@@ -63,9 +63,6 @@ class IndexUtils
                         $indexFields = $fields;
                     }
 
-                    // TODO is there a logger to use...
-                    // error_log('create index - fields: '.json_encode($fields).' - options: '.json_encode($indexOptions));
-
                     $config->getCollectionForCBD($storeName, $collectionName)
                         ->createIndex(
                         $indexFields,

--- a/src/mongo/util/IndexUtils.class.php
+++ b/src/mongo/util/IndexUtils.class.php
@@ -45,7 +45,7 @@ class IndexUtils
                     $indexName = substr($indexName,0,127); // ensure max 128 chars
 
                     $indexOptions = [
-                        "background"=>$background
+                        'background'=>$background
                     ];
 
                     if (!is_numeric($indexName))
@@ -53,20 +53,17 @@ class IndexUtils
                         $indexOptions['name'] = $indexName;
                     }
 
-                    // New
-                    //fields: [{"rdf:type.u":1},{"unique":true}]
-                    // Old
-                    //fields: {"_id":1,"_lockedForTrans":1}
-
-                    $todoKeys = array_keys($fields);
-                    if (is_numeric($todoKeys[0])) {
-                        error_log('New nested format index '.json_encode($todoKeys[0]));
+                    $indexKeys = array_keys($fields);
+                    if (is_numeric($indexKeys[0])) {
+                        // New nested format index (?)
+                        error_log('New nested format index '.json_encode($indexKeys[0]));
                         $indexFields = $fields[0];
                         error_log('field[1] '.json_encode($indexFields));
                         // TODO pass second array into options
                         $indexOptions = array_merge($indexOptions, $fields[1]);
                     } else {
-                        error_log('Old format index '.json_encode($todoKeys[0]));
+                        // Old format index
+                        error_log('Old format index '.json_encode($indexKeys[0]));
                         $indexFields = $fields;
                     }
 

--- a/src/mongo/util/IndexUtils.class.php
+++ b/src/mongo/util/IndexUtils.class.php
@@ -38,9 +38,10 @@ class IndexUtils
                         $reindexedCollections[] = $collection->getNamespace();
                     }
                 }
+                error_log('ensureIndexes: All Indexes: '. json_encode($indexes));
                 foreach ($indexes as $indexName=>$fields)
                 {
-                    error_log('Index: '.$indexName.' - fields: '.json_encode($fields));
+                    error_log('ensureIndexes: Index: '.$indexName.' - fields: '.json_encode($fields));
                     $indexName = substr($indexName,0,127); // ensure max 128 chars
 
                     $indexOptions = [

--- a/src/mongo/util/IndexUtils.class.php
+++ b/src/mongo/util/IndexUtils.class.php
@@ -16,7 +16,6 @@ class IndexUtils
      */
     public function ensureIndexes($reindex=false,$storeName=null,$background=true)
     {
-        error_log('ensureIndexes: '.$storeName);
         $config = $this->getConfig();
         $dbs = ($storeName==null) ? $config->getDbs() : array($storeName);
         $reindexedCollections = [];
@@ -30,6 +29,7 @@ class IndexUtils
                 {
                     continue;
                 }
+
                 if ($reindex)
                 {
                     $collection = $config->getCollectionForCBD($storeName, $collectionName);
@@ -38,10 +38,9 @@ class IndexUtils
                         $reindexedCollections[] = $collection->getNamespace();
                     }
                 }
-                error_log('ensureIndexes: All Indexes: '. json_encode($indexes));
+
                 foreach ($indexes as $indexName=>$fields)
                 {
-                    error_log('ensureIndexes: Index: '.$indexName.' - fields: '.json_encode($fields));
                     $indexName = substr($indexName,0,127); // ensure max 128 chars
 
                     $indexOptions = [
@@ -50,22 +49,21 @@ class IndexUtils
 
                     if (!is_numeric($indexName))
                     {
+                        // Named index vs. unnamed index
                         $indexOptions['name'] = $indexName;
                     }
 
                     $indexKeys = array_keys($fields);
                     if (is_numeric($indexKeys[0])) {
-                        // New nested format index
-                        error_log('New nested format index');
+                        // New format config - two arrays, where second is index options (e.g. unique=>true, sparse=>true)
                         $indexFields = $fields[0];
-                        error_log('field[1] '.json_encode($indexFields));
                         $indexOptions = array_merge($indexOptions, $fields[1]);
                     } else {
-                        // Old format index
-                        error_log('Old format index');
+                        // Standard format config - single array
                         $indexFields = $fields;
                     }
 
+                    // TODO is there a logger to use...
                     error_log('create index - fields: '.json_encode($fields).' - options: '.json_encode($indexOptions));
 
                     $config->getCollectionForCBD($storeName, $collectionName)
@@ -101,7 +99,6 @@ class IndexUtils
                     }
                     foreach($indexes as $index)
                     {
-                        error_log('view index? '.json_encode($index));
                         $collection->createIndex(
                             $index,
                             array(
@@ -137,7 +134,6 @@ class IndexUtils
                     }
                     foreach($indexes as $index)
                     {
-                        error_log('table row index? '.json_encode($index));
                         $collection->createIndex(
                             $index,
                             array(
@@ -170,7 +166,6 @@ class IndexUtils
                     }
                     foreach($indexes as $index)
                     {
-                        error_log('search doc index? '.json_encode($index));
                         $collection->createIndex(
                             $index,
                             array(

--- a/src/mongo/util/IndexUtils.class.php
+++ b/src/mongo/util/IndexUtils.class.php
@@ -16,6 +16,7 @@ class IndexUtils
      */
     public function ensureIndexes($reindex=false,$storeName=null,$background=true)
     {
+        error_log('ensureIndexes: '.$storeName);
         $config = $this->getConfig();
         $dbs = ($storeName==null) ? $config->getDbs() : array($storeName);
         $reindexedCollections = [];
@@ -39,30 +40,43 @@ class IndexUtils
                 }
                 foreach ($indexes as $indexName=>$fields)
                 {
+                    error_log('Index: '.$indexName.' - fields: '.json_encode($fields));
                     $indexName = substr($indexName,0,127); // ensure max 128 chars
-                    if (is_numeric($indexName))
+
+                    $indexOptions = [
+                        "background"=>$background
+                    ];
+
+                    if (!is_numeric($indexName))
                     {
-                        // no name
-                        $config->getCollectionForCBD($storeName, $collectionName)
-                            ->createIndex(
-                                $fields,
-                                array(
-                                    "background"=>$background
-                                )
-                            );
+                        $indexOptions['name'] = $indexName;
                     }
-                    else
-                    {
-                        $config->getCollectionForCBD($storeName, $collectionName)
-                            ->createIndex(
-                                $fields,
-                                array(
-                                    'name'=>$indexName,
-                                    "background"=>$background
-                                )
-                            );
+
+                    // New
+                    //fields: [{"rdf:type.u":1},{"unique":true}]
+                    // Old
+                    //fields: {"_id":1,"_lockedForTrans":1}
+
+                    $todoKeys = array_keys($fields);
+                    if (is_numeric($todoKeys[0])) {
+                        error_log('New nested format index '.json_encode($todoKeys[0]));
+                        $indexFields = $fields[0];
+                        error_log('field[1] '.json_encode($indexFields));
+                        // TODO pass second array into options
+                        $indexOptions = array_merge($indexOptions, $fields[1]);
+                    } else {
+                        error_log('Old format index '.json_encode($todoKeys[0]));
+                        $indexFields = $fields;
                     }
-                }
+
+                    error_log('create index - fields: '.json_encode($fields).' - options: '.json_encode($indexOptions));
+
+                    $config->getCollectionForCBD($storeName, $collectionName)
+                        ->createIndex(
+                        $indexFields,
+                        $indexOptions
+                    );
+        }
             }
 
             // Index views
@@ -90,6 +104,7 @@ class IndexUtils
                     }
                     foreach($indexes as $index)
                     {
+                        error_log('view index? '.json_encode($index));
                         $collection->createIndex(
                             $index,
                             array(
@@ -125,6 +140,7 @@ class IndexUtils
                     }
                     foreach($indexes as $index)
                     {
+                        error_log('table row index? '.json_encode($index));
                         $collection->createIndex(
                             $index,
                             array(
@@ -157,6 +173,7 @@ class IndexUtils
                     }
                     foreach($indexes as $index)
                     {
+                        error_log('search doc index? '.json_encode($index));
                         $collection->createIndex(
                             $index,
                             array(

--- a/src/mongo/util/IndexUtils.class.php
+++ b/src/mongo/util/IndexUtils.class.php
@@ -64,7 +64,7 @@ class IndexUtils
                     }
 
                     // TODO is there a logger to use...
-                    error_log('create index - fields: '.json_encode($fields).' - options: '.json_encode($indexOptions));
+                    // error_log('create index - fields: '.json_encode($fields).' - options: '.json_encode($indexOptions));
 
                     $config->getCollectionForCBD($storeName, $collectionName)
                         ->createIndex(

--- a/src/mongo/util/IndexUtils.class.php
+++ b/src/mongo/util/IndexUtils.class.php
@@ -55,15 +55,14 @@ class IndexUtils
 
                     $indexKeys = array_keys($fields);
                     if (is_numeric($indexKeys[0])) {
-                        // New nested format index (?)
-                        error_log('New nested format index '.json_encode($indexKeys[0]));
+                        // New nested format index
+                        error_log('New nested format index');
                         $indexFields = $fields[0];
                         error_log('field[1] '.json_encode($indexFields));
-                        // TODO pass second array into options
                         $indexOptions = array_merge($indexOptions, $fields[1]);
                     } else {
                         // Old format index
-                        error_log('Old format index '.json_encode($indexKeys[0]));
+                        error_log('Old format index');
                         $indexFields = $fields;
                     }
 

--- a/test/unit/mongo/IndexUtilsTest.php
+++ b/test/unit/mongo/IndexUtilsTest.php
@@ -28,9 +28,11 @@ class IndexUtilsTest extends MongoTripodTestBase
         $collection = $this->createMockCollection();
         $indexUtils = $this->createMockIndexUtils($config);
 
-        $this->setConfigForCBDIndexes($config, ['unique' => true]);
+        $indexOptions = ['unique' => true];
+
+        $this->setConfigForCBDIndexes($config, $indexOptions);
         $this->dropIndexesShouldNeverBeCalled($collection);
-        $this->oneCustomAndThreeInternalTripodCBDIndexesShouldBeCreated($collection, true);
+        $this->oneCustomAndThreeInternalTripodCBDIndexesShouldBeCreated($collection, true, $indexOptions);
         $this->getCollectionForCBDShouldBeCalled_n_Times(4, $config, $collection);
         $this->getCollectionForViewShouldNeverBeCalled($config);
         $this->getCollectionForTableShouldNeverBeCalled($config);
@@ -57,16 +59,17 @@ class IndexUtilsTest extends MongoTripodTestBase
         $indexUtils->ensureIndexes(false, 'tripod_php_testing', false);
     }
 
-    // todo
     public function testCBDCollectionIndexesAreCreatedInForegroundWithIndexOptions()
     {
         $config = $this->createMockConfig();
         $collection = $this->createMockCollection();
         $indexUtils = $this->createMockIndexUtils($config);
 
-        $this->setConfigForCBDIndexes($config, ['unique' => true]);
+        $indexOptions = ['unique' => true];
+
+        $this->setConfigForCBDIndexes($config, $indexOptions);
         $this->dropIndexesShouldNeverBeCalled($collection);
-        $this->oneCustomAndThreeInternalTripodCBDIndexesShouldBeCreated($collection, false);
+        $this->oneCustomAndThreeInternalTripodCBDIndexesShouldBeCreated($collection, false, $indexOptions);
         $this->getCollectionForCBDShouldBeCalled_n_Times(4, $config, $collection);
         $this->getCollectionForViewShouldNeverBeCalled($config);
         $this->getCollectionForTableShouldNeverBeCalled($config);
@@ -92,16 +95,17 @@ class IndexUtilsTest extends MongoTripodTestBase
         $indexUtils->ensureIndexes(true, 'tripod_php_testing', true);
     }
 
-    // todo
     public function testCBDCollectionIndexesAreReindexedWithIndexOptions()
     {
         $config = $this->createMockConfig();
         $collection = $this->createMockCollection();
         $indexUtils = $this->createMockIndexUtils($config);
 
-        $this->setConfigForCBDIndexes($config, ['unique' => true]);
+        $indexOptions = ['unique' => true];
+
+        $this->setConfigForCBDIndexes($config, $indexOptions);
         $this->dropIndexesShouldBeCalled($collection);
-        $this->oneCustomAndThreeInternalTripodCBDIndexesShouldBeCreated($collection, true);
+        $this->oneCustomAndThreeInternalTripodCBDIndexesShouldBeCreated($collection, true, $indexOptions);
         $this->getCollectionForCBDShouldBeCalled_n_Times(5, $config, $collection);
         $this->getCollectionForViewShouldNeverBeCalled($config);
         $this->getCollectionForTableShouldNeverBeCalled($config);
@@ -463,7 +467,7 @@ class IndexUtilsTest extends MongoTripodTestBase
      * @param bool $background create indexes in the background
      * @return void
      */
-    protected function oneCustomAndThreeInternalTripodCBDIndexesShouldBeCreated($mockCollection, $background = true)
+    protected function oneCustomAndThreeInternalTripodCBDIndexesShouldBeCreated($mockCollection, $background = true, array $indexOptions = [])
     {
         // create index is called 4 times, each time with a different set of
         // params that we know.
@@ -472,7 +476,7 @@ class IndexUtilsTest extends MongoTripodTestBase
         $mockCollection->expects($this->exactly(4))
             ->method('createIndex')
             ->withConsecutive(
-                [['rdf:type.u' => 1], ['name' => 'rdf_type', 'background' => $background]],
+                [['rdf:type.u' => 1], array_merge(['name' => 'rdf_type', 'background' => $background], $indexOptions)],
                 [[_ID_KEY => 1, _LOCKED_FOR_TRANS => 1], ['name' => '_lockedForTransIdx', 'background' => $background]],
                 [[_ID_KEY => 1, _UPDATED_TS => 1], ['name' => '_updatedTsIdx', 'background' => $background]],
                 [[_ID_KEY => 1, _CREATED_TS => 1], ['name' => '_createdTsIdx', 'background' => $background]]
@@ -598,6 +602,8 @@ class IndexUtilsTest extends MongoTripodTestBase
             'collection' => 'transaction_log',
             'data_source' => 'tlog',
         ];
+
+        error_log('IndexUtilsTest->setConfigForCBDIndexes - indexes: ' . json_encode($config['stores']['tripod_php_testing']['pods']['CBD_testing']['indexes']));
 
         $mockConfig->loadConfig($config);
     }

--- a/test/unit/mongo/IndexUtilsTest.php
+++ b/test/unit/mongo/IndexUtilsTest.php
@@ -21,7 +21,6 @@ class IndexUtilsTest extends MongoTripodTestBase
         $indexUtils->ensureIndexes(false, 'tripod_php_testing', true);
     }
 
-    // todo
     public function testCBDCollectionIndexesAreCreatedWithIndexOptions()
     {
         $config = $this->createMockConfig();
@@ -113,7 +112,6 @@ class IndexUtilsTest extends MongoTripodTestBase
 
         $indexUtils->ensureIndexes(true, 'tripod_php_testing', true);
     }
-
 
     public function testViewIndexesAreCreated()
     {

--- a/test/unit/mongo/IndexUtilsTest.php
+++ b/test/unit/mongo/IndexUtilsTest.php
@@ -511,22 +511,6 @@ class IndexUtilsTest extends MongoTripodTestBase
         ];
         $config['defaultContext'] = 'http://talisaspire.com/';
 
-        // $config['stores'] = [
-        //     'tripod_php_testing' => [
-        //         'type' => 'mongo',
-        //         'data_source' => 'mongo',
-        //         'pods' => [
-        //             'CBD_testing' => [
-        //                 'indexes' => [
-        //                     'rdf_type' => [
-        //                         'rdf:type.u' => 1,
-        //                     ],
-        //                 ],
-        //             ],
-        //         ],
-        //     ],
-        // ];
-
         $config['stores'] = [
             'tripod_php_testing' => [
                 'type' => 'mongo',
@@ -535,18 +519,34 @@ class IndexUtilsTest extends MongoTripodTestBase
                     'CBD_testing' => [
                         'indexes' => [
                             'rdf_type' => [
-                                [
-                                    'rdf:type.u' => 1,
-                                ],
-                                [
-                                    'unique' => true,
-                                ]
+                                'rdf:type.u' => 1,
                             ],
                         ],
                     ],
                 ],
             ],
         ];
+
+        // $config['stores'] = [
+        //     'tripod_php_testing' => [
+        //         'type' => 'mongo',
+        //         'data_source' => 'mongo',
+        //         'pods' => [
+        //             'CBD_testing' => [
+        //                 'indexes' => [
+        //                     'rdf_type' => [
+        //                         [
+        //                             'rdf:type.u' => 1,
+        //                         ],
+        //                         [
+        //                             'unique' => true,
+        //                         ]
+        //                     ],
+        //                 ],
+        //             ],
+        //         ],
+        //     ],
+        // ];
 
         $config['transaction_log'] = [
             'database' => 'transactions',

--- a/test/unit/mongo/IndexUtilsTest.php
+++ b/test/unit/mongo/IndexUtilsTest.php
@@ -601,8 +601,6 @@ class IndexUtilsTest extends MongoTripodTestBase
             'data_source' => 'tlog',
         ];
 
-        error_log('IndexUtilsTest->setConfigForCBDIndexes - indexes: ' . json_encode($config['stores']['tripod_php_testing']['pods']['CBD_testing']['indexes']));
-
         $mockConfig->loadConfig($config);
     }
 

--- a/test/unit/mongo/IndexUtilsTest.php
+++ b/test/unit/mongo/IndexUtilsTest.php
@@ -4,7 +4,6 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 class IndexUtilsTest extends MongoTripodTestBase
 {
-    // HERE
     public function testCBDCollectionIndexesAreCreated()
     {
         $config = $this->createMockConfig();
@@ -22,6 +21,25 @@ class IndexUtilsTest extends MongoTripodTestBase
         $indexUtils->ensureIndexes(false, 'tripod_php_testing', true);
     }
 
+    // todo
+    public function testCBDCollectionIndexesAreCreatedWithIndexOptions()
+    {
+        $config = $this->createMockConfig();
+        $collection = $this->createMockCollection();
+        $indexUtils = $this->createMockIndexUtils($config);
+
+        $this->setConfigForCBDIndexes($config, ['unique' => true]);
+        $this->dropIndexesShouldNeverBeCalled($collection);
+        $this->oneCustomAndThreeInternalTripodCBDIndexesShouldBeCreated($collection, true);
+        $this->getCollectionForCBDShouldBeCalled_n_Times(4, $config, $collection);
+        $this->getCollectionForViewShouldNeverBeCalled($config);
+        $this->getCollectionForTableShouldNeverBeCalled($config);
+        $this->getCollectionForSearchDocumentShouldNeverBeCalled($config);
+
+        $indexUtils->ensureIndexes(false, 'tripod_php_testing', true);
+    }
+
+
     public function testCBDCollectionIndexesAreCreatedInForeground()
     {
         $config = $this->createMockConfig();
@@ -29,6 +47,24 @@ class IndexUtilsTest extends MongoTripodTestBase
         $indexUtils = $this->createMockIndexUtils($config);
 
         $this->setConfigForCBDIndexes($config);
+        $this->dropIndexesShouldNeverBeCalled($collection);
+        $this->oneCustomAndThreeInternalTripodCBDIndexesShouldBeCreated($collection, false);
+        $this->getCollectionForCBDShouldBeCalled_n_Times(4, $config, $collection);
+        $this->getCollectionForViewShouldNeverBeCalled($config);
+        $this->getCollectionForTableShouldNeverBeCalled($config);
+        $this->getCollectionForSearchDocumentShouldNeverBeCalled($config);
+
+        $indexUtils->ensureIndexes(false, 'tripod_php_testing', false);
+    }
+
+    // todo
+    public function testCBDCollectionIndexesAreCreatedInForegroundWithIndexOptions()
+    {
+        $config = $this->createMockConfig();
+        $collection = $this->createMockCollection();
+        $indexUtils = $this->createMockIndexUtils($config);
+
+        $this->setConfigForCBDIndexes($config, ['unique' => true]);
         $this->dropIndexesShouldNeverBeCalled($collection);
         $this->oneCustomAndThreeInternalTripodCBDIndexesShouldBeCreated($collection, false);
         $this->getCollectionForCBDShouldBeCalled_n_Times(4, $config, $collection);
@@ -55,6 +91,25 @@ class IndexUtilsTest extends MongoTripodTestBase
 
         $indexUtils->ensureIndexes(true, 'tripod_php_testing', true);
     }
+
+    // todo
+    public function testCBDCollectionIndexesAreReindexedWithIndexOptions()
+    {
+        $config = $this->createMockConfig();
+        $collection = $this->createMockCollection();
+        $indexUtils = $this->createMockIndexUtils($config);
+
+        $this->setConfigForCBDIndexes($config, ['unique' => true]);
+        $this->dropIndexesShouldBeCalled($collection);
+        $this->oneCustomAndThreeInternalTripodCBDIndexesShouldBeCreated($collection, true);
+        $this->getCollectionForCBDShouldBeCalled_n_Times(5, $config, $collection);
+        $this->getCollectionForViewShouldNeverBeCalled($config);
+        $this->getCollectionForTableShouldNeverBeCalled($config);
+        $this->getCollectionForSearchDocumentShouldNeverBeCalled($config);
+
+        $indexUtils->ensureIndexes(true, 'tripod_php_testing', true);
+    }
+
 
     public function testViewIndexesAreCreated()
     {
@@ -497,7 +552,7 @@ class IndexUtilsTest extends MongoTripodTestBase
      * @param MockObject&\TripodTestConfig $mockConfig mock Config object
      * @return void
      */
-    protected function setConfigForCBDIndexes($mockConfig)
+    protected function setConfigForCBDIndexes($mockConfig, array $indexOptions = [])
     {
         // minimal config to verify that
         $config = [];
@@ -516,37 +571,27 @@ class IndexUtilsTest extends MongoTripodTestBase
                 'type' => 'mongo',
                 'data_source' => 'mongo',
                 'pods' => [
-                    'CBD_testing' => [
-                        'indexes' => [
-                            'rdf_type' => [
-                                'rdf:type.u' => 1,
-                            ],
-                        ],
-                    ],
+                    'CBD_testing' => []
                 ],
             ],
         ];
 
-        // $config['stores'] = [
-        //     'tripod_php_testing' => [
-        //         'type' => 'mongo',
-        //         'data_source' => 'mongo',
-        //         'pods' => [
-        //             'CBD_testing' => [
-        //                 'indexes' => [
-        //                     'rdf_type' => [
-        //                         [
-        //                             'rdf:type.u' => 1,
-        //                         ],
-        //                         [
-        //                             'unique' => true,
-        //                         ]
-        //                     ],
-        //                 ],
-        //             ],
-        //         ],
-        //     ],
-        // ];
+        if (empty($indexOptions)) {
+            $config['stores']['tripod_php_testing']['pods']['CBD_testing']['indexes'] = [
+                'rdf_type' => [
+                    'rdf:type.u' => 1,
+                ],
+            ];
+        } else {
+            $config['stores']['tripod_php_testing']['pods']['CBD_testing']['indexes'] = [
+                'rdf_type' => [
+                    [
+                        'rdf:type.u' => 1,
+                    ],
+                    $indexOptions
+                ],
+            ];
+        }
 
         $config['transaction_log'] = [
             'database' => 'transactions',

--- a/test/unit/mongo/IndexUtilsTest.php
+++ b/test/unit/mongo/IndexUtilsTest.php
@@ -4,6 +4,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 class IndexUtilsTest extends MongoTripodTestBase
 {
+    // HERE
     public function testCBDCollectionIndexesAreCreated()
     {
         $config = $this->createMockConfig();
@@ -509,6 +510,23 @@ class IndexUtilsTest extends MongoTripodTestBase
             'mongo' => ['type' => 'mongo', 'connection' => 'mongodb://localhost'],
         ];
         $config['defaultContext'] = 'http://talisaspire.com/';
+
+        // $config['stores'] = [
+        //     'tripod_php_testing' => [
+        //         'type' => 'mongo',
+        //         'data_source' => 'mongo',
+        //         'pods' => [
+        //             'CBD_testing' => [
+        //                 'indexes' => [
+        //                     'rdf_type' => [
+        //                         'rdf:type.u' => 1,
+        //                     ],
+        //                 ],
+        //             ],
+        //         ],
+        //     ],
+        // ];
+
         $config['stores'] = [
             'tripod_php_testing' => [
                 'type' => 'mongo',
@@ -517,7 +535,12 @@ class IndexUtilsTest extends MongoTripodTestBase
                     'CBD_testing' => [
                         'indexes' => [
                             'rdf_type' => [
-                                'rdf:type.u' => 1,
+                                [
+                                    'rdf:type.u' => 1,
+                                ],
+                                [
+                                    'unique' => true,
+                                ]
                             ],
                         ],
                     ],


### PR DESCRIPTION
### Fix
* Cater for a new (non-breaking) index format where there are two arrays instead of one - the second array allows passing of standard Mongo index options (e.g. sparse=>true, unique=>true)
* Add new tests to check 
* Tested the dependency manually inside local TARL to prove the index gets generated correctly and no other fallout.
* See associated TARL PR where we use the new index definitions to create a sparse/unique index on `personaUsers.guid`: https://github.com/techfromsage/rl-app/pull/4461

### Approach taken
* We drove this off the existing tests and copious amounts of temporary logging.  Adding more tests that support that new two array format (where second array is standard Mongo index options)
* Once all passing in tests, copied this code into TARL's vendor directory and updated the `tenant-pods.json` file in TARL to add a new index onto CBD_users `personaUsers.guid` that also had sparse=>true & unique=>true.
* Reloaded TARL data, no indexes present (this also generates the tripod config)
* Kicked off Setup Console "ensureIndexes"
* Looked in TARL and Tripod logs for errors (non present) and also checked CBD_users indexes - new index was present with the correct index options.
* As a safety test we also tried the index _without_ the `sparse=>true` and the index generation failed as there are many documents in local TARL that have no persona guid set.  

### Issues
It's worth noting a few issues encountered along the way with this...
* TARL's `docker-compose.yml` has a `:delegated` suffix on the `vendor` volume mount, effectively caching changes so when you copy new code in it wasn't being picked up.  We temporarily removed this to prove our changes, but _sometimes_ it still didn't pick up changes quickly enough.  The only reliable option was to stop/start the RL containers and then code in `vendor` was correctly reflected.
* It would have been nice to have left a logger statement in at the point of creating the index, just so we can see the options, but the logger isn't available in the IndexUtils class.

### Example 
From a `db.CBD_users.getIndexes()` in the local Mongo `life` database, the new index is present:
<img width="386" alt="Screenshot 2024-12-03 at 10 21 56" src="https://github.com/user-attachments/assets/a01f9f5b-0453-4fc5-a4eb-d812788069eb">
