### PR TITLE
Soft strict type

### DIFF
--- a/src/IDriver.php
+++ b/src/IDriver.php
@@ -23,7 +23,7 @@ interface IDriver
      * @param string      $resource uri resource you'd like to describe
      * @param string|null $context  string uri of the context, or named graph, you'd like to describe from
      */
-    public function describeResource(string $resource, ?string $context = null): ExtendedGraph;
+    public function describeResource($resource, $context = null): ExtendedGraph;
 
     /**
      * Return (DESCRIBE) the concise bound descriptions of a bunch of resources.
@@ -31,7 +31,7 @@ interface IDriver
      * @param array       $resources uris of resources you'd like to describe
      * @param string|null $context   string uri of the context, or named graph, you'd like to describe from
      */
-    public function describeResources(array $resources, ?string $context = null): ExtendedGraph;
+    public function describeResources(array $resources, $context = null): ExtendedGraph;
 
     /**
      * Get a view of a given type for a given resource.
@@ -39,7 +39,7 @@ interface IDriver
      * @param string|null $resource uri of the resource you'd like the view for
      * @param string      $viewType string type of view
      */
-    public function getViewForResource(?string $resource, string $viewType): ExtendedGraph;
+    public function getViewForResource($resource, $viewType): ExtendedGraph;
 
     /**
      * Get views for multiple resources in one graph.
@@ -47,7 +47,7 @@ interface IDriver
      * @param string[] $resources uris of resources you'd like to describe
      * @param string   $viewType  type of view
      */
-    public function getViewForResources(array $resources, string $viewType): ExtendedGraph;
+    public function getViewForResources(array $resources, $viewType): ExtendedGraph;
 
     /**
      * Get views based on a pattern-match $filter.
@@ -55,17 +55,21 @@ interface IDriver
      * @param array  $filter   pattern to match to select views
      * @param string $viewType type of view
      */
-    public function getViews(array $filter, string $viewType): ExtendedGraph;
+    public function getViews(array $filter, $viewType): ExtendedGraph;
 
     /**
      * Returns the etag of a resource, useful for caching.
+     *
+     * @param string      $resource
+     * @param string|null $context
      */
-    public function getETag(string $resource, ?string $context = null): string;
+    public function getETag($resource, $context = null): string;
 
     /**
      * Select data in a tabular format.
      *
-     * @param array<string, mixed> $fields array of fields, in the same format as prescribed by MongoPHP
+     * @param array<string, mixed> $fields  array of fields, in the same format as prescribed by MongoPHP
+     * @param string|null          $context
      */
     public function select(
         array $query,
@@ -73,14 +77,16 @@ interface IDriver
         ?array $sortBy = null,
         ?int $limit = null,
         ?int $offset = 0,
-        ?string $context = null
+        $context = null
     ): array;
 
     /**
      * Select data from a table.
+     *
+     * @param string $tableType
      */
     public function getTableRows(
-        string $tableType,
+        $tableType,
         array $filter = [],
         ?array $sortBy = [],
         ?int $offset = 0,
@@ -88,23 +94,31 @@ interface IDriver
         array $options = []
     ): array;
 
-    public function getDistinctTableColumnValues(string $tableType, string $fieldName, array $filter = []): array;
+    /**
+     * @param string $tableType
+     * @param string $fieldName
+     */
+    public function getDistinctTableColumnValues($tableType, $fieldName, array $filter = []): array;
 
     /**
      * Get a count of resources matching the pattern in $query. Optionally group counts by specifying a $groupBy predicate.
      *
-     * @param int|null $ttl acceptable time to live if you're willing to accept a cached version of this request
+     * @param string|null $groupBy
+     * @param int|null    $ttl     acceptable time to live if you're willing to accept a cached version of this request
      *
      * @return array|int multidimensional array with int values if grouped by, otherwise int
      */
-    public function getCount(array $query, ?string $groupBy = null, ?int $ttl = null);
+    public function getCount(array $query, $groupBy = null, ?int $ttl = null);
 
     /**
      * Save the changes between $oldGraph -> $newGraph.
      *
+     * @param string|null $context
+     * @param string|null $description
+     *
      * @return bool true or throws exception on error
      */
-    public function saveChanges(ExtendedGraph $oldGraph, ExtendedGraph $newGraph, ?string $context = null, ?string $description = null): bool;
+    public function saveChanges(ExtendedGraph $oldGraph, ExtendedGraph $newGraph, $context = null, $description = null): bool;
 
     /**
      * Register an event hook, which will be executed when the event fires.
@@ -125,9 +139,13 @@ interface IDriver
     /**
      * Generates table rows.
      *
+     * @param string      $tableType
+     * @param string|null $resource
+     * @param string|null $context
+     *
      * @deprecated calling save will generate table rows - this method seems to be only used in tests and does not belong on the interface
      */
-    public function generateTableRows(string $tableType, ?string $resource = null, ?string $context = null): void;
+    public function generateTableRows($tableType, $resource = null, $context = null): void;
 
     /**
      * Submits search params to configured search provider
@@ -161,16 +179,19 @@ interface IDriver
      *
      * @return array of locked documents
      */
-    public function getLockedDocuments(?string $fromDateTime = null, ?string $tillDateTime = null): array;
+    public function getLockedDocuments($fromDateTime = null, $tillDateTime = null): array;
 
     /**
      * Remove any inert locks left by a given transaction.
      *
      * @deprecated this is a feature of the mongo implementation - this method will move from the interface to the mongo-specific Driver class soon
      *
+     * @param string $transaction_id
+     * @param string $reason
+     *
      * @return bool true or throws exception on error
      */
-    public function removeInertLocks(string $transaction_id, string $reason): bool;
+    public function removeInertLocks($transaction_id, $reason): bool;
 
     // END Deprecated methods that will be removed in 1.x.x
 }

--- a/src/classes/ChangeSet.php
+++ b/src/classes/ChangeSet.php
@@ -196,8 +196,11 @@ class ChangeSet extends ExtendedGraph
      *
      * @author Keith
      */
