### PR TITLE
Retry composite upserts

### DIFF
--- a/src/mongo/delegates/Tables.php
+++ b/src/mongo/delegates/Tables.php
@@ -1444,6 +1444,12 @@ class Tables extends CompositeBase
             $collection->updateOne(['_id' => $generatedRow['_id']], ['$set' => $generatedRow], ['upsert' => true]);
         } catch (BulkWriteException $e) {
             if ($this->isDuplicateKeyError($e)) {
+                $existingRow = $collection->findOne(['_id' => $generatedRow['_id']]);
+                $this->getLogger()->warning('Duplicate key error when upserting generated table row, retrying.', [
+                    'error' => $e,
+                    'generatedRow' => $generatedRow,
+                    'existingRow' => $existingRow,
+                ]);
                 $collection->updateOne(['_id' => $generatedRow['_id']], ['$set' => $generatedRow], ['upsert' => false]);
             } else {
                 throw $e;

--- a/src/mongo/delegates/Tables.php
+++ b/src/mongo/delegates/Tables.php
@@ -658,7 +658,7 @@ class Tables extends CompositeBase
             $this->upsertGeneratedRow($collection, $generatedRow);
         } catch (\Exception $e) {
             // We only truncate and retry the save if the \Exception contains this text.
-            if (strpos($e->getMessage(), 'Btree::insert: key too large to index') !== false) {
+            if (strpos($e->getMessage(), '::insert: key too large to index') !== false) {
                 $this->truncateFields($collection, $generatedRow);
                 $this->upsertGeneratedRow($collection, $generatedRow);
             } else {

--- a/src/mongo/delegates/Tables.php
+++ b/src/mongo/delegates/Tables.php
@@ -6,7 +6,9 @@ require_once TRIPOD_DIR . 'mongo/MongoTripodConstants.php';
 
 use MongoDB\BSON\UTCDateTime;
 use MongoDB\Collection;
+use MongoDB\Driver\Exception\BulkWriteException;
 use MongoDB\Driver\ReadPreference;
+use Tripod\Config;
 use Tripod\Exceptions\LabellerException;
 use Tripod\ITripodStat;
 use Tripod\Mongo\DateUtil;
@@ -92,7 +94,7 @@ class Tables extends CompositeBase
         $this->storeName = $storeName;
         $this->collection = $collection;
         $this->podName = $collection->getCollectionName();
-        $this->config = $this->getConfigInstance();
+        $this->config = Config::getInstance();
         $this->defaultContext = $this->labeller->uri_to_alias($defaultContext); // make sure default context is qnamed if applicable
         $this->stat = $stat;
         $this->readPreference = $readPreference;
@@ -653,12 +655,12 @@ class Tables extends CompositeBase
     protected function truncatingSave(Collection $collection, array $generatedRow)
     {
         try {
-            $collection->updateOne(['_id' => $generatedRow['_id']], ['$set' => $generatedRow], ['upsert' => true]);
+            $this->upsertGeneratedRow($collection, $generatedRow);
         } catch (\Exception $e) {
             // We only truncate and retry the save if the \Exception contains this text.
             if (strpos($e->getMessage(), 'Btree::insert: key too large to index') !== false) {
                 $this->truncateFields($collection, $generatedRow);
-                $collection->updateOne(['_id' => $generatedRow['_id']], ['$set' => $generatedRow], ['upsert' => true]);
+                $this->upsertGeneratedRow($collection, $generatedRow);
             } else {
                 throw $e;
             }
@@ -1434,5 +1436,23 @@ class Tables extends CompositeBase
         }
 
         throw new \Tripod\Exceptions\Exception('Was expecting either VALUE_URI or VALUE_LITERAL when applying regex to value - possible data corruption with: ' . var_export($value, true));
+    }
+
+    private function upsertGeneratedRow(Collection $collection, array $generatedRow): void
+    {
+        try {
+            $collection->updateOne(['_id' => $generatedRow['_id']], ['$set' => $generatedRow], ['upsert' => true]);
+        } catch (BulkWriteException $e) {
+            if ($this->isDuplicateKeyError($e)) {
+                $collection->updateOne(['_id' => $generatedRow['_id']], ['$set' => $generatedRow], ['upsert' => false]);
+            } else {
+                throw $e;
+            }
+        }
+    }
+
+    private function isDuplicateKeyError(BulkWriteException $error): bool
+    {
+        return $error->getCode() === 11000 || strpos($error->getMessage(), 'E11000') !== false;
     }
 }

--- a/src/mongo/delegates/Views.php
+++ b/src/mongo/delegates/Views.php
@@ -830,6 +830,12 @@ class Views extends CompositeBase
             $collection->replaceOne(['_id' => $generatedView['_id']], $generatedView, ['upsert' => true]);
         } catch (BulkWriteException $e) {
             if ($this->isDuplicateKeyError($e)) {
+                $existingView = $collection->findOne(['_id' => $generatedView['_id']]);
+                $this->getLogger()->warning('Duplicate key error when upserting generated view, retrying.', [
+                    'error' => $e,
+                    'generatedView' => $generatedView,
+                    'existingView' => $existingView,
+                ]);
                 $collection->replaceOne(['_id' => $generatedView['_id']], $generatedView, ['upsert' => false]);
             } else {
                 throw $e;

--- a/src/mongo/delegates/Views.php
+++ b/src/mongo/delegates/Views.php
@@ -4,7 +4,9 @@ namespace Tripod\Mongo\Composites;
 
 use MongoDB\BSON\UTCDateTime;
 use MongoDB\Collection;
+use MongoDB\Driver\Exception\BulkWriteException;
 use MongoDB\Driver\ReadPreference;
+use Tripod\Config;
 use Tripod\Exceptions\ViewException;
 use Tripod\ITripodStat;
 use Tripod\Mongo\DateUtil;
@@ -31,7 +33,7 @@ class Views extends CompositeBase
         $this->collection = $collection;
         $this->podName = $collection->getCollectionName();
         $this->defaultContext = $defaultContext;
-        $this->config = $this->getConfigInstance();
+        $this->config = Config::getInstance();
         $this->stat = $stat;
         $this->readPreference = $readPreference;
     }
@@ -499,7 +501,7 @@ class Views extends CompositeBase
 
                 $generatedView['value'] = $value;
 
-                $collection->replaceOne(['_id' => $generatedView['_id']], $generatedView, ['upsert' => true]);
+                $this->upsertGeneratedView($collection, $generatedView);
             }
         }
 
@@ -820,5 +822,23 @@ class Views extends CompositeBase
         }
 
         return $from;
