### PR TITLE
Tone down logging level for "Generating views"

### DIFF
--- a/src/mongo/delegates/Views.php
+++ b/src/mongo/delegates/Views.php
@@ -290,10 +290,7 @@ class Views extends CompositeBase
         $filter = [];
         foreach ($resources as $resource) {
             $resourceAlias = $this->labeller->uri_to_alias($resource);
-            $this->getLogger()->warning(
-                'Generating views',
-                ['store' => $this->storeName, '_id' => $resourceAlias]
-            );
+            $this->debugLog('Generating views', ['store' => $this->storeName, '_id' => $resourceAlias]);
             // delete any views this resource is involved in. It's type may have changed so it's not enough just to regen it with it's new type below.
             foreach ($this->getConfigInstance()->getViewSpecifications($this->storeName) as $type => $spec) {
                 if ($spec['from'] == $this->podName) {


### PR DESCRIPTION
The "Generating views" lines are bloating our logs both in development and production.
I don't know why historically this was _ever_ `warning` level but that's another issue.

Tone down the logging from `warning` to `debug` for "Generating views" lines.

<img width="1044" height="357" alt="Screenshot 2026-03-09 at 13 43 32" src="https://github.com/user-attachments/assets/0a0695aa-e9b0-42d2-98f9-112f68bc56a5" />