-    public function addT(string $s, string $p, $o, $o_type = 'bnode'): void
+    public function addT($s, $p, $o, $o_type = 'bnode'): void
     {
+        $s = TypeUtil::ensureArgIsString(1, $s);
+        $p = TypeUtil::ensureArgIsString(2, $p);
+
         if (is_array($o) && isset($o[0]['type'])) {
             foreach ($o as $obj) {
                 $this->addT($s, $p, $obj);

--- a/src/classes/ExtendedGraph.php
+++ b/src/classes/ExtendedGraph.php
@@ -127,8 +127,11 @@ class ExtendedGraph
      * @param string $prefix the namespace prefix to associate with the URI
      * @param string $uri    the URI to associate with the prefix
      */
-    public function set_namespace_mapping(string $prefix, string $uri): void
+    public function set_namespace_mapping($prefix, $uri): void
     {
+        $prefix = TypeUtil::ensureArgIsString(1, $prefix);
+        $uri = TypeUtil::ensureArgIsString(2, $uri);
+
         $this->_labeller->set_namespace_mapping($prefix, $uri);
     }
 
@@ -139,8 +142,10 @@ class ExtendedGraph
      *
      * @return string|null the URI corresponding to the QName if a suitable prefix exists, null otherwise
      */
-    public function qname_to_uri(?string $qName): ?string
+    public function qname_to_uri($qName): ?string
     {
+        $qName = TypeUtil::ensureArgIsStringIsOrNull(1, $qName);
+
         return $this->_labeller->qname_to_uri($qName);
     }
 
@@ -151,18 +156,30 @@ class ExtendedGraph
      *
      * @return string|null the QName corresponding to the URI if a suitable prefix exists, null otherwise
      */
-    public function uri_to_qname(?string $uri): ?string
+    public function uri_to_qname($uri): ?string
     {
+        $uri = TypeUtil::ensureArgIsStringIsOrNull(1, $uri);
+
         return $this->_labeller->uri_to_qname($uri);
     }
 
-    public function get_prefix(string $ns): string
+    /**
+     * @param string $ns
+     */
+    public function get_prefix($ns): string
     {
+        $ns = TypeUtil::ensureArgIsString(1, $ns);
+
         return $this->_labeller->get_prefix($ns);
     }
 
-    public function add_labelling_property(string $p): void
+    /**
+     * @param string $p
+     */
+    public function add_labelling_property($p): void
     {
+        $p = TypeUtil::ensureArgIsString(1, $p);
+
         $this->_labeller->add_labelling_property($p);
     }
 
@@ -173,8 +190,10 @@ class ExtendedGraph
      *
      * @return array<string, string> an associative array with two keys: 'type' and 'value'. Type is either bnode or uri
      */
-    public function make_resource_array(string $resource): array
+    public function make_resource_array($resource): array
     {
+        $resource = TypeUtil::ensureArgIsString(1, $resource);
+
         $resource_type = strpos($resource, '_:') === 0 ? 'bnode' : 'uri';
 
         return ['type' => $resource_type, 'value' => $resource];
@@ -209,8 +228,13 @@ class ExtendedGraph
      *
      * @return bool true if the triple was new, false if it already existed in the graph
      */
-    public function add_literal_triple(string $s, string $p, $o, ?string $lang = null, ?string $dt = null): bool
+    public function add_literal_triple($s, $p, $o, $lang = null, $dt = null): bool
     {
+        $s = TypeUtil::ensureArgIsString(1, $s);
+        $p = TypeUtil::ensureArgIsString(2, $p);
+        $lang = TypeUtil::ensureArgIsStringIsOrNull(4, $lang);
+        $dt = TypeUtil::ensureArgIsStringIsOrNull(5, $dt);
+
         if ($this->isValidLiteral($o)) {
             $o_info = ['type' => 'literal', 'value' => $o];
             if ($lang != null) {
@@ -422,14 +446,18 @@ class ExtendedGraph
     /**
      * Fetch the first literal value for a given subject and predicate. If there are multiple possible values then one is selected at random.
      *
-     * @param TripleSubject                     $s       the subject to search for
-     * @param TriplePredicate|TriplePredicate[] $p       the predicate to search for, or an array of predicates
-     * @param ObjectLiteral|null                $default a default value to use if no literal values are found
+     * @param TripleSubject                     $s                  the subject to search for
+     * @param TriplePredicate|TriplePredicate[] $p                  the predicate to search for, or an array of predicates
+     * @param ObjectLiteral|null                $default            a default value to use if no literal values are found
+     * @param mixed|null                        $preferred_language
      *
      * @return ObjectLiteral|null the first literal value found or the supplied default if no values were found
      */
-    public function get_first_literal(string $s, $p, $default = null, ?string $preferred_language = null)
+    public function get_first_literal($s, $p, $default = null, $preferred_language = null)
     {
+        $s = TypeUtil::ensureArgIsString(1, $s);
+        $preferred_language = TypeUtil::ensureArgIsStringIsOrNull(4, $preferred_language);
+
         $best_literal = $default;
         if (isset($this->_index[$s])) {
             if (is_array($p)) {
@@ -479,8 +507,12 @@ class ExtendedGraph
      *
      * @return ObjectResource|null the first resource value found or the supplied default if no values were found
      */
-    public function get_first_resource(string $s, string $p, ?string $default = null): ?string
+    public function get_first_resource($s, $p, $default = null): ?string
     {
+        $s = TypeUtil::ensureArgIsString(1, $s);
+        $p = TypeUtil::ensureArgIsString(2, $p);
+        $default = TypeUtil::ensureArgIsStringIsOrNull(3, $default);
+
         if (isset($this->_index[$s][$p])) {
             foreach ($this->_index[$s][$p] as $value) {
                 if ($value['type'] == 'uri' || $value['type'] == 'bnode') {
@@ -499,8 +531,11 @@ class ExtendedGraph
      * @param TriplePredicate $p the predicate URI of the triple
      * @param ObjectResource  $o the object of the triple, either a URI or a blank node in the format _:name
      */
-    public function remove_resource_triple(string $s, string $p, $o): void
+    public function remove_resource_triple($s, $p, $o): void
     {
+        $s = TypeUtil::ensureArgIsString(1, $s);
+        $p = TypeUtil::ensureArgIsString(2, $p);
+
         // Already removed
         if (!isset($this->_index[$s]) || !isset($this->_index[$s][$p])) {
             return;
@@ -522,10 +557,15 @@ class ExtendedGraph
     }
 
     /**
+     * @param string        $s
+     * @param string        $p
      * @param ObjectLiteral $o
      */
-    public function remove_literal_triple(string $s, string $p, $o): void
+    public function remove_literal_triple($s, $p, $o): void
     {
+        $s = TypeUtil::ensureArgIsString(1, $s);
+        $p = TypeUtil::ensureArgIsString(2, $p);
+
         // Already removed
         if (!isset($this->_index[$s]) || !isset($this->_index[$s][$p])) {
             return;
@@ -551,8 +591,10 @@ class ExtendedGraph
      *
      * @param TripleSubject $s the subject of the triple, either a URI or a blank node in the format _:name
      */
-    public function remove_triples_about(string $s): void
+    public function remove_triples_about($s): void
     {
+        $s = TypeUtil::ensureArgIsString(1, $s);
+
         unset($this->_index[$s]);
     }
 
@@ -562,8 +604,11 @@ class ExtendedGraph
      * @param string $rdfxml the RDF/XML to parse
      * @param string $base   the base URI against which relative URIs in the RDF/XML document will be resolved
      */
-    public function from_rdfxml(string $rdfxml, string $base = ''): void
+    public function from_rdfxml($rdfxml, $base = ''): void
     {
+        $rdfxml = TypeUtil::ensureArgIsString(1, $rdfxml);
+        $base = TypeUtil::ensureArgIsString(2, $base);
+
         if ($rdfxml !== '' && $rdfxml !== '0') {
             $this->remove_all_triples();
             $this->add_rdfxml($rdfxml, $base);
@@ -577,8 +622,10 @@ class ExtendedGraph
      *
      * @param string $json the JSON to parse
      */
-    public function from_json(string $json): void
+    public function from_json($json): void
     {
+        $json = TypeUtil::ensureArgIsString(1, $json);
+
         if ($json !== '' && $json !== '0') {
             $this->remove_all_triples();
             $index = json_decode($json, true);
@@ -595,8 +642,10 @@ class ExtendedGraph
      *
      * @param string $json the JSON to parse
      */
-    public function add_json(string $json): void
+    public function add_json($json): void
     {
+        $json = TypeUtil::ensureArgIsString(1, $json);
+
         if ($json !== '' && $json !== '0') {
             $json_index = json_decode($json, true);
             if (is_array($json_index)) {
@@ -618,8 +667,11 @@ class ExtendedGraph
      *
      * @author Keith Alexander
      */
-    public function add_rdf(string $rdf, string $base = ''): void
+    public function add_rdf($rdf, $base = ''): void
     {
+        $rdf = TypeUtil::ensureArgIsString(1, $rdf);
+        $base = TypeUtil::ensureArgIsString(2, $base);
+
         $trimRdf = trim($rdf);
         if ($trimRdf[0] == '{') { // lazy is-this-json assessment  - might be better to try json_decode - but more costly
             $this->add_json($trimRdf);
@@ -645,8 +697,11 @@ class ExtendedGraph
      * @param string $rdfxml the RDF/XML to parse
      * @param string $base   the base URI against which relative URIs in the RDF/XML document will be resolved
      */
-    public function add_rdfxml(string $rdfxml, string $base = ''): void
+    public function add_rdfxml($rdfxml, $base = ''): void
     {
+        $rdfxml = TypeUtil::ensureArgIsString(1, $rdfxml);
+        $base = TypeUtil::ensureArgIsString(2, $base);
+
         if ($rdfxml !== '' && $rdfxml !== '0') {
             /** @var \ARC2_RDFXMLParser $parser */
             $parser = \ARC2::getRDFXMLParser();
@@ -665,8 +720,11 @@ class ExtendedGraph
      * @param string $turtle the Turtle to parse
      * @param string $base   the base URI against which relative URIs in the Turtle document will be resolved
      */
-    public function from_turtle(string $turtle, string $base = ''): void
+    public function from_turtle($turtle, $base = ''): void
     {
+        $turtle = TypeUtil::ensureArgIsString(1, $turtle);
+        $base = TypeUtil::ensureArgIsString(2, $base);
+
         if ($turtle !== '' && $turtle !== '0') {
             $this->remove_all_triples();
             $this->add_turtle($turtle, $base);
@@ -681,8 +739,11 @@ class ExtendedGraph
      * @param string $turtle the Turtle to parse
      * @param string $base   the base URI against which relative URIs in the Turtle document will be resolved
      */
-    public function add_turtle(string $turtle, string $base = ''): void
+    public function add_turtle($turtle, $base = ''): void
     {
+        $turtle = TypeUtil::ensureArgIsString(1, $turtle);
+        $base = TypeUtil::ensureArgIsString(2, $base);
+
         if ($turtle !== '' && $turtle !== '0') {
             /** @var \ARC2_TurtleParser $parser */
             $parser = \ARC2::getTurtleParser();
@@ -699,8 +760,11 @@ class ExtendedGraph
      * @param string $html the HTML containing RDFa to parse
      * @param string $base the base URI against which relative URIs in the RDFa document will be resolved
      */
-    public function from_rdfa(string $html, string $base = ''): void
+    public function from_rdfa($html, $base = ''): void
     {
+        $html = TypeUtil::ensureArgIsString(1, $html);
+        $base = TypeUtil::ensureArgIsString(2, $base);
+
         if ($html !== '' && $html !== '0') {
             $this->remove_all_triples();
             $this->add_rdfa($html, $base);
@@ -713,8 +777,11 @@ class ExtendedGraph
      * @param string $html the HTML containing RDFa to parse
      * @param string $base the base URI against which relative URIs in the RDFa document will be resolved
      */
-    public function add_rdfa(string $html, string $base = ''): void
+    public function add_rdfa($html, $base = ''): void
     {
+        $html = TypeUtil::ensureArgIsString(1, $html);
+        $base = TypeUtil::ensureArgIsString(2, $base);
+
         if ($html !== '' && $html !== '0') {
             /** @var \ARC2_SemHTMLParser $parser */
             $parser = \ARC2::getSemHTMLParser();
@@ -757,8 +824,11 @@ class ExtendedGraph
      *
      * @return bool true if the triple exists in the graph, false otherwise
      */
-    public function has_resource_triple(string $s, string $p, $o): bool
+    public function has_resource_triple($s, $p, $o): bool
     {
+        $s = TypeUtil::ensureArgIsString(1, $s);
+        $p = TypeUtil::ensureArgIsString(2, $p);
+
         if (isset($this->_index[$s][$p])) {
             foreach ($this->_index[$s][$p] as $value) {
                 if (($value['type'] == 'uri' || $value['type'] == 'bnode') && $value['value'] === $o) {
@@ -781,8 +851,13 @@ class ExtendedGraph
      *
      * @return bool true if the triple exists in the graph, false otherwise
      */
-    public function has_literal_triple(string $s, string $p, $o, ?string $lang = null, ?string $dt = null): bool
+    public function has_literal_triple($s, $p, $o, $lang = null, $dt = null): bool
     {
+        $s = TypeUtil::ensureArgIsString(1, $s);
+        $p = TypeUtil::ensureArgIsString(2, $p);
+        $lang = TypeUtil::ensureArgIsStringIsOrNull(4, $lang);
+        $dt = TypeUtil::ensureArgIsStringIsOrNull(5, $dt);
+
         if (isset($this->_index[$s][$p])) {
             foreach ($this->_index[$s][$p] as $value) {
                 if (($value['type'] == 'literal') && $value['value'] === $o) {
@@ -810,8 +885,11 @@ class ExtendedGraph
      *
      * @return ObjectResource[] list of URIs and blank nodes that are the objects of triples with the supplied subject and predicate
      */
-    public function get_resource_triple_values(string $s, string $p): array
+    public function get_resource_triple_values($s, $p): array
     {
+        $s = TypeUtil::ensureArgIsString(1, $s);
+        $p = TypeUtil::ensureArgIsString(2, $p);
+
         $values = [];
         if (isset($this->_index[$s][$p])) {
             foreach ($this->_index[$s][$p] as $value) {
@@ -832,8 +910,10 @@ class ExtendedGraph
      *
      * @return ObjectLiteral[] list of literals that are the objects of triples with the supplied subject and predicate
      */
-    public function get_literal_triple_values(string $s, $p): array
+    public function get_literal_triple_values($s, $p): array
     {
+        $s = TypeUtil::ensureArgIsString(1, $s);
+
         $values = [];
         if (isset($this->_index[$s])) {
             if (is_array($p)) {
@@ -866,8 +946,10 @@ class ExtendedGraph
      *
      * @return TripleObject[] list of values of triples with the supplied subject and predicate
      */
-    public function get_subject_property_values(string $s, $p): array
+    public function get_subject_property_values($s, $p): array
     {
+        $s = TypeUtil::ensureArgIsString(1, $s);
+
         $values = [];
         if (!is_array($p)) {
             $p = [$p];
@@ -893,8 +975,10 @@ class ExtendedGraph
      *
      * @return ExtendedGraph triples with the supplied subject
      */
-    public function get_subject_subgraph(string $s): ExtendedGraph
+    public function get_subject_subgraph($s): ExtendedGraph
     {
+        $s = TypeUtil::ensureArgIsString(1, $s);
+
         $sub = new ExtendedGraph();
         if (isset($this->_index[$s])) {
             $sub->_index[$s] = $this->_index[$s];
@@ -918,8 +1002,10 @@ class ExtendedGraph
      *
      * @param ObjectResource $o the type to match
      */
-    public function get_subjects_of_type(string $o): array
+    public function get_subjects_of_type($o): array
     {
+        $o = TypeUtil::ensureArgIsString(1, $o);
+
         return $this->get_subjects_where_resource('http://www.w3.org/1999/02/22-rdf-syntax-ns#type', $o);
     }
 
@@ -929,8 +1015,11 @@ class ExtendedGraph
      * @param TriplePredicate $p the predicate to match
      * @param ObjectResource  $o the resource object to match
      */
-    public function get_subjects_where_resource(string $p, string $o): array
+    public function get_subjects_where_resource($p, $o): array
     {
+        $p = TypeUtil::ensureArgIsString(1, $p);
+        $o = TypeUtil::ensureArgIsString(2, $o);
+
         return array_merge($this->get_subjects_where($p, $o, 'uri'), $this->get_subjects_where($p, $o, 'bnode'));
     }
 
@@ -940,8 +1029,10 @@ class ExtendedGraph
      * @param TriplePredicate $p the predicate to match
      * @param ObjectValue     $o the literal object to match
      */
-    public function get_subjects_where_literal(string $p, $o): array
+    public function get_subjects_where_literal($p, $o): array
     {
+        $p = TypeUtil::ensureArgIsString(1, $p);
+
         return $this->get_subjects_where($p, $o, 'literal');
     }
 
@@ -953,8 +1044,10 @@ class ExtendedGraph
      *
      * @return TriplePredicate[] list of property URIs
      */
-    public function get_subject_properties(string $s, bool $distinct = true): array
+    public function get_subject_properties($s, bool $distinct = true): array
     {
+        $s = TypeUtil::ensureArgIsString(1, $s);
+
         $values = [];
         if (isset($this->_index[$s])) {
             foreach ($this->_index[$s] as $prop => $prop_values) {
@@ -980,8 +1073,11 @@ class ExtendedGraph
      *
      * @return bool true if a matching triple exists in the graph, false otherwise
      */
-    public function subject_has_property(string $s, string $p): bool
+    public function subject_has_property($s, $p): bool
     {
+        $s = TypeUtil::ensureArgIsString(1, $s);
+        $p = TypeUtil::ensureArgIsString(2, $p);
+
         return isset($this->_index[$s][$p]);
     }
 
@@ -992,8 +1088,10 @@ class ExtendedGraph
      *
      * @return bool true if the graph contains any triples with the specified subject, false otherwise
      */
-    public function has_triples_about(string $s): bool
+    public function has_triples_about($s): bool
     {
+        $s = TypeUtil::ensureArgIsString(1, $s);
+
         return isset($this->_index[$s]);
     }
 
@@ -1003,8 +1101,11 @@ class ExtendedGraph
      * @param TripleSubject   $s the subject of the triple, either a URI or a blank node in the format _:name
      * @param TriplePredicate $p the predicate URI of the triple
      */
-    public function remove_property_values(string $s, string $p): void
+    public function remove_property_values($s, $p): void
     {
+        $s = TypeUtil::ensureArgIsString(1, $s);
+        $p = TypeUtil::ensureArgIsString(2, $p);
+
         unset($this->_index[$s][$p]);
     }
 
@@ -1026,21 +1127,34 @@ class ExtendedGraph
         return count($this->_index) === 0;
     }
 
-    public function get_label(string $resource_uri, bool $capitalize = false, bool $use_qnames = false): string
+    /**
+     * @param string $resource_uri
+     */
+    public function get_label($resource_uri, bool $capitalize = false, bool $use_qnames = false): string
     {
+        $resource_uri = TypeUtil::ensureArgIsString(1, $resource_uri);
+
         return $this->_labeller->get_label($resource_uri, $this, $capitalize, $use_qnames);
     }
 
-    public function get_inverse_label(string $resource_uri, bool $capitalize = false, bool $use_qnames = false): string
+    /**
+     * @param string $resource_uri
+     */
+    public function get_inverse_label($resource_uri, bool $capitalize = false, bool $use_qnames = false): string
     {
+        $resource_uri = TypeUtil::ensureArgIsString(1, $resource_uri);
+
         return $this->_labeller->get_inverse_label($resource_uri, $this, $capitalize, $use_qnames);
     }
 
     /**
      * @param TripleGraph $resources
+     * @param string      $nodeID_prefix
      */
-    public function reify(array $resources, string $nodeID_prefix = 'Statement'): array
+    public function reify(array $resources, $nodeID_prefix = 'Statement'): array
     {
+        $nodeID_prefix = TypeUtil::ensureArgIsString(2, $nodeID_prefix);
+
         $RDF = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#';
         $reified = [];
         $statement_no = 1;
@@ -1192,8 +1306,15 @@ class ExtendedGraph
         return $current;
     }
 
-    public function replace_resource(string $look_for, string $replace_with): void
+    /**
+     * @param string $look_for
+     * @param string $replace_with
+     */
+    public function replace_resource($look_for, $replace_with): void
     {
+        $look_for = TypeUtil::ensureArgIsString(1, $look_for);
+        $replace_with = TypeUtil::ensureArgIsString(2, $replace_with);
+
         $remove_list_resources = [];
         $remove_list_literals = [];
         $add_list_resources = [];
@@ -1279,8 +1400,13 @@ class ExtendedGraph
         }
     }
 
-    public function get_list_values(string $listUri): array
+    /**
+     * @param string $listUri
+     */
+    public function get_list_values($listUri): array
     {
+        $listUri = TypeUtil::ensureArgIsString(1, $listUri);
+
         $array = [];
         while (!empty($listUri) && $listUri !== RDF_NIL) {
             $array[] = $this->get_first_resource($listUri, RDF_FIRST);
@@ -1302,9 +1428,15 @@ class ExtendedGraph
 
     /**
      * Replaces $uri1 with $uri2 in subject, predicate and object position.
+     *
+     * @param string $uri1
+     * @param string $uri2
      */
-    public function replace_uris(string $uri1, string $uri2): void
+    public function replace_uris($uri1, $uri2): void
     {
+        $uri1 = TypeUtil::ensureArgIsString(1, $uri1);
+        $uri2 = TypeUtil::ensureArgIsString(2, $uri2);
+
         $index = $this->get_index();
         if (isset($index[$uri1])) {
             $index[$uri2] = $index[$uri1];
@@ -1335,8 +1467,11 @@ class ExtendedGraph
      * @param TriplePredicate|null $p
      * @param ObjectValue|null     $o
      */
-    public function get_triple_count(?string $s = null, ?string $p = null, $o = null): int
+    public function get_triple_count($s = null, $p = null, $o = null): int
     {
+        $s = TypeUtil::ensureArgIsStringIsOrNull(1, $s);
+        $p = TypeUtil::ensureArgIsStringIsOrNull(2, $p);
+
         $index = $this->get_index();
 
         if ($index === []) {
@@ -1386,8 +1521,10 @@ class ExtendedGraph
      *
      * @return ObjectResource[] the resource values found
      */
-    public function get_resources_for_subject(string $s): array
+    public function get_resources_for_subject($s): array
     {
+        $s = TypeUtil::ensureArgIsString(1, $s);
+
         $resources = [];
         if (isset($this->_index[$s])) {
             foreach ($this->_index[$s] as $values) {
@@ -1405,8 +1542,10 @@ class ExtendedGraph
     /**
      * @param TriplePredicate $p
      */
-    public function remove_properties(string $p): void
+    public function remove_properties($p): void
     {
+        $p = TypeUtil::ensureArgIsString(1, $p);
+
         foreach ($this->get_subjects() as $s) {
             $this->remove_property_values($s, $p);
         }
@@ -1417,8 +1556,10 @@ class ExtendedGraph
      *
      * @return ObjectResource[] the resource values found
      */
-    public function get_resource_properties(string $p): array
+    public function get_resource_properties($p): array
     {
+        $p = TypeUtil::ensureArgIsString(1, $p);
+
         $resources = [];
         foreach ($this->get_subjects() as $s) {
             $properties = $this->get_resource_triple_values($s, $p);
@@ -1434,8 +1575,10 @@ class ExtendedGraph
      *
      * @return TripleSubject[]
      */
-    public function get_subjects_with_property_value(string $p, $o): array
+    public function get_subjects_with_property_value($p, $o): array
     {
+        $p = TypeUtil::ensureArgIsString(1, $p);
+
         $subjects = [];
         foreach ($this->get_subjects() as $s) {
             if ($this->has_resource_triple($s, $p, $o) || $this->has_literal_triple($s, $p, $o)) {
@@ -1451,8 +1594,10 @@ class ExtendedGraph
      *
      * @return ObjectValue[]
      */
-    public function get_sequence_values(string $sequenceUri): array
+    public function get_sequence_values($sequenceUri): array
     {
+        $sequenceUri = TypeUtil::ensureArgIsString(1, $sequenceUri);
+
         $triples = $this->get_index();
         $properties = [];
 
@@ -1479,8 +1624,10 @@ class ExtendedGraph
     /**
      * @param TripleSubject $sequenceUri
      */
-    public function get_next_sequence(string $sequenceUri): int
+    public function get_next_sequence($sequenceUri): int
     {
+        $sequenceUri = TypeUtil::ensureArgIsString(1, $sequenceUri);
+
         $values = $this->get_sequence_values($sequenceUri);
 
         return count($values) + 1;
@@ -1490,8 +1637,10 @@ class ExtendedGraph
      * @param TripleSubject $s
      * @param ObjectLiteral $o
      */
-    public function add_literal_to_sequence(string $s, $o): void
+    public function add_literal_to_sequence($s, $o): void
     {
+        $s = TypeUtil::ensureArgIsString(1, $s);
+
         $this->add_to_sequence($s, $o, 'literal');
     }
 
@@ -1501,8 +1650,11 @@ class ExtendedGraph
      * @param TripleSubject  $sequenceUri
      * @param ObjectResource $resourceValue
      */
-    public function remove_resource_from_sequence(string $sequenceUri, string $resourceValue): void
+    public function remove_resource_from_sequence($sequenceUri, $resourceValue): void
     {
+        $sequenceUri = TypeUtil::ensureArgIsString(1, $sequenceUri);
+        $resourceValue = TypeUtil::ensureArgIsString(2, $resourceValue);
+
         $sequenceProperties = $this->get_subject_properties($sequenceUri);
         $sequenceValues = $this->get_sequence_values($sequenceUri);
 
@@ -1526,8 +1678,11 @@ class ExtendedGraph
      * @param TripleSubject  $s
      * @param ObjectResource $o
      */
-    public function add_resource_to_sequence(string $s, string $o): void
+    public function add_resource_to_sequence($s, $o): void
     {
+        $s = TypeUtil::ensureArgIsString(1, $s);
+        $o = TypeUtil::ensureArgIsString(2, $o);
+
         $this->add_to_sequence($s, $o, 'resource');
     }
 
@@ -1535,8 +1690,11 @@ class ExtendedGraph
      * @param TripleSubject  $s
      * @param ObjectResource $o
      */
-    public function add_resource_to_sequence_in_position(string $s, string $o, int $position): void
+    public function add_resource_to_sequence_in_position($s, $o, int $position): void
     {
+        $s = TypeUtil::ensureArgIsString(1, $s);
+        $o = TypeUtil::ensureArgIsString(2, $o);
+
         $sequenceValues = $this->get_sequence_values($s);
 
         if ($sequenceValues === [] || $position > count($sequenceValues)) {
@@ -1558,11 +1716,16 @@ class ExtendedGraph
     }
 
     /**
-     * @param ObjectLiteral $oOldValue
-     * @param ObjectLiteral $oNewValue
+     * @param TripleSubject   $s
+     * @param TriplePredicate $p
+     * @param ObjectLiteral   $oOldValue
+     * @param ObjectLiteral   $oNewValue
      */
-    public function replace_literal_triple(string $s, string $p, $oOldValue, $oNewValue): bool
+    public function replace_literal_triple($s, $p, $oOldValue, $oNewValue): bool
     {
+        $s = TypeUtil::ensureArgIsString(1, $s);
+        $p = TypeUtil::ensureArgIsString(2, $p);
+
         if ($this->has_literal_triple($s, $p, $oOldValue)) {
             $this->remove_literal_triple($s, $p, $oOldValue);
             $this->add_literal_triple($s, $p, $oNewValue);
@@ -1578,8 +1741,12 @@ class ExtendedGraph
      * @param TriplePredicate     $p
      * @param ObjectResource|null $o
      */
-    public function replace_resource_triples(string $s, string $p, ?string $o): void
+    public function replace_resource_triples($s, $p, $o): void
     {
+        $s = TypeUtil::ensureArgIsString(1, $s);
+        $p = TypeUtil::ensureArgIsString(2, $p);
+        $o = TypeUtil::ensureArgIsStringIsOrNull(3, $o);
+
         if ($this->subject_has_property($s, $p)) {
             $this->remove_property_values($s, $p);
         }
@@ -1594,8 +1761,11 @@ class ExtendedGraph
      * @param TriplePredicate    $p
      * @param ObjectLiteral|null $o
      */
-    public function replace_literal_triples(string $s, string $p, $o): void
+    public function replace_literal_triples($s, $p, $o): void
     {
+        $s = TypeUtil::ensureArgIsString(1, $s);
+        $p = TypeUtil::ensureArgIsString(2, $p);
+
         if ($this->subject_has_property($s, $p)) {
             $this->remove_property_values($s, $p);
         }
@@ -1610,8 +1780,10 @@ class ExtendedGraph
      *
      * @throws Exception
      */
-    public function get_label_for_uri(string $uri): string
+    public function get_label_for_uri($uri): string
     {
+        $uri = TypeUtil::ensureArgIsString(1, $uri);
+
         if (empty($this->_index[$uri])) {
             return '';
         }
@@ -1640,8 +1812,10 @@ class ExtendedGraph
     /**
      * @param ObjectResource $type
      */
-    public function remove_subjects_of_type(string $type): void
+    public function remove_subjects_of_type($type): void
     {
+        $type = TypeUtil::ensureArgIsString(1, $type);
+
         $subjects = $this->get_subjects_of_type($type);
         foreach ($subjects as $s) {
             $this->remove_triples_about($s);
@@ -1685,8 +1859,11 @@ class ExtendedGraph
      *
      * @throws Exception
      */
-    private function _add_triple(string $s, string $p, array $o_info): bool
+    private function _add_triple($s, $p, $o_info): bool
     {
+        $s = TypeUtil::ensureArgIsString(1, $s);
+        $p = TypeUtil::ensureArgIsString(2, $p);
+
         // The value $o should already have been validated by this point
         // It's validation differs depending on whether it is a literal or resource
         // So just check the subject and predicate here...
@@ -1815,8 +1992,11 @@ class ExtendedGraph
      * @param ObjectValue     $o
      * @param ObjectType      $type
      */
-    private function get_subjects_where(string $p, $o, string $type): array
+    private function get_subjects_where($p, $o, $type): array
     {
+        $p = TypeUtil::ensureArgIsString(1, $p);
+        $type = TypeUtil::ensureArgIsString(3, $type);
+
         $subjects = [];
         foreach ($this->_index as $subject => $properties) {
             if (isset($properties[$p])) {
@@ -1838,8 +2018,11 @@ class ExtendedGraph
      * @param ObjectValue          $o
      * @param 'literal'|'resource' $type
      */
-    private function add_to_sequence(string $s, $o, string $type = 'resource'): void
+    private function add_to_sequence($s, $o, $type = 'resource'): void
     {
+        $s = TypeUtil::ensureArgIsString(1, $s);
+        $type = TypeUtil::ensureArgIsString(3, $type);
+
         $sequenceValue = $this->get_next_sequence($s);
         $this->add_resource_triple($s, self::rdf_type, self::rdf_seq);
 

--- a/src/classes/TypeUtil.php
+++ b/src/classes/TypeUtil.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=0);
+
+namespace Tripod;
+
+use Tripod\Mongo\DriverBase;
+
+class TypeUtil
+{
+    /**
+     * @param mixed $value
+     */
+    public static function ensureArgIsString(int $argIndex, $value): string
+    {
+        if (!is_string($value)) {
+            self::logArgTypeError('must be of the type string', $argIndex, $value);
+        }
+
+        return (string) $value;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    public static function ensureArgIsStringIsOrNull(int $argIndex, $value): ?string
+    {
+        if (!is_string($value) && !is_null($value)) {
+            self::logArgTypeError('must be of the type string or null', $argIndex, $value);
+        }
+
+        return is_null($value) ? null : (string) $value;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private static function logArgTypeError(string $message, int $argIndex, $value): void
+    {
+        $error = self::makeArgTypeError($message, $argIndex, $value);
+        DriverBase::getLogger()->warning((string) $error);
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private static function makeArgTypeError(string $message, int $argIndex, $value): \TypeError
+    {
+        $caller = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 4)[3] ?? [];
+
+        return new \TypeError(sprintf(
+            'Argument %d passed to %s%s%s() %s, %s given',
+            $argIndex,
+            $caller['class'] ?? '',
+            isset($caller['class']) ? '::' : '',
+            $caller['function'] ?? 'function',
+            $message,
+            gettype($value)
+        ));
+    }
+}

--- a/src/mongo/Driver.php
+++ b/src/mongo/Driver.php
@@ -16,6 +16,7 @@ use Tripod\Mongo\Composites\SearchIndexer;
 use Tripod\Mongo\Composites\Tables;
 use Tripod\Mongo\Composites\Views;
 use Tripod\Timer;
+use Tripod\TypeUtil;
 
 class Driver extends DriverBase implements IDriver
 {
@@ -37,15 +38,20 @@ class Driver extends DriverBase implements IDriver
     /**
      * Constructor for Driver.
      *
-     * @param array<string, mixed> $opts an Array of options: <ul>
-     *                                   <li>defaultContext: (string) to use where a specific default context is not defined. Default is Null</li>
-     *                                   <li>async: (array) determines the async behaviour of views, tables and search. For each of these array keys, if set to true, generation of these elements will be done asyncronously on save. Default is array(OP_VIEWS=>false,OP_TABLES=>true,OP_SEARCH=>true)</li>
-     *                                   <li>stat: this sets the stats object to use to record statistics around operations performed by Driver. Default is null</li>
-     *                                   <li>readPreference: The Read preference to set for Mongo: Default is ReadPreference::RP_PRIMARY_PREFERRED</li>
-     *                                   <li>retriesToGetLock: Retries to do when unable to get lock on a document, default is 20</li></ul>
+     * @param string               $podName
+     * @param string               $storeName
+     * @param array<string, mixed> $opts      an Array of options: <ul>
+     *                                        <li>defaultContext: (string) to use where a specific default context is not defined. Default is Null</li>
+     *                                        <li>async: (array) determines the async behaviour of views, tables and search. For each of these array keys, if set to true, generation of these elements will be done asyncronously on save. Default is array(OP_VIEWS=>false,OP_TABLES=>true,OP_SEARCH=>true)</li>
+     *                                        <li>stat: this sets the stats object to use to record statistics around operations performed by Driver. Default is null</li>
+     *                                        <li>readPreference: The Read preference to set for Mongo: Default is ReadPreference::RP_PRIMARY_PREFERRED</li>
+     *                                        <li>retriesToGetLock: Retries to do when unable to get lock on a document, default is 20</li></ul>
      */
-    public function __construct(string $podName, string $storeName, array $opts = [])
+    public function __construct($podName, $storeName, array $opts = [])
     {
+        $podName = TypeUtil::ensureArgIsString(1, $podName);
+        $storeName = TypeUtil::ensureArgIsString(2, $storeName);
+
         $opts = array_merge([
             'defaultContext' => null,
             OP_ASYNC => [OP_VIEWS => false, OP_TABLES => true, OP_SEARCH => true],
@@ -110,8 +116,11 @@ class Driver extends DriverBase implements IDriver
      *
      * @return MongoGraph
      */
-    public function describeResource(string $resource, ?string $context = null): ExtendedGraph
+    public function describeResource($resource, $context = null): ExtendedGraph
     {
+        $resource = TypeUtil::ensureArgIsString(1, $resource);
+        $context = TypeUtil::ensureArgIsStringIsOrNull(2, $context);
+
         $resource = $this->labeller->uri_to_alias($resource);
         $query = [
             _ID_KEY => [
@@ -126,10 +135,14 @@ class Driver extends DriverBase implements IDriver
     /**
      * Pass subjects as to $resources and have mongo return a DESCRIBE <?resource[0]> <?resource[1]> <?resource[2]> etc.
      *
+     * @param mixed|null $context
+     *
      * @return MongoGraph
      */
-    public function describeResources(array $resources, ?string $context = null): ExtendedGraph
+    public function describeResources(array $resources, $context = null): ExtendedGraph
     {
+        $context = TypeUtil::ensureArgIsStringIsOrNull(2, $context);
+
         $ids = [];
         foreach ($resources as $resource) {
             $resource = $this->labeller->uri_to_alias($resource);
@@ -145,39 +158,54 @@ class Driver extends DriverBase implements IDriver
     }
 
     /**
+     * @param mixed $resource
+     * @param mixed $viewType
+     *
      * @return MongoGraph
      */
-    public function getViewForResource(?string $resource, string $viewType): ExtendedGraph
+    public function getViewForResource($resource, $viewType): ExtendedGraph
     {
+        $resource = TypeUtil::ensureArgIsStringIsOrNull(1, $resource);
+        $viewType = TypeUtil::ensureArgIsString(2, $viewType);
+
         return $this->getTripodViews()->getViewForResource($resource, $viewType);
     }
 
     /**
      * @param string[] $resources
+     * @param mixed    $viewType
      *
      * @return MongoGraph
      */
-    public function getViewForResources(array $resources, string $viewType): ExtendedGraph
+    public function getViewForResources(array $resources, $viewType): ExtendedGraph
     {
+        $viewType = TypeUtil::ensureArgIsString(2, $viewType);
+
         return $this->getTripodViews()->getViewForResources($resources, $viewType);
     }
 
     /**
+     * @param mixed $viewType
+     *
      * @return MongoGraph
      */
-    public function getViews(array $filter, string $viewType): ExtendedGraph
+    public function getViews(array $filter, $viewType): ExtendedGraph
     {
+        $viewType = TypeUtil::ensureArgIsString(2, $viewType);
+
         return $this->getTripodViews()->getViews($filter, $viewType);
     }
 
     public function getTableRows(
-        string $tableType,
+        $tableType,
         array $filter = [],
         ?array $sortBy = [],
         ?int $offset = 0,
         ?int $limit = 10,
         array $options = []
     ): array {
+        $tableType = TypeUtil::ensureArgIsString(1, $tableType);
+
         return $this->getTripodTables()->getTableRows(
             $tableType,
             $filter,
@@ -188,45 +216,70 @@ class Driver extends DriverBase implements IDriver
         );
     }
 
-    public function generateTableRows(string $tableType, ?string $resource = null, ?string $context = null): void
+    public function generateTableRows($tableType, $resource = null, $context = null): void
     {
+        $tableType = TypeUtil::ensureArgIsString(1, $tableType);
+        $resource = TypeUtil::ensureArgIsStringIsOrNull(2, $resource);
+        $context = TypeUtil::ensureArgIsStringIsOrNull(3, $context);
+
         $this->getTripodTables()->generateTableRows($tableType, $resource, $context);
     }
 
-    public function getDistinctTableColumnValues(string $tableType, string $fieldName, array $filter = []): array
+    public function getDistinctTableColumnValues($tableType, $fieldName, array $filter = []): array
     {
+        $tableType = TypeUtil::ensureArgIsString(1, $tableType);
+        $fieldName = TypeUtil::ensureArgIsString(2, $fieldName);
+
         return $this->getTripodTables()->distinct($tableType, $fieldName, $filter);
     }
 
     /**
      * Create and apply a changeset which is the delta between $oldGraph and $newGraph.
      *
+     * @param mixed|null $context
+     * @param mixed|null $description
+     *
      * @throws Exception
      */
     public function saveChanges(
         ExtendedGraph $oldGraph,
         ExtendedGraph $newGraph,
-        ?string $context = null,
-        ?string $description = null
+        $context = null,
+        $description = null
     ): bool {
+        $context = TypeUtil::ensureArgIsStringIsOrNull(3, $context);
+        $description = TypeUtil::ensureArgIsStringIsOrNull(4, $description);
+
         return $this->getDataUpdater()->saveChanges($oldGraph, $newGraph, $context, $description);
     }
 
     /**
      * Get locked documents for a date range or all documents if no date range is given.
+     *
+     * @param mixed|null $fromDateTime
+     * @param mixed|null $tillDateTime
      */
-    public function getLockedDocuments(?string $fromDateTime = null, ?string $tillDateTime = null): array
+    public function getLockedDocuments($fromDateTime = null, $tillDateTime = null): array
     {
+        $fromDateTime = TypeUtil::ensureArgIsStringIsOrNull(1, $fromDateTime);
+        $tillDateTime = TypeUtil::ensureArgIsStringIsOrNull(2, $tillDateTime);
+
         return $this->getDataUpdater()->getLockedDocuments($fromDateTime, $tillDateTime);
     }
 
     /**
      * Remove locks that are there forever, creates a audit entry to keep track who and why removed these locks.
      *
+     * @param mixed $transaction_id
+     * @param mixed $reason
+     *
      * @throws \Exception If something goes wrong when unlocking documents, or creating audit entries
      */
-    public function removeInertLocks(string $transaction_id, string $reason): bool
+    public function removeInertLocks($transaction_id, $reason): bool
     {
+        $transaction_id = TypeUtil::ensureArgIsString(1, $transaction_id);
+        $reason = TypeUtil::ensureArgIsString(2, $reason);
+
         return $this->getDataUpdater()->removeInertLocks($transaction_id, $reason);
     }
 
@@ -280,13 +333,16 @@ class Driver extends DriverBase implements IDriver
     /**
      * Returns a count according to the $query and $groupBy conditions.
      *
-     * @param array    $query Mongo query object
-     * @param int|null $ttl   acceptable time to live if you're willing to accept a cached version of this request
+     * @param array      $query   Mongo query object
+     * @param int|null   $ttl     acceptable time to live if you're willing to accept a cached version of this request
+     * @param mixed|null $groupBy
      *
      * @return array|int
      */
-    public function getCount(array $query, ?string $groupBy = null, ?int $ttl = null)
+    public function getCount(array $query, $groupBy = null, ?int $ttl = null)
     {
+        $groupBy = TypeUtil::ensureArgIsStringIsOrNull(2, $groupBy);
+
         $t = new Timer();
         $t->start();
 
@@ -356,12 +412,15 @@ class Driver extends DriverBase implements IDriver
      * Selects $fields from the result set determined by $query.
      * Returns an array of all results, each array element is a CBD graph, keyed by r.
      *
-     * @param array<string, mixed> $fields array of fields, in the same format as prescribed by MongoPHP
+     * @param array<string, mixed> $fields  array of fields, in the same format as prescribed by MongoPHP
+     * @param mixed|null           $context
      *
      * @return array<string, array<int|string, int|mixed[]|null>>
      */
-    public function select(array $query, array $fields, ?array $sortBy = null, ?int $limit = null, ?int $offset = 0, ?string $context = null): array
+    public function select(array $query, array $fields, ?array $sortBy = null, ?int $limit = null, ?int $offset = 0, $context = null): array
     {
+        $context = TypeUtil::ensureArgIsStringIsOrNull(6, $context);
+
         $t = new Timer();
         $t->start();
 
@@ -478,9 +537,15 @@ class Driver extends DriverBase implements IDriver
 
     /**
      * Returns the eTag of the $resource, useful for cache control or optimistic concurrency control.
+     *
+     * @param mixed      $resource
+     * @param mixed|null $context
      */
-    public function getETag(string $resource, ?string $context = null): string
+    public function getETag($resource, $context = null): string
     {
+        $resource = TypeUtil::ensureArgIsString(1, $resource);
+        $context = TypeUtil::ensureArgIsStringIsOrNull(2, $context);
+
         $this->getStat()->increment(MONGO_GET_ETAG);
         $resource = $this->labeller->uri_to_alias($resource);
         $query = [

--- a/src/mongo/delegates/SearchDocuments.php
+++ b/src/mongo/delegates/SearchDocuments.php
@@ -210,16 +210,17 @@ class SearchDocuments extends DriverBase
                     $values = [];
 
                     if (isset($source[$p])) {
-                        if (isset($source[$p][VALUE_URI])) {
-                            $values[] = ($isIndex) ? mb_strtolower(trim($source[$p][VALUE_URI]), 'UTF-8') : trim($source[$p][VALUE_URI]);
-                        } elseif (isset($source[$p][VALUE_LITERAL])) {
-                            $values[] = ($isIndex) ? mb_strtolower(trim($source[$p][VALUE_LITERAL]), 'UTF-8') : trim($source[$p][VALUE_LITERAL]);
-                        } elseif (is_array($source[$p])) {
-                            foreach ($source[$p] as $v) {
+                        $sourceValue = $source[$p];
+                        if (isset($sourceValue[VALUE_URI])) {
+                            $values[] = $this->normalizeSearchValue($sourceValue[VALUE_URI], $isIndex);
+                        } elseif (isset($sourceValue[VALUE_LITERAL])) {
+                            $values[] = $this->normalizeSearchValue($sourceValue[VALUE_LITERAL], $isIndex);
+                        } elseif (is_array($sourceValue)) {
+                            foreach ($sourceValue as $v) {
                                 if (isset($v[VALUE_URI])) {
-                                    $values[] = ($isIndex) ? mb_strtolower(trim($v[VALUE_URI]), 'UTF-8') : trim($v[VALUE_URI]);
+                                    $values[] = $this->normalizeSearchValue($v[VALUE_URI], $isIndex);
                                 } elseif (isset($v[VALUE_LITERAL])) {
-                                    $values[] = ($isIndex) ? mb_strtolower(trim($v[VALUE_LITERAL]), 'UTF-8') : trim($v[VALUE_LITERAL]);
+                                    $values[] = $this->normalizeSearchValue($v[VALUE_LITERAL], $isIndex);
                                 }
                             }
                         }
@@ -249,6 +250,18 @@ class SearchDocuments extends DriverBase
     protected function getSearchDocumentSpecification(string $specId): ?array
     {
         return $this->getConfigInstance()->getSearchDocumentSpecification($this->storeName, $specId);
+    }
+
+    /**
+     * @param bool|float|int|string $value
+     *
+     * @return string
+     */
+    private function normalizeSearchValue($value, bool $isIndex)
+    {
+        $value = trim((string) $value);
+
+        return $isIndex ? mb_strtolower($value, 'UTF-8') : $value;
     }
 
     /**

--- a/test/unit/TypeUtilTest.php
+++ b/test/unit/TypeUtilTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
+use Tripod\Mongo\DriverBase;
+use Tripod\TypeUtil;
+
+class TypeUtilTest extends TestCase
+{
+    private TestHandler $log;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->log = new TestHandler();
+        $logger = new Logger('unittest');
+        $logger->pushHandler($this->log);
+        DriverBase::$logger = $logger;
+    }
+
+    /**
+     * @testWith [1234, "1234"]
+     *           [3.14, "3.14"]
+     *           [true, "1"]
+     *           [null, ""]
+     *
+     * @param mixed $value
+     * @param mixed $expected
+     */
+    public function testEnsureArgIsString($value, $expected): void
+    {
+        $result = TypeUtil::ensureArgIsString(1, $value);
+        $this->assertSame($expected, $result);
+        $this->assertTrue($this->log->hasWarningThatContains(
+            'TypeError: Argument 1 passed to ' . __CLASS__ . '::' . __FUNCTION__ . '() must be of the type string, ' . gettype($value) . ' given'
+        ));
+    }
+
+    /**
+     * @testWith [1234, "1234"]
+     *           [3.14, "3.14"]
+     *           [true, "1"]
+     *
+     * @param mixed $value
+     * @param mixed $expected
+     */
+    public function testEnsureArgIsStringOrNull($value, $expected): void
+    {
+        $result = TypeUtil::ensureArgIsStringIsOrNull(1, $value);
+        $this->assertIsString($result);
+        $this->assertSame($expected, $result);
+        $this->assertTrue($this->log->hasWarningThatContains(
+            'TypeError: Argument 1 passed to ' . __CLASS__ . '::' . __FUNCTION__ . '() must be of the type string or null, ' . gettype($value) . ' given'
+        ));
+    }
+}

--- a/test/unit/mongo/MongoTripodSearchDocumentsTest.php
+++ b/test/unit/mongo/MongoTripodSearchDocumentsTest.php
@@ -8,6 +8,7 @@ use Tripod\Mongo\Composites\SearchIndexer;
 use Tripod\Mongo\Driver;
 use Tripod\Mongo\ImpactedSubject;
 use Tripod\Mongo\Labeller;
+use Tripod\Mongo\MongoGraph;
 use Tripod\Mongo\SearchDocuments;
 use Tripod\Mongo\Updates;
 
@@ -82,6 +83,88 @@ class MongoTripodSearchDocumentsTest extends MongoTripodTestBase
         $this->assertEquals('René Chapus', $generatedDocuments['result']['author']);
         $this->assertContains('rené chapus', $generatedDocuments['search_terms']);
         $this->assertEquals('http://talisaspire.com/resources/doc13', $generatedDocuments['_id']['r']);
+    }
+
+    public function testGenerateSearchDocumentHandlesNonStringLiterals(): void
+    {
+        $doc = [
+            '_id' => [
+                'r' => 'http://talisaspire.com/resources/typedDoc1',
+                'c' => 'http://talisaspire.com/',
+            ],
+            '_version' => 0,
+            'dct:title' => [
+                'l' => 'Typed PHP: Stronger Types For Cleaner Code',
+            ],
+            'rdf:type' => [
+                ['u' => 'http://purl.org/ontology/bibo/Book'],
+            ],
+            'dct:date' => ['l' => 2016],
+            'temp:price' => ['l' => 19.99],
+            'temp:isHardcover' => ['l' => true],
+        ];
+
+        $searchSpecs = [
+            '_id' => 'i_search_resource',
+            'type' => ['bibo:Book'],
+            'from' => 'CBD_testing',
+            'filter' => [
+                [
+                    'condition' => [
+                        'dct:title.l' => ['$exists' => true],
+                    ],
+                ],
+            ],
+            'indices' => [
+                [
+                    'fieldName' => 'search_terms',
+                    'predicates' => ['dct:title'],
+                ],
+            ],
+            'fields' => [
+                [
+                    'fieldName' => 'result.title',
+                    'predicates' => ['dct:title'],
+                    'limit' => 1,
+                ],
+                [
+                    'fieldName' => 'result.date',
+                    'predicates' => ['dct:date'],
+                    'limit' => 1,
+                ],
+                [
+                    'fieldName' => 'result.price',
+                    'predicates' => ['temp:price'],
+                    'limit' => 1,
+                ],
+                [
+                    'fieldName' => 'result.isHardcover',
+                    'predicates' => ['temp:isHardcover'],
+                    'limit' => 1,
+                ],
+            ],
+        ];
+
+        $graph = new MongoGraph();
+        $graph->add_tripod_array($doc);
+        $this->tripod->saveChanges(new ExtendedGraph(), $graph, $doc['_id'][_ID_CONTEXT]);
+
+        $mockSearchDocuments = $this->getMockBuilder(SearchDocuments::class)
+            ->onlyMethods(['getSearchDocumentSpecification'])
+            ->setConstructorArgs([$this->tripod->getStoreName(), $this->getTripodCollection($this->tripod), 'http://talisaspire.com/'])
+            ->getMock();
+
+        $mockSearchDocuments->expects($this->once())
+            ->method('getSearchDocumentSpecification')
+            ->willReturn($searchSpecs);
+
+        $generatedDocuments = $mockSearchDocuments->generateSearchDocumentBasedOnSpecId('i_search_resource', 'http://talisaspire.com/resources/typedDoc1', 'http://talisaspire.com/');
+        $this->assertEquals([
+            'title' => 'Typed PHP: Stronger Types For Cleaner Code',
+            'date' => '2016',
+            'price' => '19.99',
+            'isHardcover' => '1',
+        ], $generatedDocuments['result']);
     }
 
     public function testGenerateSearchDocumentBasedOnSpecIdWithFieldNamePredicatesHavingNoValueInCollection(): void


### PR DESCRIPTION
- Upgrading to 0.31 is proving difficult, this PR proposes that, where most sensible, instead of using PHP's native type hints and strict types, we'll coerce and expected type and log an error if type wasn't as expected during function call.