+    }
+
+    private function upsertGeneratedView(Collection $collection, array $generatedView): void
+    {
+        try {
+            $collection->replaceOne(['_id' => $generatedView['_id']], $generatedView, ['upsert' => true]);
+        } catch (BulkWriteException $e) {
+            if ($this->isDuplicateKeyError($e)) {
+                $collection->replaceOne(['_id' => $generatedView['_id']], $generatedView, ['upsert' => false]);
+            } else {
+                throw $e;
+            }
+        }
+    }
+
+    private function isDuplicateKeyError(BulkWriteException $error): bool
+    {
+        return $error->getCode() === 11000 || strpos($error->getMessage(), 'E11000') !== false;
     }
 }

--- a/src/mongo/providers/MongoSearchProvider.php
+++ b/src/mongo/providers/MongoSearchProvider.php
@@ -402,6 +402,13 @@ class MongoSearchProvider implements ISearchProvider
             );
         } catch (BulkWriteException $e) {
             if ($this->isDuplicateKeyError($e)) {
+                $existingDocument = $collection->findOne(['_id' => $document['_id']]);
+                $this->tripod->getLogger()->warning('Duplicate key error when upserting generated table row, retrying.', [
+                    'error' => $e,
+                    'document' => $document,
+                    'existingDocument' => $existingDocument,
+                ]);
+
                 return $collection->updateOne(
                     ['_id' => $document['_id']],
                     ['$set' => $document],

--- a/src/mongo/providers/MongoSearchProvider.php
+++ b/src/mongo/providers/MongoSearchProvider.php
@@ -7,6 +7,8 @@ require_once TRIPOD_DIR . 'mongo/MongoTripodConstants.php';
 use MongoDB\BSON\Regex;
 use MongoDB\BSON\UTCDateTime;
 use MongoDB\Collection;
+use MongoDB\Driver\Exception\BulkWriteException;
+use MongoDB\UpdateResult;
 use Tripod\Exceptions\SearchException;
 use Tripod\ISearchProvider;
 use Tripod\Timer;
@@ -61,7 +63,7 @@ class MongoSearchProvider implements ISearchProvider
         }
 
         try {
-            $result = $collection->updateOne(['_id' => $document['_id']], ['$set' => $document], ['upsert' => true]);
+            $result = $this->upsertDocument($collection, $document);
             if (!$result->isAcknowledged()) {
                 throw new SearchException('Inserting search document not acknowledged');
             }
@@ -388,5 +390,31 @@ class MongoSearchProvider implements ISearchProvider
     protected function getCollectionForSearchSpec($searchSpecId)
     {
         return $this->config->getCollectionForSearchDocument($this->storeName, $searchSpecId);
+    }
+
+    private function upsertDocument(Collection $collection, array $document): UpdateResult
+    {
+        try {
+            return $collection->updateOne(
+                ['_id' => $document['_id']],
+                ['$set' => $document],
+                ['upsert' => true],
+            );
+        } catch (BulkWriteException $e) {
+            if ($this->isDuplicateKeyError($e)) {
+                return $collection->updateOne(
+                    ['_id' => $document['_id']],
+                    ['$set' => $document],
+                    ['upsert' => false],
+                );
+            }
+
+            throw $e;
+        }
+    }
+
+    private function isDuplicateKeyError(BulkWriteException $error): bool
+    {
+        return $error->getCode() === 11000 || strpos($error->getMessage(), 'E11000') !== false;
     }
 }

--- a/test/unit/mongo/MongoSearchProviderTest.php
+++ b/test/unit/mongo/MongoSearchProviderTest.php
@@ -3,7 +3,9 @@
 use MongoDB\BSON\UTCDateTime;
 use MongoDB\Collection;
 use MongoDB\DeleteResult;
+use MongoDB\Driver\Exception\BulkWriteException;
 use MongoDB\Driver\Manager;
+use MongoDB\UpdateResult;
 use Tripod\Config;
 use Tripod\Exceptions\ConfigException;
 use Tripod\Exceptions\SearchException;
@@ -319,6 +321,64 @@ class MongoSearchProviderTest extends MongoTripodTestBase
             'r' => 'http://talisaspire.com/resources/doc1',
             'c' => 'http://talisaspire.com/',
             'type' => 'i_search_resource',
+        ]);
+    }
+
+    public function testSearchIndexingIsRetriedOnDuplicateKeyError()
+    {
+        $collection = $this->getMockBuilder(Collection::class)
+            ->onlyMethods(['updateOne'])
+            ->setConstructorArgs([new Manager(), 'db', 'coll'])
+            ->getMock();
+
+        $invokedCount = $this->atLeast(2);
+        $collection->expects($invokedCount)->method('updateOne')
+            ->willReturnCallback(function ($filter, $doc, $options) use ($invokedCount) {
+                static $prevFilter;
+                static $prevDoc;
+
+                // Fail the first time with a duplicate key error
+                if ($invokedCount->getInvocationCount() === 1) {
+                    $prevFilter = $filter;
+                    $prevDoc = $doc;
+                    $this->assertSame(['upsert' => true], $options);
+
+                    throw new BulkWriteException('E11000 duplicate key error', 11000);
+                }
+
+                // On the second attempt, we should be trying to update the same document, but with upsert false
+                if ($invokedCount->getInvocationCount() === 2) {
+                    $this->assertSame($prevFilter, $filter);
+                    $this->assertSame($prevDoc, $doc);
+                    $this->assertSame(['upsert' => false], $options);
+                }
+
+                $mockUpdate = $this->createMock(UpdateResult::class);
+                $mockUpdate->method('isAcknowledged')->willReturn(true);
+
+                return $mockUpdate;
+            });
+
+        $configInstance = $this->getMockBuilder(TripodTestConfig::class)
+            ->onlyMethods(['getCollectionForSearchDocument'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $configInstance->loadConfig(Config::getConfig());
+        $configInstance->method('getCollectionForSearchDocument')->willReturn($collection);
+
+        $searchProviderReflection = new ReflectionClass(MongoSearchProvider::class);
+        $searchProviderConfigProperty = $searchProviderReflection->getProperty('config');
+        $searchProviderConfigProperty->setAccessible(true);
+        $searchProviderConfigProperty->setValue($this->searchProvider, $configInstance);
+
+        $this->searchProvider->indexDocument([
+            '_id' => ['r' => 'http://talisaspire.com/resources/doc1', 'c' => 'http://talisaspire.com/', 'type' => 'i_search_resource'],
+            'result' => ['title' => 'Physics for Engineers and Scientists', 'link' => 'http://talisaspire.com/resources/doc1', 'author' => 'Sayid Jarrah'],
+            'search_terms' => ['physics for engineers and scientists', 'physics', 'science', 'sayid jarrah'],
+            '_impactIndex' => [
+                ['r' => 'http://talisaspire.com/resources/doc1', 'c' => 'http://talisaspire.com/'],
+                ['r' => 'http://talisaspire.com/authors/1', 'c' => 'http://talisaspire.com/'],
+            ],
         ]);
     }
 

--- a/test/unit/mongo/MongoSearchProviderTest.php
+++ b/test/unit/mongo/MongoSearchProviderTest.php
@@ -327,7 +327,7 @@ class MongoSearchProviderTest extends MongoTripodTestBase
     public function testSearchIndexingIsRetriedOnDuplicateKeyError()
     {
         $collection = $this->getMockBuilder(Collection::class)
-            ->onlyMethods(['updateOne'])
+            ->onlyMethods(['updateOne', 'findOne'])
             ->setConstructorArgs([new Manager(), 'db', 'coll'])
             ->getMock();
 
@@ -358,6 +358,11 @@ class MongoSearchProviderTest extends MongoTripodTestBase
 
                 return $mockUpdate;
             });
+        $collection->method('findOne')->willReturn(['_id' => [
+            'r' => 'http://talisaspire.com/resources/doc1',
+            'c' => 'http://talisaspire.com/',
+            'type' => 'i_search_resource',
+        ]]);
 
         $configInstance = $this->getMockBuilder(TripodTestConfig::class)
             ->onlyMethods(['getCollectionForSearchDocument'])

--- a/test/unit/mongo/MongoTripodTablesTest.php
+++ b/test/unit/mongo/MongoTripodTablesTest.php
@@ -14,6 +14,7 @@ use Tripod\ExtendedGraph;
 use Tripod\Mongo\Documents\Tables;
 use Tripod\Mongo\Driver;
 use Tripod\Mongo\ImpactedSubject;
+use Tripod\Mongo\IndexUtils;
 use Tripod\Mongo\Labeller;
 use Tripod\Mongo\MongoGraph;
 use Tripod\Mongo\TransactionLog;
@@ -713,6 +714,9 @@ class MongoTripodTablesTest extends MongoTripodTestBase
      */
     public function testGenerateTableRowsTruncatesFieldsTooLargeToIndex()
     {
+        $indexUtils = new IndexUtils();
+        $indexUtils->ensureIndexes(false, $this->tripod->getStoreName(), false);
+
         $fullTitle = 'Mahommah Gardo Baquaqua. Biography of Mahommah G. Baquaqua, a Native of Zoogoo, in the Interior of Africa. (A Convert to Christianity,) With a Description of That Part of the World; Including the Manners and Customs of the Inhabitants, Their Religious Notions, Form of Government, Laws, Appearance of the Country, Buildings, Agriculture, Manufactures, Shepherds and Herdsmen, Domestic Animals, Marriage Ceremonials, Funeral Services, Styles of Dress, Trade and Commerce, Modes of Warfare, System of Slavery, &amp;c., &amp;c. Mahommah&#039;s Early Life, His Education, His Capture and Slavery in Western Africa and Brazil, His Escape to the United States, from Thence to Hayti, (the City of Port Au Prince,) His Reception by the Baptist Missionary There, The Rev. W. L. Judd; His Conversion to Christianity, Baptism, and Return to This Country, His Views, Objects and Aim. Written and Revised from His Own Words, by Samuel Moore, Esq., Late Publisher of the &quot;North of England Shipping Gazette,&quot; Author of Several Popular Works, and Editor of Sundry Reform Papers.';
         $truncatedTitle = substr($fullTitle, 0, 1007); // 1007 = 1024 - index name "value_title_1" + Randomness
         $fullTitleLength = strlen($fullTitle);

--- a/test/unit/mongo/MongoTripodTablesTest.php
+++ b/test/unit/mongo/MongoTripodTablesTest.php
@@ -4,8 +4,10 @@ use MongoDB\BSON\UTCDateTime;
 use MongoDB\Collection;
 use MongoDB\DeleteResult;
 use MongoDB\Driver\Cursor;
+use MongoDB\Driver\Exception\BulkWriteException;
 use MongoDB\Driver\Manager;
 use MongoDB\Model\BSONDocument;
+use MongoDB\UpdateResult;
 use Tripod\Config;
 use Tripod\Exceptions\ConfigException;
 use Tripod\ExtendedGraph;
@@ -274,6 +276,58 @@ class MongoTripodTablesTest extends MongoTripodTestBase
         $this->assertTrue(isset($result['type']), 'Result does not contain type');
         $this->assertTrue(isset($result['isbn']), 'Result does not contain isbn');
         $this->assertTrue(isset($result['isbn13']), 'Result does not contain isbn13');
+    }
+
+    public function testTableRowUpsertIsRetriedOnDuplicateKeyError()
+    {
+        $collection = $this->getMockBuilder(Collection::class)
+            ->onlyMethods(['updateOne'])
+            ->setConstructorArgs([new Manager(), 'db', 'coll'])
+            ->getMock();
+
+        $invokedCount = $this->atLeast(2);
+        $collection->expects($invokedCount)->method('updateOne')
+            ->willReturnCallback(function ($filter, $doc, $options) use ($invokedCount) {
+                static $prevFilter;
+                static $prevDoc;
+
+                // Fail the first time with a duplicate key error
+                if ($invokedCount->getInvocationCount() === 1) {
+                    $prevFilter = $filter;
+                    $prevDoc = $doc;
+                    $this->assertSame(['upsert' => true], $options);
+
+                    throw new BulkWriteException('E11000 duplicate key error', 11000);
+                }
+
+                // On the second attempt, we should be trying to update the same document, but with upsert false
+                if ($invokedCount->getInvocationCount() === 2) {
+                    $this->assertSame($prevFilter, $filter);
+                    $this->assertSame($prevDoc, $doc);
+                    $this->assertSame(['upsert' => false], $options);
+                }
+
+                return $this->createMock(UpdateResult::class);
+            });
+
+        $configInstance = $this->getMockBuilder(TripodTestConfig::class)
+            ->onlyMethods(['getCollectionForTable'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $configInstance->loadConfig(Config::getConfig());
+        $configInstance->method('getCollectionForTable')->willReturn($collection);
+
+        $tables = $this->getMockBuilder(Tripod\Mongo\Composites\Tables::class)
+            ->onlyMethods(['getConfigInstance'])
+            ->setConstructorArgs([
+                $this->tripod->getStoreName(),
+                $this->getTripodCollection($this->tripod),
+                'http://talisaspire.com/',
+            ])
+            ->getMock();
+        $tables->method('getConfigInstance')->willReturn($configInstance);
+
+        $tables->generateTableRows('t_resource');
     }
 
     public function testBatchTableRowGeneration()

--- a/test/unit/mongo/MongoTripodTablesTest.php
+++ b/test/unit/mongo/MongoTripodTablesTest.php
@@ -282,7 +282,7 @@ class MongoTripodTablesTest extends MongoTripodTestBase
     public function testTableRowUpsertIsRetriedOnDuplicateKeyError()
     {
         $collection = $this->getMockBuilder(Collection::class)
-            ->onlyMethods(['updateOne'])
+            ->onlyMethods(['updateOne', 'findOne'])
             ->setConstructorArgs([new Manager(), 'db', 'coll'])
             ->getMock();
 
@@ -310,6 +310,12 @@ class MongoTripodTablesTest extends MongoTripodTestBase
 
                 return $this->createMock(UpdateResult::class);
             });
+        $collection->method('findOne')->willReturn(['_id' => [
+            'r' => 'http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA',
+            'c' => 'http://talisaspire.com/',
+            'type' => 't_resource',
+            'value' => ['test' => 'data'],
+        ]]);
 
         $configInstance = $this->getMockBuilder(TripodTestConfig::class)
             ->onlyMethods(['getCollectionForTable'])

--- a/test/unit/mongo/MongoTripodViewsTest.php
+++ b/test/unit/mongo/MongoTripodViewsTest.php
@@ -4,7 +4,9 @@ use MongoDB\BSON\UTCDateTime;
 use MongoDB\Collection;
 use MongoDB\Database;
 use MongoDB\DeleteResult;
+use MongoDB\Driver\Exception\BulkWriteException;
 use MongoDB\Driver\Manager;
+use MongoDB\UpdateResult;
 use PHPUnit\Framework\MockObject\MockObject;
 use Tripod\Config;
 use Tripod\ExtendedGraph;
@@ -2231,6 +2233,58 @@ class MongoTripodViewsTest extends MongoTripodTestBase
             ->will($this->returnValue($deleteResult));
 
         $this->assertEquals(30, $views->deleteViewsByViewId('v_resource_full', $timestamp));
+    }
+
+    public function testViewUpsertIsRetriedOnDuplicateKeyError()
+    {
+        $collection = $this->getMockBuilder(Collection::class)
+            ->onlyMethods(['replaceOne'])
+            ->setConstructorArgs([new Manager(), 'db', 'coll'])
+            ->getMock();
+
+        $invokedCount = $this->atLeast(2);
+        $collection->expects($invokedCount)->method('replaceOne')
+            ->willReturnCallback(function ($filter, $doc, $options) use ($invokedCount) {
+                static $prevFilter;
+                static $prevDoc;
+
+                // Fail the first time with a duplicate key error
+                if ($invokedCount->getInvocationCount() === 1) {
+                    $prevFilter = $filter;
+                    $prevDoc = $doc;
+                    $this->assertSame(['upsert' => true], $options);
+
+                    throw new BulkWriteException('E11000 duplicate key error', 11000);
+                }
+
+                // On the second attempt, we should be trying to update the same document, but with upsert false
+                if ($invokedCount->getInvocationCount() === 2) {
+                    $this->assertSame($prevFilter, $filter);
+                    $this->assertSame($prevDoc, $doc);
+                    $this->assertSame(['upsert' => false], $options);
+                }
+
+                return $this->createMock(UpdateResult::class);
+            });
+
+        $configInstance = $this->getMockBuilder(TripodTestConfig::class)
+            ->onlyMethods(['getCollectionForView'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $configInstance->loadConfig(Config::getConfig());
+        $configInstance->method('getCollectionForView')->willReturn($collection);
+
+        $views = $this->getMockBuilder(Views::class)
+            ->onlyMethods(['getConfigInstance'])
+            ->setConstructorArgs([
+                $this->tripod->getStoreName(),
+                $this->getTripodCollection($this->tripod),
+                'http://talisaspire.com/',
+            ])
+            ->getMock();
+        $views->method('getConfigInstance')->willReturn($configInstance);
+
+        $views->generateView('v_resource_full_ttl', 'http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA');
     }
 
     public function testBatchViewGeneration()

--- a/test/unit/mongo/MongoTripodViewsTest.php
+++ b/test/unit/mongo/MongoTripodViewsTest.php
@@ -2238,7 +2238,7 @@ class MongoTripodViewsTest extends MongoTripodTestBase
     public function testViewUpsertIsRetriedOnDuplicateKeyError()
     {
         $collection = $this->getMockBuilder(Collection::class)
-            ->onlyMethods(['replaceOne'])
+            ->onlyMethods(['replaceOne', 'findOne'])
             ->setConstructorArgs([new Manager(), 'db', 'coll'])
             ->getMock();
 
@@ -2266,6 +2266,12 @@ class MongoTripodViewsTest extends MongoTripodTestBase
 
                 return $this->createMock(UpdateResult::class);
             });
+        $collection->method('findOne')->willReturn(['_id' => [
+            'r' => 'http://talisaspire.com/resources/3SplCtWGPqEyXcDiyhHQpA',
+            'c' => 'http://talisaspire.com/',
+            'type' => 'v_resource_full_ttl',
+            'value' => ['test' => 'data'],
+        ]]);
 
         $configInstance = $this->getMockBuilder(TripodTestConfig::class)
             ->onlyMethods(['getCollectionForView'])


### PR DESCRIPTION
- Retry composite upserts
  - Concurrent upserts may encounter `E11000 duplicate key error collection`; since the model was always "last writer wins", we're going to simply retry those writes but as regular updates next time.
- Fix table row truncating
  - Update error message so it can match one returned by WiredTiger.
  - Ensure indexes under test so an error is thrown.